### PR TITLE
Fix assert in bakery_lock_release()

### DIFF
--- a/include/bakery_lock.h
+++ b/include/bakery_lock.h
@@ -45,8 +45,6 @@ typedef struct {
 #define NO_OWNER (-1)
 
 void bakery_lock_init(bakery_lock* bakery);
-/* Check whether a lock is held. Mainly used for debug purpose. */
-int bakery_lock_held(unsigned long mpidr, const bakery_lock * bakery);
 void bakery_lock_get(unsigned long mpidr, bakery_lock* bakery);
 void bakery_lock_release(unsigned long mpidr, bakery_lock* bakery);
 int bakery_lock_try(unsigned long mpidr, bakery_lock* bakery);

--- a/lib/sync/locks/bakery/bakery_lock.c
+++ b/lib/sync/locks/bakery/bakery_lock.c
@@ -88,17 +88,8 @@ void bakery_lock_release(unsigned long mpidr, bakery_lock * bakery)
 	unsigned int entry = platform_get_core_pos(mpidr);
 
 	assert_bakery_entry_valid(entry, bakery);
-	assert(bakery_lock_held(entry, bakery));
+	assert(bakery->owner == entry);
 
 	bakery->owner = NO_OWNER;
 	bakery->number[entry] = 0;
-}
-
-int bakery_lock_held(unsigned long mpidr, const bakery_lock * bakery)
-{
-	unsigned int entry = platform_get_core_pos(mpidr);
-
-	assert_bakery_entry_valid(entry, bakery);
-
-	return bakery->owner == entry;
 }


### PR DESCRIPTION
 Fix assert in bakery_lock_release()

bakery_lock_release() expects an mpidr as the first argument however
bakery_lock_release() is calling it with the 'entry' argument it has
calculated. Rather than fixing this to pass the mpidr value it would be
much more efficient to just replace the call with

   assert(bakery->owner == entry)

As this leaves no remaining users of bakery_lock_held(), we might as
well delete it.

Fixes ARM-software/tf-issues#27

Signed-off-by: Jon Medhurst tixy@linaro.org
