### PR TITLE
Ensure a console is initialized before it is used

### DIFF
--- a/plat/fvp/bl1_plat_setup.c
+++ b/plat/fvp/bl1_plat_setup.c
@@ -78,6 +78,9 @@ void bl1_early_platform_setup(void)
 	const unsigned long bl1_ram_limit = BL1_RAM_LIMIT;
 	const unsigned long tzram_limit = TZRAM_BASE + TZRAM_SIZE;
 
+	/* Initialize the console to provide early debug support */
+	console_init(PL011_UART0_BASE);
+
 	/*
 	 * Calculate how much ram is BL1 using & how much remains free.
 	 * This also includes a rudimentary mechanism to detect whether
@@ -102,9 +105,6 @@ void bl1_early_platform_setup(void)
 
 	/* Initialize the platform config for future decision making */
 	platform_config_setup();
-
-	/* Initialize the console */
-	console_init(PL011_UART0_BASE);
 }
 
 /*******************************************************************************

--- a/plat/fvp/bl2_plat_setup.c
+++ b/plat/fvp/bl2_plat_setup.c
@@ -100,6 +100,9 @@ bl31_args_t *bl2_get_bl31_args_ptr(void)
 void bl2_early_platform_setup(meminfo_t *mem_layout,
 			      void *data)
 {
+	/* Initialize the console to provide early debug support */
+	console_init(PL011_UART0_BASE);
+
 	/* Setup the BL2 memory layout */
 	bl2_tzram_layout.total_base = mem_layout->total_base;
 	bl2_tzram_layout.total_size = mem_layout->total_size;
@@ -110,10 +113,6 @@ void bl2_early_platform_setup(meminfo_t *mem_layout,
 
 	/* Initialize the platform config for future decision making */
 	platform_config_setup();
-
-	console_init(PL011_UART0_BASE);
-
-	return;
 }
 
 /*******************************************************************************

--- a/plat/fvp/bl31_plat_setup.c
+++ b/plat/fvp/bl31_plat_setup.c
@@ -119,10 +119,11 @@ void bl31_early_platform_setup(bl31_args_t *from_bl2,
 {
 	bl2_to_bl31_args = from_bl2;
 
+	/* Initialize the console to provide early debug support */
+	console_init(PL011_UART0_BASE);
+
 	/* Initialize the platform config for future decision making */
 	platform_config_setup();
-
-	console_init(PL011_UART0_BASE);
 }
 
 /*******************************************************************************

--- a/plat/fvp/bl32_plat_setup.c
+++ b/plat/fvp/bl32_plat_setup.c
@@ -75,11 +75,18 @@ meminfo_t *bl32_plat_sec_mem_layout(void)
 
 /*******************************************************************************
  * BL1 has passed the extents of the trusted SRAM that's at BL32's disposal.
- * Initialize the BL32 data structure with the memory extends
+ * Initialize the BL32 data structure with the memory extends and initialize
+ * the UART
  ******************************************************************************/
 void bl32_early_platform_setup(meminfo_t *mem_layout,
 			      void *data)
 {
+	/*
+	 * Initialize a different console than already in use to display
+	 * messages from TSP
+	 */
+	console_init(PL011_UART1_BASE);
+
 	/* Setup the BL32 memory layout */
 	bl32_tzdram_layout.total_base = mem_layout->total_base;
 	bl32_tzdram_layout.total_size = mem_layout->total_size;
@@ -88,19 +95,14 @@ void bl32_early_platform_setup(meminfo_t *mem_layout,
 	bl32_tzdram_layout.attr = mem_layout->attr;
 	bl32_tzdram_layout.next = 0;
 
-	return;
 }
 
 /*******************************************************************************
- * Perform platform specific setup
+ * Perform platform specific setup placeholder
  ******************************************************************************/
 void bl32_platform_setup()
 {
-	/*
-	 * Initialize a different console than already in use to display
-	 * messages from TSP
-	 */
-	console_init(PL011_UART1_BASE);
+
 }
 
 /*******************************************************************************


### PR DESCRIPTION
This patch moves console_init() to bl32_early_platform_setup(). It
also ensures that console_init() is called in each
blX_early_platform_setup() function before the console is used
e.g. through a printf call in an assert() statement.

Fixes ARM-software/TF-issues#127

Change-Id: I5b1f17e0152bab674d807d2a95ff3689c5d4794e
