### PR TITLE
Fixes for TZC configuration on FVP

### DIFF
--- a/docs/porting-guide.md
+++ b/docs/porting-guide.md
@@ -631,8 +631,10 @@ this function. This information is accessible in the `bl33_meminfo` field in
 the `bl31_args` structure pointed to by `bl2_to_bl31_args`.
 
 Platform security components are configured if required. For the Base FVP the
-TZC-400 TrustZone controller is configured to grant secure and non-secure access
-to DRAM.
+TZC-400 TrustZone controller is configured to only grant non-secure access
+to DRAM. This avoids aliasing between secure and non-secure accesses in the
+TLB and cache - secure execution states can use the NS attributes in the
+MMU translation tables to access the DRAM.
 
 This function is also responsible for initializing the storage abstraction layer
 which is used to load further bootloader images.

--- a/plat/fvp/plat_security.c
+++ b/plat/fvp/plat_security.c
@@ -88,36 +88,33 @@ void plat_security_setup(void)
 	tzc_disable_filters(&controller);
 
 	/*
-	 * Allow full access to all DRAM to supported devices for the
-	 * moment. Give access to the CPUs and Virtio. Some devices
+	 * Allow only non-secure access to all DRAM to supported devices.
+	 * Give access to the CPUs and Virtio. Some devices
 	 * would normally use the default ID so allow that too. We use
-	 * three different regions to cover the three separate blocks of
-	 * memory in the FVPs. We allow secure access to DRAM to load NS
-	 * software.
-	 * FIXME: In current models Virtio uses a reserved ID. This is
-	 * not correct and will be fixed.
+	 * two regions to cover the blocks of physical memory in the FVPs.
+	 *
+	 * Software executing in the secure state, such as a secure
+	 * boot-loader, can access the DRAM by using the NS attributes in
+	 * the MMU translation tables and descriptors.
 	 */
 
-	/* Set to cover 2GB block of DRAM */
+	/* Set to cover the first block of DRAM */
 	tzc_configure_region(&controller, FILTER_SHIFT(0), 1,
-			DRAM_BASE, 0xFFFFFFFF, TZC_REGION_S_RDWR,
-			TZC_REGION_ACCESS_RDWR(FVP_NSAID_AP) |
+			DRAM_BASE, 0xFFFFFFFF, TZC_REGION_S_NONE,
 			TZC_REGION_ACCESS_RDWR(FVP_NSAID_DEFAULT) |
-			TZC_REGION_ACCESS_RDWR(FVP_NSAID_RES5));
+			TZC_REGION_ACCESS_RDWR(FVP_NSAID_PCI) |
+			TZC_REGION_ACCESS_RDWR(FVP_NSAID_AP) |
+			TZC_REGION_ACCESS_RDWR(FVP_NSAID_VIRTIO) |
+			TZC_REGION_ACCESS_RDWR(FVP_NSAID_VIRTIO_OLD));
 
-	/* Set to cover the 30GB block */
+	/* Set to cover the second block of DRAM */
 	tzc_configure_region(&controller, FILTER_SHIFT(0), 2,
-			0x880000000, 0xFFFFFFFFF, TZC_REGION_S_RDWR,
-			TZC_REGION_ACCESS_RDWR(FVP_NSAID_AP) |
+			0x880000000, 0xFFFFFFFFF, TZC_REGION_S_NONE,
 			TZC_REGION_ACCESS_RDWR(FVP_NSAID_DEFAULT) |
-			TZC_REGION_ACCESS_RDWR(FVP_NSAID_RES5));
-
-	/* Set to cover 480GB block */
-	tzc_configure_region(&controller, FILTER_SHIFT(0), 3,
-			0x8800000000, 0xFFFFFFFFFF, TZC_REGION_S_RDWR,
+			TZC_REGION_ACCESS_RDWR(FVP_NSAID_PCI) |
 			TZC_REGION_ACCESS_RDWR(FVP_NSAID_AP) |
-			TZC_REGION_ACCESS_RDWR(FVP_NSAID_DEFAULT) |
-			TZC_REGION_ACCESS_RDWR(FVP_NSAID_RES5));
+			TZC_REGION_ACCESS_RDWR(FVP_NSAID_VIRTIO) |
+			TZC_REGION_ACCESS_RDWR(FVP_NSAID_VIRTIO_OLD));
 
 	/*
 	 * TODO: Interrupts are not currently supported. The only

--- a/plat/fvp/platform.h
+++ b/plat/fvp/platform.h
@@ -307,18 +307,21 @@
 
 /*
  * The NSAIDs for this platform as used to program the TZC400.
- * TODO:
- * This list and the numbers in it is still changing on the Base FVP.
- * For now only specify the NSAIDs we actually use.
  */
 
 /* The FVP has 4 bits of NSAIDs. Used with TZC FAIL_ID (ACE Lite ID width) */
 #define FVP_AID_WIDTH			4
-#define FVP_NSAID_DEFAULT		0
-#define FVP_NSAID_AP			9  /* Application Processors */
 
-/* FIXME: Currently incorrectly used by Virtio */
-#define FVP_NSAID_RES5			15
+/* NSAIDs used by devices in TZC filter 0 on FVP */
+#define FVP_NSAID_DEFAULT		0
+#define FVP_NSAID_PCI			1
+#define FVP_NSAID_VIRTIO		8  /* from FVP v5.6 onwards */
+#define FVP_NSAID_AP			9  /* Application Processors */
+#define FVP_NSAID_VIRTIO_OLD		15 /* until FVP v5.5 */
+
+/* NSAIDs used by devices in TZC filter 2 on FVP */
+#define FVP_NSAID_HDLCD0		2
+#define FVP_NSAID_CLCD			7
 
 
 /*******************************************************************************


### PR DESCRIPTION
The TZC configuration on FVP was incorrectly allowing both secure
and non-secure accesses to the DRAM, which can cause aliasing
problems for software. It was also not enabling virtio access on
some models.

This patch fixes both of those issues. The patch also enabless
non-secure access to the DDR RAM for all devices with defined IDs.

The third region of DDR RAM has been removed from the configuration
as this is not used in any of the FVP models.

Fixes ARM-software/tf-issues#150
Fixes ARM-software/tf-issues#151

Change-Id: I60ad5daaf55e14f178affb8afd95d17e7537abd7
