### PR TITLE
Update Makefiles to get proper dependency checking working.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,14 +59,14 @@ else
 	BUILD_TYPE	:=	release
 endif
 
-BL_COMMON_OBJS		:=	misc_helpers.o		\
-				cache_helpers.o		\
-				tlb_helpers.o		\
-				xlat_helpers.o		\
-				std.o			\
-				bl_common.o		\
-				platform_helpers.o	\
-				io_storage.o
+BL_COMMON_SOURCES	:=	misc_helpers.S		\
+				cache_helpers.S		\
+				tlb_helpers.S		\
+				xlat_helpers.c		\
+				std.c			\
+				bl_common.c		\
+				platform_helpers.S	\
+				io_storage.c
 
 ARCH 			?=	aarch64
 
@@ -77,10 +77,6 @@ SPD			?=	none
 
 BUILD_BASE		:=	./build
 BUILD_PLAT		:=	${BUILD_BASE}/${PLAT}/${BUILD_TYPE}
-BUILD_BL1		:=	${BUILD_PLAT}/bl1
-BUILD_BL2		:=	${BUILD_PLAT}/bl2
-BUILD_BL31		:=	${BUILD_PLAT}/bl31
-BUILD_DIRS		:=	${BUILD_BL1} ${BUILD_BL2} ${BUILD_BL31}
 
 PLATFORMS		:=	$(shell ls -I common plat/)
 SPDS			:=	$(shell ls -I none services/spd)
@@ -96,7 +92,7 @@ endif
 ifeq (${PLAT},all)
 all: ${PLATFORMS}
 else
-all: msg_start bl1 bl2 bl31 fip
+all: msg_start fip
 endif
 
 msg_start:
@@ -132,19 +128,9 @@ ifneq (${SPD},none)
   # variable to "yes"
 endif
 
-.PHONY:			all msg_start ${PLATFORMS} dump clean realclean distclean bl1 bl2 bl31 cscope locate-checkpatch checkcodebase checkpatch fiptool fip locate-bl33
+.PHONY:			all msg_start ${PLATFORMS} dump clean realclean distclean cscope locate-checkpatch checkcodebase checkpatch fiptool fip locate-bl33
 .SUFFIXES:
 
-
-BL1_OBJS		:= 	$(addprefix ${BUILD_BL1}/,${BL1_OBJS} ${BL_COMMON_OBJS} ${PLAT_BL_COMMON_OBJS})
-BL2_OBJS		:= 	$(addprefix ${BUILD_BL2}/,${BL2_OBJS} ${BL_COMMON_OBJS} ${PLAT_BL_COMMON_OBJS})
-BL31_OBJS		:= 	$(addprefix ${BUILD_BL31}/,${BL31_OBJS} ${BL_COMMON_OBJS} ${PLAT_BL_COMMON_OBJS} ${SPD_OBJS})
-BL1_MAPFILE		:= 	$(addprefix ${BUILD_BL1}/,${BL1_MAPFILE})
-BL2_MAPFILE		:= 	$(addprefix ${BUILD_BL2}/,${BL2_MAPFILE})
-BL31_MAPFILE		:= 	$(addprefix ${BUILD_BL31}/,${BL31_MAPFILE})
-BL1_LINKERFILE		:= 	$(addprefix ${BUILD_BL1}/,${BL1_LINKERFILE})
-BL2_LINKERFILE		:= 	$(addprefix ${BUILD_BL2}/,${BL2_LINKERFILE})
-BL31_LINKERFILE		:= 	$(addprefix ${BUILD_BL31}/,${BL31_LINKERFILE})
 
 INCLUDES		+=	-Ilib/include/			\
 				-Idrivers/io			\
@@ -166,9 +152,6 @@ CFLAGS			:= 	-nostdinc -pedantic -ffreestanding -Wall	\
 				-DDEBUG=${DEBUG} ${INCLUDES} ${CFLAGS}
 
 LDFLAGS			+=	--fatal-warnings -O1
-BL1_LDFLAGS		:=	-Map=${BL1_MAPFILE} --script ${BL1_LINKERFILE} --entry=${BL1_ENTRY_POINT}
-BL2_LDFLAGS		:=	-Map=${BL2_MAPFILE} --script ${BL2_LINKERFILE} --entry=${BL2_ENTRY_POINT}
-BL31_LDFLAGS		:=	-Map=${BL31_MAPFILE} --script ${BL31_LINKERFILE} --entry=${BL31_ENTRY_POINT}
 
 
 vpath %.ld.S bl1:bl2:bl31
@@ -196,16 +179,6 @@ OC			:=	${CROSS_COMPILE}objcopy
 OD			:=	${CROSS_COMPILE}objdump
 NM			:=	${CROSS_COMPILE}nm
 PP			:=	${CROSS_COMPILE}gcc -E ${CFLAGS}
-
-
-bl1:			${BUILD_BL1} ${BUILD_PLAT}/bl1.bin
-FIP_DEPS		+= ${BUILD_PLAT}/bl1.bin
-
-bl2:			${BUILD_BL2} ${BUILD_PLAT}/bl2.bin
-FIP_DEPS		+= ${BUILD_PLAT}/bl2.bin
-
-bl31:			${BUILD_BL31} ${BUILD_PLAT}/bl31.bin
-FIP_DEPS		+= ${BUILD_PLAT}/bl31.bin
 
 BASE_COMMIT		?=	origin/master
 
@@ -238,53 +211,6 @@ ifeq (,$(wildcard ${BL33}))
 	$(error "The file BL33 points to cannot be found (${BL33})")
 endif
 FIP_DEPS		+= ${BL33}
-endif
-
-
-# If BL32 needs to be built, provide necessary build rules and targets
-ifeq (${NEED_BL32},yes)
-BUILD_BL32		:=	${BUILD_PLAT}/bl32
-BUILD_DIRS		+=	${BUILD_BL32}
-
-BL32_OBJS		:=	$(addprefix ${BUILD_BL32}/,${BL32_OBJS})
-BL32_MAPFILE		:=	$(addprefix ${BUILD_BL32}/,${BL32_MAPFILE})
-BL32_LINKERFILE	:=	$(addprefix ${BUILD_BL32}/,${BL32_LINKERFILE})
-BL32_LDFLAGS		:=	-Map=${BL32_MAPFILE} --script ${BL32_LINKERFILE} --entry=${BL32_ENTRY_POINT}
-
-bl32:			${BUILD_BL32} ${BUILD_PLAT}/bl32.bin
-all:			bl32
-dump:			bl32_dump
-.PHONY:			bl32
-
-# Add BL32 image to FIP's input image list
-FIP_DEPS		:= bl32
-FIP_ARGS		:= --bl32 ${BUILD_PLAT}/bl32.bin
-
-${BUILD_BL32}/%.o:	%.S
-			@echo "  AS      $<"
-			${Q}${AS} ${ASFLAGS} -c $< -o $@
-
-${BUILD_BL32}/%.o:	%.c
-			@echo "  CC      $<"
-			${Q}${CC} ${CFLAGS} -c $< -o $@
-
-${BUILD_BL32}/%.ld:	%.ld.S
-			@echo "  PP      $<"
-			${Q}${AS} ${ASFLAGS} -P -E $< -o $@
-
-${BUILD_BL32}/bl32.elf:	${BL32_OBJS} ${BL32_LINKERFILE}
-			@echo "  LD      $@"
-			${Q}${LD} -o $@ ${LDFLAGS} ${BL32_LDFLAGS} ${BL32_OBJS}
-
-${BUILD_PLAT}/bl32.bin:	${BUILD_BL32}/bl32.elf
-			@echo "  BIN     $@"
-			${Q}${OC} -O binary $< $@
-			@echo
-			@echo "Built $@ successfully"
-			@echo
-
-bl32_dump:
-	${Q}${OD} -d ${BUILD_BL32}/bl32.elf > ${BUILD_BL32}/bl32.dump
 endif
 
 
@@ -323,86 +249,133 @@ ${FIPTOOL}:
 			@echo "Built $@ successfully"
 			@echo
 
-${BUILD_DIRS}:
-			${Q}mkdir -p "$@"
+define match_goals
+$(strip $(foreach goal,$(1),$(filter $(goal),$(MAKECMDGOALS))))
+endef
 
 
-${BUILD_BL1}/%.o:	%.S
-			@echo "  AS      $<"
-			${Q}${AS} ${ASFLAGS} -c $< -o $@
-
-${BUILD_BL2}/%.o:	%.S
-			@echo "  AS      $<"
-			${Q}${AS} ${ASFLAGS} -c $< -o $@
-
-${BUILD_BL31}/%.o:	%.S
-			@echo "  AS      $<"
-			${Q}${AS} ${ASFLAGS} -c $< -o $@
-
-${BUILD_BL1}/%.o:	%.c
-			@echo "  CC      $<"
-			${Q}${CC} ${CFLAGS} -c $< -o $@
-
-${BUILD_BL2}/%.o:	%.c
-			@echo "  CC      $<"
-			${Q}${CC} ${CFLAGS} -c $< -o $@
-
-${BUILD_BL31}/%.o:	%.c
-			@echo "  CC      $<"
-			${Q}${CC} ${CFLAGS} -c $< -o $@
-
-${BUILD_BL1}/%.ld:	%.ld.S
-			@echo "  PP      $<"
-			${Q}${AS} ${ASFLAGS} -P -E $< -o $@
-
-${BUILD_BL2}/%.ld:	%.ld.S
-			@echo "  PP      $<"
-			${Q}${AS} ${ASFLAGS} -P -E $< -o $@
-
-${BUILD_BL31}/%.ld:	%.ld.S
-			@echo "  PP      $<"
-			${Q}${AS} ${ASFLAGS} -P -E $< -o $@
+CLEANING := $(call match_goals,clean realclean distclean)
 
 
-${BUILD_BL1}/bl1.elf:	${BL1_OBJS} ${BL1_LINKERFILE}
-			@echo "  LD      $@"
-			${Q}${LD} -o $@ ${LDFLAGS} ${BL1_LDFLAGS} ${BL1_OBJS}
+define MAKE_C
 
-${BUILD_BL2}/bl2.elf:	${BL2_OBJS} ${BL2_LINKERFILE}
-			@echo "  LD      $@"
-			${Q}${LD} -o $@ ${LDFLAGS} ${BL2_LDFLAGS} ${BL2_OBJS}
+$(eval OBJ := $(1)/$(patsubst %.c,%.o,$(notdir $(2))))
+$(eval PREREQUISITES := $(patsubst %.o,%.d,$(OBJ)))
 
-${BUILD_BL31}/bl31.elf:	${BL31_OBJS} ${BL31_LINKERFILE}
-			@echo "  LD      $@"
-			${Q}${LD} -o $@ ${LDFLAGS} ${BL31_LDFLAGS} ${BL31_OBJS}
+$(OBJ) : $(2)
+	@echo "  CC      $$<"
+	$$(Q)$$(CC) $$(CFLAGS) -c $$< -o $$@
 
-${BUILD_PLAT}/bl1.bin:	${BUILD_BL1}/bl1.elf
-			@echo "  BIN     $@"
-			${Q}${OC} -O binary $< $@
-			@echo
-			@echo "Built $@ successfully"
-			@echo
 
-${BUILD_PLAT}/bl2.bin:	${BUILD_BL2}/bl2.elf
-			@echo "  BIN     $@"
-			${Q}${OC} -O binary $< $@
-			@echo
-			@echo "Built $@ successfully"
-			@echo
+$(PREREQUISITES) : $(2)
+	@echo "  DEPS    $$@"
+	@mkdir -p $(1)
+	$$(Q)$$(CC) $$(CFLAGS) -M -MT $(OBJ) -MF $$@ $$<
 
-${BUILD_PLAT}/bl31.bin:	${BUILD_BL31}/bl31.elf
-			@echo "  BIN     $@"
-			${Q}${OC} -O binary $< $@
-			@echo
-			@echo "Built $@ successfully"
-			@echo
+ifeq "$(CLEANING)" ""
+-include $(PREREQUISITES)
+endif
+
+endef
+
+
+define MAKE_S
+
+$(eval OBJ := $(1)/$(patsubst %.S,%.o,$(notdir $(2))))
+$(eval PREREQUISITES := $(patsubst %.o,%.d,$(OBJ)))
+
+$(OBJ) : $(2)
+	@echo "  AS      $$<"
+	$$(Q)$$(AS) $$(ASFLAGS) -c $$< -o $$@
+
+$(PREREQUISITES) : $(2)
+	@echo "  DEPS    $$@"
+	@mkdir -p $(1)
+	$$(Q)$$(AS) $$(ASFLAGS) -M -MT $(OBJ) -MF $$@ $$<
+
+ifeq "$(CLEANING)" ""
+-include $(PREREQUISITES)
+endif
+
+endef
+
+
+define MAKE_OBJS
+	$(eval C_OBJS := $(filter %.c,$(2)))
+	$(eval REMAIN := $(filter-out %.c,$(2)))
+	$(eval $(foreach obj,$(C_OBJS),$(call MAKE_C,$(1),$(obj))))
+
+	$(eval S_OBJS := $(filter %.S,$(REMAIN)))
+	$(eval REMAIN := $(filter-out %.S,$(REMAIN)))
+	$(eval $(foreach obj,$(S_OBJS),$(call MAKE_S,$(1),$(obj))))
+
+	$(and $(REMAIN),$(error Unexpected source files present: $(REMAIN)))
+endef
+
+
+# NOTE: The line continuation '\' is required in the next define otherwise we
+# end up with a line-feed characer at the end of the last c filename.
+# Also bare this issue in mind if extending the list of supported filetypes.
+define SOURCES_TO_OBJS
+	$(notdir $(patsubst %.c,%.o,$(filter %.c,$(1)))) \
+	$(notdir $(patsubst %.S,%.o,$(filter %.S,$(1))))
+endef
+
+define MAKE_BL
+	$(eval BUILD_DIR  := ${BUILD_PLAT}/bl$(1))
+	$(eval SOURCES    := $(BL$(1)_SOURCES) $(BL_COMMON_SOURCES) $(PLAT_BL_COMMON_SOURCES))
+	$(eval OBJS       := $(addprefix $(BUILD_DIR)/,$(call SOURCES_TO_OBJS,$(SOURCES))))
+	$(eval LINKERFILE := $(BUILD_DIR)/bl$(1).ld)
+	$(eval MAPFILE    := $(BUILD_DIR)/bl$(1).map)
+	$(eval ELF        := $(BUILD_DIR)/bl$(1).elf)
+	$(eval BIN        := $(BUILD_PLAT)/bl$(1).bin)
+
+	$(eval $(call MAKE_OBJS,$(BUILD_DIR),$(SOURCES)))
+
+$(BUILD_DIR) :
+	$$(Q)mkdir -p "$$@"
+
+$(LINKERFILE) : $(BL$(1)_LINKERFILE)
+	@echo "  PP      $$<"
+	$$(Q)$$(AS) $$(ASFLAGS) -P -E $$< -o $$@
+
+$(ELF) : $(OBJS) $(LINKERFILE)
+	@echo "  LD      $$@"
+	$$(Q)$$(LD) -o $$@ $$(LDFLAGS) -Map=$(MAPFILE) --script $(LINKERFILE) \
+					--entry=$(BL$(1)_ENTRY_POINT) $(OBJS)
+
+$(BIN) : $(ELF)
+	@echo "  BIN     $$@"
+	$$(Q)$$(OC) -O binary $$< $$@
+	@echo
+	@echo "Built $$@ successfully"
+	@echo
+
+.PHONY : bl$(1)
+bl$(1) : $(BUILD_DIR) $(BIN)
+
+all : bl$(1)
+
+$(eval FIP_DEPS += $(if $2,$(BIN),))
+$(eval FIP_ARGS += $(if $2,--bl$(1) $(BIN),))
+
+endef
+
+
+$(eval $(call MAKE_BL,1))
+
+$(eval $(call MAKE_BL,2,in_fip))
+
+$(eval $(call MAKE_BL,31,in_fip))
+
+ifeq (${NEED_BL32},yes)
+$(eval $(call MAKE_BL,32,in_fip))
+endif
 
 ${BUILD_PLAT}/fip.bin:	locate-bl33 ${FIP_DEPS} ${FIPTOOL}
 			${Q}${FIPTOOL} --dump \
-				--bl2 ${BUILD_PLAT}/bl2.bin \
-				--bl31 ${BUILD_PLAT}/bl31.bin \
-				--bl33 ${BL33} \
 				${FIP_ARGS} \
+				--bl33 ${BL33} \
 				$@
 			@echo
 			@echo "Built $@ successfully"

--- a/bl1/bl1.mk
+++ b/bl1/bl1.mk
@@ -43,12 +43,11 @@ vpath			%.S	arch/${ARCH}/cpu	\
 				lib/arch/${ARCH}	\
 				${PLAT_BL1_S_VPATH}
 
-BL1_OBJS		+=	bl1_arch_setup.o	\
-				bl1_entrypoint.o	\
-				early_exceptions.o	\
-				bl1_main.o		\
-				cpu_helpers.o
+BL1_SOURCES		+=	bl1_arch_setup.c	\
+				bl1_entrypoint.S	\
+				early_exceptions.S	\
+				bl1_main.c		\
+				cpu_helpers.S
 
 BL1_ENTRY_POINT		:=	reset_handler
-BL1_MAPFILE		:=	bl1.map
-BL1_LINKERFILE		:=	bl1.ld
+BL1_LINKERFILE		:=	bl1.ld.S

--- a/bl2/bl2.mk
+++ b/bl2/bl2.mk
@@ -40,14 +40,13 @@ vpath			%.S	lib/arch/${ARCH}		\
 				lib/sync/locks/exclusive	\
 				${PLAT_BL2_S_VPATH}
 
-BL2_OBJS		+=	bl2_entrypoint.o		\
-				bl2_arch_setup.o		\
-				bl2_main.o			\
-				spinlock.o			\
-				early_exceptions.o
+BL2_SOURCES		+=	bl2_entrypoint.S		\
+				bl2_arch_setup.c		\
+				bl2_main.c			\
+				spinlock.S			\
+				early_exceptions.S
 
 BL2_ENTRY_POINT		:=	bl2_entrypoint
-BL2_MAPFILE		:=	bl2.map
-BL2_LINKERFILE		:=	bl2.ld
+BL2_LINKERFILE		:=	bl2.ld.S
 
 CFLAGS			+=	$(DEFINES)

--- a/bl31/bl31.mk
+++ b/bl31/bl31.mk
@@ -47,25 +47,24 @@ vpath			%.S	lib/arch/${ARCH}			\
 				arch/system/gic/${ARCH}			\
 				${PLAT_BL31_S_VPATH}
 
-BL31_OBJS		+=	bl31_arch_setup.o			\
-				bl31_entrypoint.o			\
-				runtime_exceptions.o			\
-				bl31_main.o				\
-				psci_entry.o				\
-				psci_setup.o				\
-				psci_common.o				\
-				psci_afflvl_on.o			\
-				psci_main.o				\
-				psci_afflvl_off.o			\
-				psci_afflvl_suspend.o			\
-				spinlock.o				\
-				gic_v3_sysregs.o			\
-				bakery_lock.o				\
-				runtime_svc.o				\
-				early_exceptions.o			\
-				context_mgmt.o				\
-				context.o
+BL31_SOURCES		+=	bl31_arch_setup.c			\
+				bl31_entrypoint.S			\
+				runtime_exceptions.S			\
+				bl31_main.c				\
+				psci_entry.S				\
+				psci_setup.c				\
+				psci_common.c				\
+				psci_afflvl_on.c			\
+				psci_main.c				\
+				psci_afflvl_off.c			\
+				psci_afflvl_suspend.c			\
+				spinlock.S				\
+				gic_v3_sysregs.S			\
+				bakery_lock.c				\
+				runtime_svc.c				\
+				early_exceptions.S			\
+				context_mgmt.c				\
+				context.S
 
 BL31_ENTRY_POINT	:=	bl31_entrypoint
-BL31_MAPFILE		:=	bl31.map
-BL31_LINKERFILE		:=	bl31.ld
+BL31_LINKERFILE		:=	bl31.ld.S

--- a/bl32/tsp/tsp-fvp.mk
+++ b/bl32/tsp/tsp-fvp.mk
@@ -33,7 +33,6 @@ vpath			%.c	${PLAT_BL2_C_VPATH}
 vpath			%.S	${PLAT_BL2_S_VPATH}
 
 # TSP source files specific to FVP platform
-BL32_OBJS		+=	bl32_plat_setup.o			\
-				bl32_setup_xlat.o			\
-				plat_common.o				\
-				${PLAT_BL_COMMON_OBJS}
+BL32_SOURCES		+=	bl32_plat_setup.c			\
+				bl32_setup_xlat.c			\
+				plat_common.c

--- a/bl32/tsp/tsp.mk
+++ b/bl32/tsp/tsp.mk
@@ -38,16 +38,14 @@ vpath			%.S	lib/arch/${ARCH}		\
 				include				\
 				lib/sync/locks/exclusive
 
-BL32_OBJS		+=	tsp_entrypoint.o		\
-				tsp_main.o			\
-				tsp_request.o			\
-				spinlock.o			\
-				early_exceptions.o		\
-				${BL_COMMON_OBJS}
+BL32_SOURCES		+=	tsp_entrypoint.S		\
+				tsp_main.c			\
+				tsp_request.S			\
+				spinlock.S			\
+				early_exceptions.S
 
 BL32_ENTRY_POINT	:=	tsp_entrypoint
-BL32_MAPFILE		:=	tsp.map
-BL32_LINKERFILE		:=	tsp.ld
+BL32_LINKERFILE		:=	tsp.ld.S
 
 vpath %.ld.S ${BL32_ROOT}
 vpath %.c ${BL32_ROOT}

--- a/plat/fvp/platform.mk
+++ b/plat/fvp/platform.mk
@@ -57,35 +57,35 @@ PLAT_BL31_C_VPATH	:=	drivers/arm/interconnect/cci-400	\
 
 PLAT_BL31_S_VPATH	:=	lib/semihosting/${ARCH}
 
-PLAT_BL_COMMON_OBJS	:=	semihosting_call.o			\
-				mmio.o					\
-				pl011.o					\
-				semihosting.o				\
-				sysreg_helpers.o			\
-				plat_io_storage.o			\
-				io_semihosting.o			\
-				io_fip.o				\
-				io_memmap.o
+PLAT_BL_COMMON_SOURCES	:=	semihosting_call.S			\
+				mmio.c					\
+				pl011.c					\
+				semihosting.c				\
+				sysreg_helpers.S			\
+				plat_io_storage.c			\
+				io_semihosting.c			\
+				io_fip.c				\
+				io_memmap.c
 
-BL1_OBJS		+=	bl1_plat_setup.o			\
-				bl1_plat_helpers.o			\
-				plat_helpers.o				\
-				plat_common.o				\
-				plat_setup_xlat.o			\
-				cci400.o
+BL1_SOURCES		+=	bl1_plat_setup.c			\
+				bl1_plat_helpers.S			\
+				plat_helpers.S				\
+				plat_common.c				\
+				plat_setup_xlat.c			\
+				cci400.c
 
-BL2_OBJS		+=	bl2_plat_setup.o			\
-				plat_setup_xlat.o			\
-				plat_common.o
+BL2_SOURCES		+=	bl2_plat_setup.c			\
+				plat_setup_xlat.c			\
+				plat_common.c
 
-BL31_OBJS		+=	bl31_plat_setup.o			\
-				plat_helpers.o				\
-				plat_setup_xlat.o			\
-				plat_common.o				\
-				plat_pm.o				\
-				plat_topology.o				\
-				plat_gic.o				\
-				fvp_pwrc.o				\
-				cci400.o				\
-				gic_v2.o				\
-				gic_v3.o
+BL31_SOURCES		+=	bl31_plat_setup.c			\
+				plat_helpers.S				\
+				plat_setup_xlat.c			\
+				plat_common.c				\
+				plat_pm.c				\
+				plat_topology.c				\
+				plat_gic.c				\
+				fvp_pwrc.c				\
+				cci400.c				\
+				gic_v2.c				\
+				gic_v3.c

--- a/services/spd/tspd/tspd.mk
+++ b/services/spd/tspd/tspd.mk
@@ -32,10 +32,10 @@ TSPD_DIR		:=	services/spd/tspd
 SPD_INCLUDES		:=	-Iinclude/spd/tspd	\
 				-I${TSPD_DIR}
 
-SPD_OBJS		:=	tspd_common.o		\
-				tspd_main.o		\
-				tspd_pm.o		\
-				tspd_helpers.o
+SPD_SOURCES		:=	tspd_common.c		\
+				tspd_main.c		\
+				tspd_pm.c		\
+				tspd_helpers.S
 
 vpath %.c ${TSPD_DIR}
 vpath %.S ${TSPD_DIR}


### PR DESCRIPTION
This change requires all platforms to now specify a list of source files
rather than object files.

New source files should preferably be specified by using the path as
well and we should add this in the future for all files and remove use
of VPATH. This is desirable because VPATH can hide issues like the fact
that BL2 currently pulls in the BL1 file bl1/aarch64/early_exceptions.S
and if in the future we added bl2/aarch64/early_exceptions.S then it's
likely only one of the two version would be used for both bootloaders.

Fixes ARM-software/tf-issues#11

Signed-off-by: Jon Medhurst tixy@linaro.org
