### PR TITLE
Update Makefiles to get proper dependency checking working.

### DIFF
--- a/bl1/bl1.mk
+++ b/bl1/bl1.mk
@@ -43,12 +43,11 @@ vpath			%.S	arch/${ARCH}/cpu	\
 				lib/arch/${ARCH}	\
 				${PLAT_BL1_S_VPATH}
 
-BL1_OBJS		+=	bl1_arch_setup.o	\
-				bl1_entrypoint.o	\
-				early_exceptions.o	\
-				bl1_main.o		\
-				cpu_helpers.o
+BL1_SOURCES		+=	bl1_arch_setup.c	\
+				bl1_entrypoint.S	\
+				early_exceptions.S	\
+				bl1_main.c		\
+				cpu_helpers.S
 
 BL1_ENTRY_POINT		:=	reset_handler
-BL1_MAPFILE		:=	bl1.map
-BL1_LINKERFILE		:=	bl1.ld
+BL1_LINKERFILE		:=	bl1.ld.S

--- a/bl2/bl2.mk
+++ b/bl2/bl2.mk
@@ -40,14 +40,13 @@ vpath			%.S	lib/arch/${ARCH}		\
 				lib/sync/locks/exclusive	\
 				${PLAT_BL2_S_VPATH}
 
-BL2_OBJS		+=	bl2_entrypoint.o		\
-				bl2_arch_setup.o		\
-				bl2_main.o			\
-				spinlock.o			\
-				early_exceptions.o
+BL2_SOURCES		+=	bl2_entrypoint.S		\
+				bl2_arch_setup.c		\
+				bl2_main.c			\
+				spinlock.S			\
+				early_exceptions.S
 
 BL2_ENTRY_POINT		:=	bl2_entrypoint
-BL2_MAPFILE		:=	bl2.map
-BL2_LINKERFILE		:=	bl2.ld
+BL2_LINKERFILE		:=	bl2.ld.S
 
 CFLAGS			+=	$(DEFINES)

--- a/bl31/bl31.mk
+++ b/bl31/bl31.mk
@@ -47,25 +47,24 @@ vpath			%.S	lib/arch/${ARCH}			\
 				arch/system/gic/${ARCH}			\
 				${PLAT_BL31_S_VPATH}
 
-BL31_OBJS		+=	bl31_arch_setup.o			\
-				bl31_entrypoint.o			\
-				runtime_exceptions.o			\
-				bl31_main.o				\
-				psci_entry.o				\
-				psci_setup.o				\
-				psci_common.o				\
-				psci_afflvl_on.o			\
-				psci_main.o				\
-				psci_afflvl_off.o			\
-				psci_afflvl_suspend.o			\
-				spinlock.o				\
-				gic_v3_sysregs.o			\
-				bakery_lock.o				\
-				runtime_svc.o				\
-				early_exceptions.o			\
-				context_mgmt.o				\
-				context.o
+BL31_SOURCES		+=	bl31_arch_setup.c			\
+				bl31_entrypoint.S			\
+				runtime_exceptions.S			\
+				bl31_main.c				\
+				psci_entry.S				\
+				psci_setup.c				\
+				psci_common.c				\
+				psci_afflvl_on.c			\
+				psci_main.c				\
+				psci_afflvl_off.c			\
+				psci_afflvl_suspend.c			\
+				spinlock.S				\
+				gic_v3_sysregs.S			\
+				bakery_lock.c				\
+				runtime_svc.c				\
+				early_exceptions.S			\
+				context_mgmt.c				\
+				context.S
 
 BL31_ENTRY_POINT	:=	bl31_entrypoint
-BL31_MAPFILE		:=	bl31.map
-BL31_LINKERFILE		:=	bl31.ld
+BL31_LINKERFILE		:=	bl31.ld.S

--- a/bl32/tsp/tsp-fvp.mk
+++ b/bl32/tsp/tsp-fvp.mk
@@ -33,7 +33,6 @@ vpath			%.c	${PLAT_BL2_C_VPATH}
 vpath			%.S	${PLAT_BL2_S_VPATH}
 
 # TSP source files specific to FVP platform
-BL32_OBJS		+=	bl32_plat_setup.o			\
-				bl32_setup_xlat.o			\
-				plat_common.o				\
-				${PLAT_BL_COMMON_OBJS}
+BL32_SOURCES		+=	bl32_plat_setup.c			\
+				bl32_setup_xlat.c			\
+				plat_common.c

--- a/bl32/tsp/tsp.mk
+++ b/bl32/tsp/tsp.mk
@@ -38,16 +38,14 @@ vpath			%.S	lib/arch/${ARCH}		\
 				include				\
 				lib/sync/locks/exclusive
 
-BL32_OBJS		+=	tsp_entrypoint.o		\
-				tsp_main.o			\
-				tsp_request.o			\
-				spinlock.o			\
-				early_exceptions.o		\
-				${BL_COMMON_OBJS}
+BL32_SOURCES		+=	tsp_entrypoint.S		\
+				tsp_main.c			\
+				tsp_request.S			\
+				spinlock.S			\
+				early_exceptions.S
 
 BL32_ENTRY_POINT	:=	tsp_entrypoint
-BL32_MAPFILE		:=	tsp.map
-BL32_LINKERFILE		:=	tsp.ld
+BL32_LINKERFILE		:=	tsp.ld.S
 
 vpath %.ld.S ${BL32_ROOT}
 vpath %.c ${BL32_ROOT}

--- a/plat/fvp/platform.mk
+++ b/plat/fvp/platform.mk
@@ -57,35 +57,35 @@ PLAT_BL31_C_VPATH	:=	drivers/arm/interconnect/cci-400	\
 
 PLAT_BL31_S_VPATH	:=	lib/semihosting/${ARCH}
 
-PLAT_BL_COMMON_OBJS	:=	semihosting_call.o			\
-				mmio.o					\
-				pl011.o					\
-				semihosting.o				\
-				sysreg_helpers.o			\
-				plat_io_storage.o			\
-				io_semihosting.o			\
-				io_fip.o				\
-				io_memmap.o
+PLAT_BL_COMMON_SOURCES	:=	semihosting_call.S			\
+				mmio.c					\
+				pl011.c					\
+				semihosting.c				\
+				sysreg_helpers.S			\
+				plat_io_storage.c			\
+				io_semihosting.c			\
+				io_fip.c				\
+				io_memmap.c
 
-BL1_OBJS		+=	bl1_plat_setup.o			\
-				bl1_plat_helpers.o			\
-				plat_helpers.o				\
-				plat_common.o				\
-				plat_setup_xlat.o			\
-				cci400.o
+BL1_SOURCES		+=	bl1_plat_setup.c			\
+				bl1_plat_helpers.S			\
+				plat_helpers.S				\
+				plat_common.c				\
+				plat_setup_xlat.c			\
+				cci400.c
 
-BL2_OBJS		+=	bl2_plat_setup.o			\
-				plat_setup_xlat.o			\
-				plat_common.o
+BL2_SOURCES		+=	bl2_plat_setup.c			\
+				plat_setup_xlat.c			\
+				plat_common.c
 
-BL31_OBJS		+=	bl31_plat_setup.o			\
-				plat_helpers.o				\
-				plat_setup_xlat.o			\
-				plat_common.o				\
-				plat_pm.o				\
-				plat_topology.o				\
-				plat_gic.o				\
-				fvp_pwrc.o				\
-				cci400.o				\
-				gic_v2.o				\
-				gic_v3.o
+BL31_SOURCES		+=	bl31_plat_setup.c			\
+				plat_helpers.S				\
+				plat_setup_xlat.c			\
+				plat_common.c				\
+				plat_pm.c				\
+				plat_topology.c				\
+				plat_gic.c				\
+				fvp_pwrc.c				\
+				cci400.c				\
+				gic_v2.c				\
+				gic_v3.c

--- a/services/spd/tspd/tspd.mk
+++ b/services/spd/tspd/tspd.mk
@@ -32,10 +32,10 @@ TSPD_DIR		:=	services/spd/tspd
 SPD_INCLUDES		:=	-Iinclude/spd/tspd	\
 				-I${TSPD_DIR}
 
-SPD_OBJS		:=	tspd_common.o		\
-				tspd_main.o		\
-				tspd_pm.o		\
-				tspd_helpers.o
+SPD_SOURCES		:=	tspd_common.c		\
+				tspd_main.c		\
+				tspd_pm.c		\
+				tspd_helpers.S
 
 vpath %.c ${TSPD_DIR}
 vpath %.S ${TSPD_DIR}


### PR DESCRIPTION
This change requires all platforms to now specify a list of source files
rather than object files.

New source files should preferably be specified by using the path as
well and we should add this in the future for all files so we can remove
use of vpath. This is desirable because vpath hides issues like the fact that BL2 currently pulls in a BL1 file bl1/aarch64/early_exceptions.S
and if in the future we added bl2/aarch64/early_exceptions.S then it's
likely only one of the two version would be used for both bootloaders.

This change also removes the 'dump' build target and simply gets
bootloaders to always generate a dump file. At the same time the -x
option is added so the section headers and symbols table are listed.

Fixes ARM-software/tf-issues#11

Signed-off-by: Jon Medhurst tixy@linaro.org
