### PR TITLE
Remove redundant code from bl1_plat_helpers.S

### DIFF
--- a/plat/fvp/aarch64/bl1_plat_helpers.S
+++ b/plat/fvp/aarch64/bl1_plat_helpers.S
@@ -59,11 +59,6 @@
 	 * -----------------------------------------------------
 	 */
 func plat_secondary_cold_boot_setup
-	bl	read_mpidr
-	mov	x19, x0
-	bl	platform_get_core_pos
-	mov	x20, x0
-
 	/* ---------------------------------------------
 	 * Power down this cpu.
 	 * TODO: Do we need to worry about powering the
@@ -72,8 +67,9 @@ func plat_secondary_cold_boot_setup
 	 * loader zeroes out the zi section.
 	 * ---------------------------------------------
 	 */
+	bl	read_mpidr
 	ldr	x1, =PWRC_BASE
-	str	w19, [x1, #PPOFFR_OFF]
+	str	w0, [x1, #PPOFFR_OFF]
 
 	/* ---------------------------------------------
 	 * Deactivate the gic cpu interface as well


### PR DESCRIPTION
Remove redundant code in plat_secondary_cold_boot_setup() in
plat/fvp/aarch64/bl1_plat_helpers.S.

Fixes ARM-software/tf-issues#136

Change-Id: I98c0a46d95cfea33125e34e609c83dc2c97cd86e
