### PR TITLE
Set SCR_EL3.RW correctly before exiting bl31_main

### DIFF
--- a/bl31/bl31_main.c
+++ b/bl31/bl31_main.c
@@ -169,8 +169,14 @@ void bl31_prepare_next_image_entry()
 	assert(next_image_info);
 
 	scr = read_scr();
+	scr &= ~SCR_NS_BIT;
 	if (image_type == NON_SECURE)
 		scr |= SCR_NS_BIT;
+
+	scr &= ~SCR_RW_BIT;
+	if ((next_image_info->spsr & (1 << MODE_RW_SHIFT)) ==
+				(MODE_RW_64 << MODE_RW_SHIFT))
+		scr |= SCR_RW_BIT;
 
 	/*
 	 * Tell the context mgmt. library to ensure that SP_EL3 points to


### PR DESCRIPTION
SCR_EL3.RW was not updated immediately before exiting bl31_main() and
running BL3-3. If a AArch32 Secure-EL1 Payload had just been
initialised, then the SCR_EL3.RW bit would be left indicating a
32-bit BL3-3, which may not be correct.

This patch explicitly sets SCR_EL3.RW appropriately based on the
provided SPSR_EL3 value for the BL3-3 image.

Fixes ARM-software/tf-issues#126

Change-Id: Ic7716fe8bc87e577c4bfaeb46702e88deedd9895
