### PR TITLE
Rename FVP "mmap" array to avoid name confusion

### DIFF
--- a/plat/fvp/aarch64/plat_common.c
+++ b/plat/fvp/aarch64/plat_common.c
@@ -126,7 +126,7 @@ void disable_mmu(void)
  * This doesn't include TZRAM as the 'mem_layout' argument passed to to
  * configure_mmu() will give the available subset of that,
  */
-const mmap_region mmap[] = {
+const mmap_region fvp_mmap[] = {
 	{ TZROM_BASE,	TZROM_SIZE,	MT_MEMORY | MT_RO | MT_SECURE },
 	{ TZDRAM_BASE,	TZDRAM_SIZE,	MT_MEMORY | MT_RW | MT_SECURE },
 	{ FLASH0_BASE,	FLASH0_SIZE,	MT_MEMORY | MT_RO | MT_SECURE },
@@ -157,7 +157,7 @@ void configure_mmu(meminfo *mem_layout,
 	mmap_add_region(coh_start, coh_limit - coh_start,
 				MT_DEVICE | MT_RW | MT_SECURE);
 
-	mmap_add(mmap);
+	mmap_add(fvp_mmap);
 
 	init_xlat_tables();
 


### PR DESCRIPTION
Rename the array "mmap" in plat/fvp/aarch64/plat_common.c to
"fvp_mmap", to avoid confusion with the array of the same name
in lib/arch/aarch64/xlat_tables.c

Fixes ARM-software/tf-issues#114

Change-Id: I61478c0070aa52d5dcf5d85af2f353f56c060cfb
