### PR TITLE
bl_common: add image_size()

### DIFF
--- a/include/bl_common.h
+++ b/include/bl_common.h
@@ -133,6 +133,7 @@ extern void init_bl2_mem_layout(meminfo *,
 extern void init_bl31_mem_layout(const meminfo *,
 				 meminfo *,
 				 unsigned int) __attribute__((weak));
+extern unsigned long image_size(const char *);
 extern unsigned long load_image(meminfo *, const char *, unsigned int, unsigned long);
 extern void __dead2 run_image(unsigned long entrypoint,
 			      unsigned long spsr,


### PR DESCRIPTION
Fixes ARM-software/tf-issues#42

Some callers of load_image() may need to get the size of the image
before/after loading it.

Signed-off-by: Ryan Harkin ryan.harkin@linaro.org
