### PR TITLE
fvp: Use the right implem. of plat_report_exception() in BL3-2

### DIFF
--- a/bl32/tsp/tsp-fvp.mk
+++ b/bl32/tsp/tsp-fvp.mk
@@ -31,4 +31,5 @@
 # TSP source files specific to FVP platform
 BL32_SOURCES		+=	plat/common/aarch64/platform_mp_stack.S		\
 				plat/fvp/bl32_plat_setup.c			\
-				plat/fvp/aarch64/plat_common.c
+				plat/fvp/aarch64/plat_common.c			\
+				plat/fvp/aarch64/plat_helpers.S


### PR DESCRIPTION
On FVP, the file 'plat/fvp/aarch64/plat_helpers.S' contains an
FVP-specific implementation of the function 'plat_report_exception()',
which is meant to override the default implementation. However, this
file was not included into the BL3-2 image, meaning it was still
using the default implementation. This patch fixes the FVP makefile
to compile this file in.
