### PR TITLE
Allow BL3-2 platform definitions to be optional

### DIFF
--- a/bl2/bl2_main.c
+++ b/bl2/bl2_main.c
@@ -86,6 +86,7 @@ void bl2_main(void)
 	 */
 	bl2_to_bl31_args = bl2_get_bl31_args_ptr();
 
+#ifdef BL32_BASE
 	/*
 	 * Load the BL32 image if there's one. It is upto to platform
 	 * to specify where BL32 should be loaded if it exists. It
@@ -99,6 +100,7 @@ void bl2_main(void)
 				       bl2_to_bl31_args->bl32_meminfo.attr &
 				       LOAD_MASK,
 				       BL32_BASE);
+#endif /* BL32_BASE */
 
 	/*
 	 * Create a new layout of memory for BL31 as seen by BL2. This

--- a/docs/porting-guide.md
+++ b/docs/porting-guide.md
@@ -543,23 +543,24 @@ using the `platform_is_primary_cpu()` function. BL1 passed control to BL2 at
     if the platform wants to restrict the amount of memory visible to BL3-1.
     Details of this function are given below.
 
-4.  Loading the BL3-2 binary image (if present) in platform provided memory
-    using semi-hosting. To load the BL3-2 image, BL2 makes use of the
-    `bl32_meminfo` field in the `bl31_args` structure to which a pointer is
+4.  (Optional) Loading the BL3-2 binary image (if present) from platform
+    provided non-volatile storage. To load the BL3-2 image, BL2 makes use of
+    the `bl32_meminfo` field in the `bl31_args` structure to which a pointer is
     returned by the `bl2_get_bl31_args_ptr()` function. The platform also
-    defines the address in memory where BL3-2 is loaded through the constant
-    `BL32_BASE`. BL2 uses this information to determine if there is enough
-    memory to load the BL3-2 image.
+    defines the address in memory where BL3-2 is loaded through the optional
+    constant `BL32_BASE`. BL2 uses this information to determine if there is
+    enough memory to load the BL3-2 image. If `BL32_BASE` is not defined then
+    this and the following two steps are not performed.
 
-5.  Arranging to pass control to the BL3-2 image (if present) that has been
-    pre-loaded at `BL32_BASE`. BL2 populates an `el_change_info` structure
-    in memory provided by the platform with information about how BL3-1 should
-    pass control to the BL3-2 image. This structure follows the
+5.  (Optional) Arranging to pass control to the BL3-2 image (if present) that
+    has been pre-loaded at `BL32_BASE`. BL2 populates an `el_change_info`
+    structure in memory provided by the platform with information about how
+    BL3-1 should pass control to the BL3-2 image. This structure follows the
     `el_change_info` structure populated for the normal world BL image in 2.
     above.
 
-6.  Populating a `meminfo` structure with the following information in
-    memory that is accessible by BL3-1 immediately upon entry.
+6.  (Optional) Populating a `meminfo` structure with the following information
+    in memory that is accessible by BL3-1 immediately upon entry.
 
         meminfo.total_base = Base address of memory visible to BL3-2
         meminfo.total_size = Size of memory visible to BL3-2
@@ -569,7 +570,7 @@ using the `platform_is_primary_cpu()` function. BL1 passed control to BL2 at
                              BL3-2
 
     BL2 populates this information in the `bl32_meminfo` field of the pointer
-    returned by the `bl2_get_bl31_args_ptr() function.
+    returned by the `bl2_get_bl31_args_ptr()` function.
 
 The following functions must be implemented by the platform port to enable BL2
 to perform the above tasks.

--- a/drivers/io/io_fip.c
+++ b/drivers/io/io_fip.c
@@ -65,7 +65,10 @@ typedef struct {
 static const plat_fip_name_uuid_t name_uuid[] = {
 	{BL2_IMAGE_NAME, UUID_TRUSTED_BOOT_FIRMWARE_BL2},
 	{BL31_IMAGE_NAME, UUID_EL3_RUNTIME_FIRMWARE_BL31},
+#ifdef BL32_IMAGE_NAME
+	/* BL3-2 is optional in the platform */
 	{BL32_IMAGE_NAME, UUID_SECURE_PAYLOAD_BL32},
+#endif /* BL32_IMAGE_NAME */
 	{BL33_IMAGE_NAME, UUID_NON_TRUSTED_FIRMWARE_BL33},
 };
 


### PR DESCRIPTION
The generic image loading and IO FIP code no longer forces the
platform to create BL3-2 (Secure-EL1 Payload) specific
definitions. The BL3-2 loading code in bl2/bl2main.c is wrapped
by a #ifdef BL32_BASE blocks, allowing the BL3-2 definitions to
be optional. Similarly for the name_uuid array defintion in
drivers/io/io_fip.c.

Also update the porting guide to reflect this change.

The BL3-2 platform definitions remain non-configurably present
in the FVP port.

Fixes ARM-software/tf-issues#68

Change-Id: Iea28b4e94d87a31f5522f271e290919a8a955460
