### PR TITLE
Fix semihosting with latest toolchain

### DIFF
--- a/drivers/io/io_semihosting.c
+++ b/drivers/io/io_semihosting.c
@@ -94,7 +94,7 @@ static int sh_file_open(struct io_dev_info *dev_info __attribute__((unused)),
 		const void *spec, struct io_entity *entity)
 {
 	int result = IO_FAIL;
-	int sh_result = -1;
+	long sh_result = -1;
 	const io_file_spec *file_spec = (io_file_spec *)spec;
 
 	assert(file_spec != NULL);
@@ -103,7 +103,7 @@ static int sh_file_open(struct io_dev_info *dev_info __attribute__((unused)),
 	sh_result = semihosting_file_open(file_spec->path, file_spec->mode);
 
 	if (sh_result > 0) {
-		entity->info = sh_result;
+		entity->info = (uintptr_t)sh_result;
 		result = IO_SUCCESS;
 	} else {
 		result = IO_FAIL;
@@ -116,11 +116,11 @@ static int sh_file_open(struct io_dev_info *dev_info __attribute__((unused)),
 static int sh_file_seek(struct io_entity *entity, int mode, ssize_t offset)
 {
 	int result = IO_FAIL;
-	int file_handle, sh_result;
+	long file_handle, sh_result;
 
 	assert(entity != NULL);
 
-	file_handle = (int)entity->info;
+	file_handle = (long)entity->info;
 
 	sh_result = semihosting_file_seek(file_handle, offset);
 
@@ -138,8 +138,8 @@ static int sh_file_len(struct io_entity *entity, size_t *length)
 	assert(entity != NULL);
 	assert(length != NULL);
 
-	int sh_handle = entity->info;
-	int sh_result = semihosting_file_length(sh_handle);
+	long sh_handle = (long)entity->info;
+	long sh_result = semihosting_file_length(sh_handle);
 
 	if (sh_result >= 0) {
 		result = IO_SUCCESS;
@@ -155,15 +155,15 @@ static int sh_file_read(struct io_entity *entity, void *buffer, size_t length,
 		size_t *length_read)
 {
 	int result = IO_FAIL;
-	int sh_result = -1;
-	int bytes = length;
-	int file_handle;
+	long sh_result = -1;
+	size_t bytes = length;
+	long file_handle;
 
 	assert(entity != NULL);
 	assert(buffer != NULL);
 	assert(length_read != NULL);
 
-	file_handle = (int)entity->info;
+	file_handle = (long)entity->info;
 
 	sh_result = semihosting_file_read(file_handle, &bytes, buffer);
 
@@ -182,15 +182,15 @@ static int sh_file_write(struct io_entity *entity, const void *buffer,
 		size_t length, size_t *length_written)
 {
 	int result = IO_FAIL;
-	int sh_result = -1;
-	int file_handle;
-	int bytes = length;
+	long sh_result = -1;
+	long file_handle;
+	size_t bytes = length;
 
 	assert(entity != NULL);
 	assert(buffer != NULL);
 	assert(length_written != NULL);
 
-	file_handle = (int)entity->info;
+	file_handle = (long)entity->info;
 
 	sh_result = semihosting_file_write(file_handle, &bytes, buffer);
 
@@ -208,12 +208,12 @@ static int sh_file_write(struct io_entity *entity, const void *buffer,
 static int sh_file_close(struct io_entity *entity)
 {
 	int result = IO_FAIL;
-	int sh_result = -1;
-	int file_handle;
+	long sh_result = -1;
+	long file_handle;
 
 	assert(entity != NULL);
 
-	file_handle = (int)entity->info;
+	file_handle = (long)entity->info;
 
 	sh_result = semihosting_file_close(file_handle);
 

--- a/include/semihosting.h
+++ b/include/semihosting.h
@@ -57,16 +57,16 @@
 #define FOPEN_MODE_APLUS		0xa
 #define FOPEN_MODE_APLUSB		0xb
 
-int semihosting_connection_supported(void);
-int semihosting_file_open(const char *file_name, unsigned int mode);
-int semihosting_file_seek(int file_handle, unsigned int offset);
-int semihosting_file_read(int file_handle, int *length, void *buffer);
-int semihosting_file_write(int file_handle, int *length, const void *buffer);
-int semihosting_file_close(int file_handle);
-int semihosting_file_length(int file_handle);
-int semihosting_system(char *command_line);
-int semihosting_get_flen(const char* file_name);
-int semihosting_download_file(const char* file_name, int buf_size, void *buf);
+long semihosting_connection_supported(void);
+long semihosting_file_open(const char *file_name, size_t mode);
+long semihosting_file_seek(long file_handle, ssize_t offset);
+long semihosting_file_read(long file_handle, size_t *length, void *buffer);
+long semihosting_file_write(long file_handle, size_t *length, const void *buffer);
+long semihosting_file_close(long file_handle);
+long semihosting_file_length(long file_handle);
+long semihosting_system(char *command_line);
+long semihosting_get_flen(const char* file_name);
+long semihosting_download_file(const char* file_name, size_t buf_size, void *buf);
 void semihosting_write_char(char character);
 void semihosting_write_string(char *string);
 char semihosting_read_char(void);

--- a/lib/semihosting/semihosting.c
+++ b/lib/semihosting/semihosting.c
@@ -31,43 +31,44 @@
 #include <assert.h>
 #include <string.h>
 #include <errno.h>
+#include <stdio.h>
 #include <semihosting.h>
 
 #ifndef SEMIHOSTING_SUPPORTED
 #define SEMIHOSTING_SUPPORTED  1
 #endif
 
-extern int semihosting_call(unsigned int operation,
+extern long semihosting_call(unsigned long operation,
 			    void *system_block_address);
 
 typedef struct {
 	const char *file_name;
-	unsigned int mode;
-	unsigned int name_length;
+	unsigned long mode;
+	size_t name_length;
 } smh_file_open_block;
 
 typedef struct {
-	int handle;
+	long handle;
 	void *buffer;
-	unsigned int length;
+	size_t length;
 } smh_file_read_write_block;
 
 typedef struct {
-	int handle;
-	unsigned int location;
+	long handle;
+	ssize_t location;
 } smh_file_seek_block;
 
 typedef struct {
 	char *command_line;
-	unsigned int command_length;
+	size_t command_length;
 } smh_system_block;
 
-int semihosting_connection_supported(void)
+long semihosting_connection_supported(void)
 {
 	return SEMIHOSTING_SUPPORTED;
 }
 
-int semihosting_file_open(const char *file_name, unsigned int mode)
+long semihosting_file_open(const char *file_name, size_t mode)
 {
 	smh_file_open_block open_block;
 
@@ -79,10 +80,10 @@ int semihosting_file_open(const char *file_name, unsigned int mode)
 				(void *) &open_block);
 }
 
-int semihosting_file_seek(int file_handle, unsigned int offset)
+long semihosting_file_seek(long file_handle, ssize_t offset)
 {
 	smh_file_seek_block seek_block;
-	int result;
+	long result;
 
 	seek_block.handle = file_handle;
 	seek_block.location = offset;
@@ -96,10 +97,10 @@ int semihosting_file_seek(int file_handle, unsigned int offset)
 	return result;
 }
 
-int semihosting_file_read(int file_handle, int *length, void *buffer)
+long semihosting_file_read(long file_handle, size_t *length, void *buffer)
 {
 	smh_file_read_write_block read_block;
-	int result = -EINVAL;
+	long result = -EINVAL;
 
 	if ((length == NULL) || (buffer == NULL))
 		return result;
@@ -120,7 +121,7 @@ int semihosting_file_read(int file_handle, int *length, void *buffer)
 		return result;
 }
 
-int semihosting_file_write(int file_handle, int *length, const void *buffer)
+long semihosting_file_write(long file_handle, size_t *length, const void *buffer)
 {
 	smh_file_read_write_block write_block;
 
@@ -137,13 +138,13 @@ int semihosting_file_write(int file_handle, int *length, const void *buffer)
 	return *length;
 }
 
-int semihosting_file_close(int file_handle)
+long semihosting_file_close(long file_handle)
 {
 	return semihosting_call(SEMIHOSTING_SYS_CLOSE,
 				(void *) &file_handle);
 }
 
-int semihosting_file_length(int file_handle)
+long semihosting_file_length(long file_handle)
 {
 	return semihosting_call(SEMIHOSTING_SYS_FLEN,
 				(void *) &file_handle);
@@ -164,7 +165,7 @@ void semihosting_write_string(char *string)
 	semihosting_call(SEMIHOSTING_SYS_WRITE0, (void *) string);
 }
 
-int semihosting_system(char *command_line)
+long semihosting_system(char *command_line)
 {
 	smh_system_block system_block;
 
@@ -175,9 +176,10 @@ int semihosting_system(char *command_line)
 				(void *) &system_block);
 }
 
-int semihosting_get_flen(const char *file_name)
+long semihosting_get_flen(const char *file_name)
 {
-	int file_handle, length;
+	long file_handle;
+	size_t length;
 
 	assert(semihosting_connection_supported());
 
@@ -191,11 +193,13 @@ int semihosting_get_flen(const char *file_name)
 	return semihosting_file_close(file_handle) ? -1 : length;
 }
 
-int semihosting_download_file(const char *file_name,
-			      int buf_size,
+long semihosting_download_file(const char *file_name,
+			      size_t buf_size,
 			      void *buf)
 {
-	int ret = -EINVAL, file_handle, length;
+	long ret = -EINVAL;
+	size_t length;
+	long file_handle;
 
 	/* Null pointer check */
 	if (!buf)


### PR DESCRIPTION
Fixes issues #10:

https://github.com/ARM-software/tf-issues/issues/10

This patch changes all/most variables of type int to be size_t or long
to fix the sizing and alignment problems found when building with the
newer toolchains such as Linaro GCC 13.12 or later.

Signed-off-by: Ryan Harkin ryan.harkin@linaro.org
