### PR TITLE
Pass 'cookie' parameter to interrupt handler in BL3-1

### DIFF
--- a/bl31/aarch64/runtime_exceptions.S
+++ b/bl31/aarch64/runtime_exceptions.S
@@ -105,8 +105,9 @@
 	 * Read the id of the highest priority pending interrupt. If
 	 * no interrupt is asserted then return to where we came from.
 	 */
+	mov	x19,  #INTR_ID_UNAVAILABLE
 	bl	plat_ic_get_pending_interrupt_id
-	cmp	x0, #INTR_ID_UNAVAILABLE
+	cmp	x19, x0
 	b.eq	interrupt_exit_\label
 #endif
 

--- a/services/spd/tspd/tspd_main.c
+++ b/services/spd/tspd/tspd_main.c
@@ -90,7 +90,7 @@ static uint64_t tspd_sel1_interrupt_handler(uint32_t id,
 
 #if IMF_READ_INTERRUPT_ID
 	/* Check the security status of the interrupt */
-	assert(ic_get_interrupt_group(id) == SECURE);
+	assert(plat_ic_get_interrupt_type(id) == INTR_TYPE_S_EL1);
 #endif
 
 	/* Sanity check the pointer to this cpu's context */


### PR DESCRIPTION
The interrupt handling routine in BL3-1 expects a cookie as its last
parameter which was not being passed when invoking the interrupt
handler in BL3-1. This patch fixes that by passing a dummy cookie
parameter in the x3 register.

Fixes ARM-software/tf-issues#171

Change-Id: Ic98abbbd9f849e6f1c55343e865b5e0a4904a1c5
