### PR TITLE
Remove variables from .data section

### DIFF
--- a/bl31/bl31_main.c
+++ b/bl31/bl31_main.c
@@ -50,7 +50,7 @@ static int32_t (*bl32_init)(meminfo_t *);
  * Variable to indicate whether next image to execute after BL31 is BL33
  * (non-secure & default) or BL32 (secure).
  ******************************************************************************/
-static uint32_t next_image_type = NON_SECURE;
+static uint32_t next_image_type;
 
 /*******************************************************************************
  * Simple function to initialise all BL31 helper libraries.
@@ -100,6 +100,7 @@ void bl31_main(void)
 	assert(cm_get_context(mpidr, NON_SECURE));
 	cm_set_next_eret_context(NON_SECURE);
 	write_vbar_el3((uint64_t) runtime_exceptions);
+	next_image_type = NON_SECURE;
 
 	/*
 	 * All the cold boot actions on the primary cpu are done. We now need to

--- a/common/bl_common.c
+++ b/common/bl_common.c
@@ -251,9 +251,9 @@ static void dump_load_info(unsigned long image_load_addr,
 /* Generic function to return the size of an image */
 unsigned long image_size(const char *image_name)
 {
-	io_dev_handle dev_handle;
-	io_handle image_handle;
-	void *image_spec;
+	uintptr_t dev_handle;
+	uintptr_t image_handle;
+	uintptr_t image_spec;
 	size_t image_size = 0;
 	int io_result = IO_FAIL;
 
@@ -303,9 +303,9 @@ unsigned long load_image(meminfo_t *mem_layout,
 			 unsigned int load_type,
 			 unsigned long fixed_addr)
 {
-	io_dev_handle dev_handle;
-	io_handle image_handle;
-	void *image_spec;
+	uintptr_t dev_handle;
+	uintptr_t image_handle;
+	uintptr_t image_spec;
 	unsigned long temp_image_base = 0;
 	unsigned long image_base = 0;
 	long offset = 0;
@@ -504,7 +504,7 @@ unsigned long load_image(meminfo_t *mem_layout,
 
 	/* We have enough space so load the image now */
 	/* TODO: Consider whether to try to recover/retry a partially successful read */
-	io_result = io_read(image_handle, (void *)image_base, image_size, &bytes_read);
+	io_result = io_read(image_handle, image_base, image_size, &bytes_read);
 	if ((io_result != IO_SUCCESS) || (bytes_read < image_size)) {
 		WARN("Failed to load '%s' file (%i)\n", image_name, io_result);
 		goto fail;

--- a/drivers/io/io_fip.c
+++ b/drivers/io/io_fip.c
@@ -62,7 +62,7 @@ typedef struct {
 	fip_toc_entry_t entry;
 } file_state_t;
 
-static plat_fip_name_uuid_t name_uuid[] = {
+static const plat_fip_name_uuid_t name_uuid[] = {
 	{BL2_IMAGE_NAME, UUID_TRUSTED_BOOT_FIRMWARE_BL2},
 	{BL31_IMAGE_NAME, UUID_EL3_RUNTIME_FIRMWARE_BL31},
 	{BL32_IMAGE_NAME, UUID_SECURE_PAYLOAD_BL32},
@@ -71,19 +71,19 @@ static plat_fip_name_uuid_t name_uuid[] = {
 
 static const uuid_t uuid_null = {0};
 static file_state_t current_file = {0};
-static io_dev_handle backend_dev_handle;
-static void *backend_image_spec;
+static uintptr_t backend_dev_handle;
+static uintptr_t backend_image_spec;
 
 
 /* Firmware Image Package driver functions */
-static int fip_dev_open(void *spec, io_dev_info_t **dev_info);
-static int fip_file_open(io_dev_info_t *dev_info, const void *spec,
+static int fip_dev_open(const uintptr_t dev_spec, io_dev_info_t **dev_info);
+static int fip_file_open(io_dev_info_t *dev_info, const uintptr_t spec,
 			  io_entity_t *entity);
 static int fip_file_len(io_entity_t *entity, size_t *length);
-static int fip_file_read(io_entity_t *entity, void *buffer, size_t length,
+static int fip_file_read(io_entity_t *entity, uintptr_t buffer, size_t length,
 			  size_t *length_read);
 static int fip_file_close(io_entity_t *entity);
-static int fip_dev_init(io_dev_info_t *dev_info, const void *init_params);
+static int fip_dev_init(io_dev_info_t *dev_info, const uintptr_t init_params);
 static int fip_dev_close(io_dev_info_t *dev_info);
 
 
@@ -135,12 +135,12 @@ io_type_t device_type_fip(void)
 }
 
 
-static struct io_dev_connector fip_dev_connector = {
+static const io_dev_connector_t fip_dev_connector = {
 	.dev_open = fip_dev_open
 };
 
 
-static struct io_dev_funcs fip_dev_funcs = {
+static const io_dev_funcs_t fip_dev_funcs = {
 	.type = device_type_fip,
 	.open = fip_file_open,
 	.seek = NULL,
@@ -153,29 +153,30 @@ static struct io_dev_funcs fip_dev_funcs = {
 };
 
 
-static struct io_dev_info fip_dev_info = {
+/* No state associated with this device so structure can be const */
+static const io_dev_info_t fip_dev_info = {
 	.funcs = &fip_dev_funcs,
 	.info = (uintptr_t)NULL
 };
 
 
 /* Open a connection to the FIP device */
-static int fip_dev_open(void *spec __attribute__((unused)),
+static int fip_dev_open(const uintptr_t dev_spec __attribute__((unused)),
 			 io_dev_info_t **dev_info)
 {
 	assert(dev_info != NULL);
-	*dev_info = &fip_dev_info;
+	*dev_info = (io_dev_info_t *)&fip_dev_info; /* cast away const */
 
 	return IO_SUCCESS;
 }
 
 
 /* Do some basic package checks. */
-static int fip_dev_init(io_dev_info_t *dev_info, const void *init_params)
+static int fip_dev_init(io_dev_info_t *dev_info, const uintptr_t init_params)
 {
 	int result = IO_FAIL;
 	char *image_name = (char *)init_params;
-	io_handle backend_handle;
+	uintptr_t backend_handle;
 	fip_toc_header_t header;
 	size_t bytes_read;
 
@@ -198,7 +199,8 @@ static int fip_dev_init(io_dev_info_t *dev_info, const void *init_params)
 		goto fip_dev_init_exit;
 	}
 
-	result = io_read(backend_handle, &header, sizeof(header), &bytes_read);
+	result = io_read(backend_handle, (uintptr_t)&header, sizeof(header),
+			&bytes_read);
 	if (result == IO_SUCCESS) {
 		if (!is_valid_header(&header)) {
 			WARN("Firmware Image Package header check failed.\n");
@@ -220,19 +222,19 @@ static int fip_dev_close(io_dev_info_t *dev_info)
 	/* TODO: Consider tracking open files and cleaning them up here */
 
 	/* Clear the backend. */
-	backend_dev_handle = NULL;
-	backend_image_spec = NULL;
+	backend_dev_handle = (uintptr_t)NULL;
+	backend_image_spec = (uintptr_t)NULL;
 
 	return IO_SUCCESS;
 }
 
 
 /* Open a file for access from package. */
-static int fip_file_open(io_dev_info_t *dev_info, const void *spec,
+static int fip_file_open(io_dev_info_t *dev_info, const uintptr_t spec,
 			 io_entity_t *entity)
 {
 	int result = IO_FAIL;
-	io_handle backend_handle;
+	uintptr_t backend_handle;
 	uuid_t file_uuid;
 	const io_file_spec_t *file_spec = (io_file_spec_t *)spec;
 	size_t bytes_read;
@@ -273,7 +275,8 @@ static int fip_file_open(io_dev_info_t *dev_info, const void *spec,
 
 	found_file = 0;
 	do {
-		result = io_read(backend_handle, &current_file.entry,
+		result = io_read(backend_handle,
+				 (uintptr_t)&current_file.entry,
 				 sizeof(current_file.entry),
 				 &bytes_read);
 		if (result == IO_SUCCESS) {
@@ -322,19 +325,19 @@ static int fip_file_len(io_entity_t *entity, size_t *length)
 
 
 /* Read data from a file in package */
-static int fip_file_read(io_entity_t *entity, void *buffer, size_t length,
+static int fip_file_read(io_entity_t *entity, uintptr_t buffer, size_t length,
 			  size_t *length_read)
 {
 	int result = IO_FAIL;
 	file_state_t *fp;
 	size_t file_offset;
 	size_t bytes_read;
-	io_handle backend_handle;
+	uintptr_t backend_handle;
 
 	assert(entity != NULL);
-	assert(buffer != NULL);
+	assert(buffer != (uintptr_t)NULL);
 	assert(length_read != NULL);
-	assert((void *)entity->info != NULL);
+	assert(entity->info != (uintptr_t)NULL);
 
 	/* Open the backend, attempt to access the blob image */
 	result = io_open(backend_dev_handle, backend_image_spec,
@@ -396,7 +399,7 @@ static int fip_file_close(io_entity_t *entity)
 /* Exported functions */
 
 /* Register the Firmware Image Package driver with the IO abstraction */
-int register_io_dev_fip(io_dev_connector_t **dev_con)
+int register_io_dev_fip(const io_dev_connector_t **dev_con)
 {
 	int result = IO_FAIL;
 	assert(dev_con != NULL);

--- a/drivers/io/io_semihosting.c
+++ b/drivers/io/io_semihosting.c
@@ -44,23 +44,23 @@ static io_type_t device_type_sh(void)
 
 /* Semi-hosting functions, device info and handle */
 
-static int sh_dev_open(void *spec, io_dev_info_t **dev_info);
-static int sh_file_open(io_dev_info_t *dev_info, const void *spec,
+static int sh_dev_open(const uintptr_t dev_spec, io_dev_info_t **dev_info);
+static int sh_file_open(io_dev_info_t *dev_info, const uintptr_t spec,
 		io_entity_t *entity);
 static int sh_file_seek(io_entity_t *entity, int mode, ssize_t offset);
 static int sh_file_len(io_entity_t *entity, size_t *length);
-static int sh_file_read(io_entity_t *entity, void *buffer, size_t length,
+static int sh_file_read(io_entity_t *entity, uintptr_t buffer, size_t length,
 		size_t *length_read);
-static int sh_file_write(io_entity_t *entity, const void *buffer,
+static int sh_file_write(io_entity_t *entity, const uintptr_t buffer,
 		size_t length, size_t *length_written);
 static int sh_file_close(io_entity_t *entity);
 
-static struct io_dev_connector sh_dev_connector = {
+static const io_dev_connector_t sh_dev_connector = {
 	.dev_open = sh_dev_open
 };
 
 
-static struct io_dev_funcs sh_dev_funcs = {
+static const io_dev_funcs_t sh_dev_funcs = {
 	.type = device_type_sh,
 	.open = sh_file_open,
 	.seek = sh_file_seek,
@@ -73,29 +73,31 @@ static struct io_dev_funcs sh_dev_funcs = {
 };
 
 
-static struct io_dev_info sh_dev_info = {
+/* No state associated with this device so structure can be const */
+static const io_dev_info_t sh_dev_info = {
 	.funcs = &sh_dev_funcs,
 	.info = (uintptr_t)NULL
 };
 
 
 /* Open a connection to the semi-hosting device */
-static int sh_dev_open(void *spec __unused, io_dev_info_t **dev_info)
+static int sh_dev_open(const uintptr_t dev_spec __unused,
+		io_dev_info_t **dev_info)
 {
 	int result = IO_SUCCESS;
 	assert(dev_info != NULL);
-	*dev_info = &sh_dev_info;
+	*dev_info = (io_dev_info_t *)&sh_dev_info; /* cast away const */
 	return result;
 }
 
 
 /* Open a file on the semi-hosting device */
 static int sh_file_open(io_dev_info_t *dev_info __attribute__((unused)),
-		const void *spec, io_entity_t *entity)
+		const uintptr_t spec, io_entity_t *entity)
 {
 	int result = IO_FAIL;
 	long sh_result = -1;
-	const io_file_spec_t *file_spec = (io_file_spec_t *)spec;
+	const io_file_spec_t *file_spec = (const io_file_spec_t *)spec;
 
 	assert(file_spec != NULL);
 	assert(entity != NULL);
@@ -151,7 +153,7 @@ static int sh_file_len(io_entity_t *entity, size_t *length)
 
 
 /* Read data from a file on the semi-hosting device */
-static int sh_file_read(io_entity_t *entity, void *buffer, size_t length,
+static int sh_file_read(io_entity_t *entity, uintptr_t buffer, size_t length,
 		size_t *length_read)
 {
 	int result = IO_FAIL;
@@ -160,7 +162,7 @@ static int sh_file_read(io_entity_t *entity, void *buffer, size_t length,
 	long file_handle;
 
 	assert(entity != NULL);
-	assert(buffer != NULL);
+	assert(buffer != (uintptr_t)NULL);
 	assert(length_read != NULL);
 
 	file_handle = (long)entity->info;
@@ -178,7 +180,7 @@ static int sh_file_read(io_entity_t *entity, void *buffer, size_t length,
 
 
 /* Write data to a file on the semi-hosting device */
-static int sh_file_write(io_entity_t *entity, const void *buffer,
+static int sh_file_write(io_entity_t *entity, const uintptr_t buffer,
 		size_t length, size_t *length_written)
 {
 	int result = IO_FAIL;
@@ -187,7 +189,7 @@ static int sh_file_write(io_entity_t *entity, const void *buffer,
 	size_t bytes = length;
 
 	assert(entity != NULL);
-	assert(buffer != NULL);
+	assert(buffer != (uintptr_t)NULL);
 	assert(length_written != NULL);
 
 	file_handle = (long)entity->info;
@@ -226,7 +228,7 @@ static int sh_file_close(io_entity_t *entity)
 /* Exported functions */
 
 /* Register the semi-hosting driver with the IO abstraction */
-int register_io_dev_sh(io_dev_connector_t **dev_con)
+int register_io_dev_sh(const io_dev_connector_t **dev_con)
 {
 	int result = IO_FAIL;
 	assert(dev_con != NULL);

--- a/include/drivers/io_driver.h
+++ b/include/drivers/io_driver.h
@@ -39,7 +39,7 @@
 /* Generic IO entity structure,representing an accessible IO construct on the
  * device, such as a file */
 typedef struct io_entity {
-	io_dev_handle dev_handle;
+	struct io_dev_info *dev_handle;
 	uintptr_t info;
 } io_entity_t;
 
@@ -47,7 +47,7 @@ typedef struct io_entity {
 /* Device info structure, providing device-specific functions and a means of
  * adding driver-specific state */
 typedef struct io_dev_info {
-	struct io_dev_funcs *funcs;
+	const struct io_dev_funcs *funcs;
 	uintptr_t info;
 } io_dev_info_t;
 
@@ -55,23 +55,23 @@ typedef struct io_dev_info {
 /* Structure used to create a connection to a type of device */
 typedef struct io_dev_connector {
 	/* dev_open opens a connection to a particular device driver */
-	int (*dev_open)(void *spec, io_dev_info_t **dev_info);
+	int (*dev_open)(const uintptr_t dev_spec, io_dev_info_t **dev_info);
 } io_dev_connector_t;
 
 
 /* Structure to hold device driver function pointers */
 typedef struct io_dev_funcs {
 	io_type_t (*type)(void);
-	int (*open)(io_dev_info_t *dev_info, const void *spec,
+	int (*open)(io_dev_info_t *dev_info, const uintptr_t spec,
 			io_entity_t *entity);
 	int (*seek)(io_entity_t *entity, int mode, ssize_t offset);
 	int (*size)(io_entity_t *entity, size_t *length);
-	int (*read)(io_entity_t *entity, void *buffer, size_t length,
+	int (*read)(io_entity_t *entity, uintptr_t buffer, size_t length,
 			size_t *length_read);
-	int (*write)(io_entity_t *entity, const void *buffer,
+	int (*write)(io_entity_t *entity, const uintptr_t buffer,
 			size_t length, size_t *length_written);
 	int (*close)(io_entity_t *entity);
-	int (*dev_init)(io_dev_info_t *dev_info, const void *init_params);
+	int (*dev_init)(io_dev_info_t *dev_info, const uintptr_t init_params);
 	int (*dev_close)(io_dev_info_t *dev_info);
 } io_dev_funcs_t;
 
@@ -79,7 +79,7 @@ typedef struct io_dev_funcs {
 /* IO platform data - used to track devices registered for a specific
  * platform */
 typedef struct io_plat_data {
-	io_dev_info_t *devices[MAX_IO_DEVICES];
+	const io_dev_info_t *devices[MAX_IO_DEVICES];
 	unsigned int dev_count;
 } io_plat_data_t;
 
@@ -90,6 +90,6 @@ typedef struct io_plat_data {
 void io_init(io_plat_data_t *data);
 
 /* Register a device driver */
-int io_register_device(io_dev_info_t *dev_info);
+int io_register_device(const io_dev_info_t *dev_info);
 
 #endif  /* __IO_DRIVER_H__ */

--- a/include/drivers/io_fip.h
+++ b/include/drivers/io_fip.h
@@ -33,6 +33,6 @@
 
 struct io_dev_connector;
 
-int register_io_dev_fip(struct io_dev_connector **dev_con);
+int register_io_dev_fip(const struct io_dev_connector **dev_con);
 
 #endif /* __IO_FIP_H__ */

--- a/include/drivers/io_memmap.h
+++ b/include/drivers/io_memmap.h
@@ -33,6 +33,6 @@
 
 struct io_dev_connector;
 
-int register_io_dev_memmap(struct io_dev_connector **dev_con);
+int register_io_dev_memmap(const struct io_dev_connector **dev_con);
 
 #endif /* __IO_MEMMAP_H__ */

--- a/include/drivers/io_semihosting.h
+++ b/include/drivers/io_semihosting.h
@@ -33,6 +33,6 @@
 
 struct io_dev_connector;
 
-int register_io_dev_sh(struct io_dev_connector **dev_con);
+int register_io_dev_sh(const struct io_dev_connector **dev_con);
 
 #endif /* __IO_SH_H__ */

--- a/include/lib/io_storage.h
+++ b/include/lib/io_storage.h
@@ -31,6 +31,7 @@
 #ifndef __IO_H__
 #define __IO_H__
 
+#include <stdint.h>
 #include <stdio.h> /* For ssize_t */
 
 
@@ -58,13 +59,6 @@ typedef enum {
 /* Connector type, providing a means of identifying a device to open */
 struct io_dev_connector;
 
-/* Device handle, providing a client with access to a specific device */
-typedef struct io_dev_info *io_dev_handle;
-
-/* IO handle, providing a client with access to a specific source of data from
- * a device */
-typedef struct io_entity *io_handle;
-
 
 /* File specification - used to refer to data on a device supporting file-like
  * entities */
@@ -77,7 +71,7 @@ typedef struct io_file_spec {
 /* Block specification - used to refer to data on a device supporting
  * block-like entities */
 typedef struct io_block_spec {
-	unsigned long offset;
+	size_t offset;
 	size_t length;
 } io_block_spec_t;
 
@@ -96,33 +90,35 @@ typedef struct io_block_spec {
 
 
 /* Open a connection to a device */
-int io_dev_open(struct io_dev_connector *dev_con, void *dev_spec,
-		io_dev_handle *dev_handle);
+int io_dev_open(const struct io_dev_connector *dev_con,
+		const uintptr_t dev_spec,
+		uintptr_t *dev_handle);
 
 
 /* Initialise a device explicitly - to permit lazy initialisation or
  * re-initialisation */
-int io_dev_init(io_dev_handle dev_handle, const void *init_params);
+int io_dev_init(uintptr_t dev_handle, const uintptr_t init_params);
 
 /* TODO: Consider whether an explicit "shutdown" API should be included */
 
 /* Close a connection to a device */
-int io_dev_close(io_dev_handle dev_handle);
+int io_dev_close(uintptr_t dev_handle);
 
 
 /* Synchronous operations */
-int io_open(io_dev_handle dev_handle, const void *spec, io_handle *handle);
+int io_open(uintptr_t dev_handle, const uintptr_t spec, uintptr_t *handle);
 
-int io_seek(io_handle handle, io_seek_mode_t mode, ssize_t offset);
+int io_seek(uintptr_t handle, io_seek_mode_t mode, ssize_t offset);
 
-int io_size(io_handle handle, size_t *length);
+int io_size(uintptr_t handle, size_t *length);
 
-int io_read(io_handle handle, void *buffer, size_t length, size_t *length_read);
+int io_read(uintptr_t handle, uintptr_t buffer, size_t length,
+		size_t *length_read);
 
-int io_write(io_handle handle, const void *buffer, size_t length,
+int io_write(uintptr_t handle, const uintptr_t buffer, size_t length,
 		size_t *length_written);
 
-int io_close(io_handle handle);
+int io_close(uintptr_t handle);
 
 
 #endif /* __IO_H__ */

--- a/include/lib/semihosting.h
+++ b/include/lib/semihosting.h
@@ -31,6 +31,7 @@
 #ifndef __SEMIHOSTING_H__
 #define __SEMIHOSTING_H__
 
+#include <stdint.h>
 #include <stdio.h> /* For ssize_t */
 
 
@@ -63,17 +64,17 @@
 long semihosting_connection_supported(void);
 long semihosting_file_open(const char *file_name, size_t mode);
 long semihosting_file_seek(long file_handle, ssize_t offset);
-long semihosting_file_read(long file_handle, size_t *length, void *buffer);
+long semihosting_file_read(long file_handle, size_t *length, uintptr_t buffer);
 long semihosting_file_write(long file_handle,
 			    size_t *length,
-			    const void *buffer);
+			    const uintptr_t buffer);
 long semihosting_file_close(long file_handle);
 long semihosting_file_length(long file_handle);
 long semihosting_system(char *command_line);
 long semihosting_get_flen(const char *file_name);
 long semihosting_download_file(const char *file_name,
 			       size_t buf_size,
-			       void *buf);
+			       uintptr_t buf);
 void semihosting_write_char(char character);
 void semihosting_write_string(char *string);
 char semihosting_read_char(void);

--- a/lib/semihosting/semihosting.c
+++ b/lib/semihosting/semihosting.c
@@ -48,7 +48,7 @@ typedef struct {
 
 typedef struct {
 	long handle;
-	void *buffer;
+	uintptr_t buffer;
 	size_t length;
 } smh_file_read_write_block_t;
 
@@ -96,12 +96,12 @@ long semihosting_file_seek(long file_handle, ssize_t offset)
 	return result;
 }
 
-long semihosting_file_read(long file_handle, size_t *length, void *buffer)
+long semihosting_file_read(long file_handle, size_t *length, uintptr_t buffer)
 {
 	smh_file_read_write_block_t read_block;
 	long result = -EINVAL;
 
-	if ((length == NULL) || (buffer == NULL))
+	if ((length == NULL) || (buffer == (uintptr_t)NULL))
 		return result;
 
 	read_block.handle = file_handle;
@@ -122,15 +122,15 @@ long semihosting_file_read(long file_handle, size_t *length, void *buffer)
 
 long semihosting_file_write(long file_handle,
 			    size_t *length,
-			    const void *buffer)
+			    const uintptr_t buffer)
 {
 	smh_file_read_write_block_t write_block;
 
-	if ((length == NULL) || (buffer == NULL))
+	if ((length == NULL) || (buffer == (uintptr_t)NULL))
 		return -EINVAL;
 
 	write_block.handle = file_handle;
-	write_block.buffer = (void *)buffer;
+	write_block.buffer = (uintptr_t)buffer; /* cast away const */
 	write_block.length = *length;
 
 	*length = semihosting_call(SEMIHOSTING_SYS_WRITE,
@@ -196,7 +196,7 @@ long semihosting_get_flen(const char *file_name)
 
 long semihosting_download_file(const char *file_name,
 			      size_t buf_size,
-			      void *buf)
+			      uintptr_t buf)
 {
 	long ret = -EINVAL;
 	size_t length;

--- a/plat/fvp/plat_pm.c
+++ b/plat/fvp/plat_pm.c
@@ -388,7 +388,7 @@ int fvp_affinst_suspend_finish(unsigned long mpidr,
 /*******************************************************************************
  * Export the platform handlers to enable psci to invoke them
  ******************************************************************************/
-static plat_pm_ops_t fvp_plat_pm_ops = {
+static const plat_pm_ops_t fvp_plat_pm_ops = {
 	fvp_affinst_standby,
 	fvp_affinst_on,
 	fvp_affinst_off,
@@ -400,7 +400,7 @@ static plat_pm_ops_t fvp_plat_pm_ops = {
 /*******************************************************************************
  * Export the platform specific power ops & initialize the fvp power controller
  ******************************************************************************/
-int platform_setup_pm(plat_pm_ops_t **plat_ops)
+int platform_setup_pm(const plat_pm_ops_t **plat_ops)
 {
 	*plat_ops = &fvp_plat_pm_ops;
 	return 0;

--- a/plat/fvp/platform.h
+++ b/plat/fvp/platform.h
@@ -349,7 +349,6 @@ typedef volatile struct mailbox {
  ******************************************************************************/
 struct plat_pm_ops;
 struct meminfo;
-struct io_dev_info;
 
 /*******************************************************************************
  * Function and variable prototypes
@@ -370,7 +369,7 @@ extern unsigned long warm_boot_entrypoint;
 extern void bl1_plat_arch_setup(void);
 extern void bl2_plat_arch_setup(void);
 extern void bl31_plat_arch_setup(void);
-extern int platform_setup_pm(struct plat_pm_ops **);
+extern int platform_setup_pm(const struct plat_pm_ops **);
 extern unsigned int platform_get_core_pos(unsigned long mpidr);
 extern void disable_mmu(void);
 extern void enable_mmu(void);
@@ -401,7 +400,7 @@ extern unsigned int plat_get_aff_state(unsigned int, unsigned long);
 /* Declarations for plat_io_storage.c */
 extern void io_setup(void);
 extern int plat_get_image_source(const char *image_name,
-		struct io_dev_info **dev_handle, void **image_spec);
+		uintptr_t *dev_handle, uintptr_t *image_spec);
 
 /* Declarations for plat_security.c */
 extern void plat_security_setup(void);

--- a/services/std_svc/psci/psci_common.c
+++ b/services/std_svc/psci/psci_common.c
@@ -74,7 +74,7 @@ aff_limits_node_t psci_aff_limits[MPIDR_MAX_AFFLVL + 1];
 /*******************************************************************************
  * Pointer to functions exported by the platform to complete power mgmt. ops
  ******************************************************************************/
-plat_pm_ops_t *psci_plat_pm_ops;
+const plat_pm_ops_t *psci_plat_pm_ops;
 
 /*******************************************************************************
  * Routine to return the maximum affinity level to traverse to after a cpu has

--- a/services/std_svc/psci/psci_private.h
+++ b/services/std_svc/psci/psci_private.h
@@ -88,7 +88,7 @@ extern suspend_context_t psci_suspend_context[PSCI_NUM_AFFS];
 extern ns_entry_info_t psci_ns_entry_info[PSCI_NUM_AFFS];
 extern unsigned int psci_ns_einfo_idx;
 extern aff_limits_node_t psci_aff_limits[MPIDR_MAX_AFFLVL + 1];
-extern plat_pm_ops_t *psci_plat_pm_ops;
+extern const plat_pm_ops_t *psci_plat_pm_ops;
 extern aff_map_node_t psci_aff_map[PSCI_NUM_AFFS];
 extern afflvl_power_on_finisher_t psci_afflvl_off_finish_handlers[];
 extern afflvl_power_on_finisher_t psci_afflvl_sus_finish_handlers[];


### PR DESCRIPTION
Update code base to remove variables from the .data section,
mainly by using const static data where possible and adding
the const specifier as required. Most changes are to the IO
subsystem, including the framework APIs. The FVP power
management code is also affected.

Delay initialization of the global static variable,
next_image_type in bl31_main.c, until it is realy needed.
Doing this moves the variable from the .data to the .bss
section.

Also review the IO interface for inconsistencies, using
uintptr_t where possible instead of void *. Remove the
io_handle and io_dev_handle typedefs, which were
unnecessary, replacing instances with uintptr_t.

This pull request is based on #48, and is only about the
the last commit.
