### PR TITLE
Set processor endianness immediately after RESET

### DIFF
--- a/bl1/aarch64/bl1_arch_setup.c
+++ b/bl1/aarch64/bl1_arch_setup.c
@@ -40,10 +40,9 @@ void bl1_arch_setup(void)
 {
 	unsigned long tmp_reg = 0;
 
-	/* Enable alignment checks and set the exception endianess to LE */
+	/* Enable alignment checks */
 	tmp_reg = read_sctlr_el3();
 	tmp_reg |= (SCTLR_A_BIT | SCTLR_SA_BIT);
-	tmp_reg &= ~SCTLR_EE_BIT;
 	write_sctlr_el3(tmp_reg);
 
 	/*

--- a/bl1/aarch64/bl1_entrypoint.S
+++ b/bl1/aarch64/bl1_entrypoint.S
@@ -43,6 +43,16 @@
 
 func bl1_entrypoint
 	/* ---------------------------------------------
+	 * Set the CPU endianness before doing anything
+	 * that might involve memory reads or writes
+	 * ---------------------------------------------
+	 */
+	mrs	x0, sctlr_el3
+	bic	x0, x0, #SCTLR_EE_BIT
+	msr	sctlr_el3, x0
+	isb
+
+	/* ---------------------------------------------
 	 * Perform any processor specific actions upon
 	 * reset e.g. cache, tlb invalidations etc.
 	 * ---------------------------------------------

--- a/bl31/aarch64/bl31_arch_setup.c
+++ b/bl31/aarch64/bl31_arch_setup.c
@@ -42,10 +42,9 @@ void bl31_arch_setup(void)
 	unsigned long tmp_reg = 0;
 	uint64_t counter_freq;
 
-	/* Enable alignment checks and set the exception endianness to LE */
+	/* Enable alignment checks */
 	tmp_reg = read_sctlr_el3();
 	tmp_reg |= (SCTLR_A_BIT | SCTLR_SA_BIT);
-	tmp_reg &= ~SCTLR_EE_BIT;
 	write_sctlr_el3(tmp_reg);
 
 	/*


### PR DESCRIPTION
SCTLR_EL3.EE is being configured too late in bl1_arch_setup() and
bl31_arch_setup() after data accesses have already occured on
the cold and warm boot paths.

This control bit must be configured immediately on CPU reset to
match the endian state of the firmware (little endian).

Fixes ARM-software/tf-issues#145

Change-Id: Ie12e46fbbed6baf024c30beb50751591bb8c8655
