### PR TITLE
Enable mapping higher physical address

### DIFF
--- a/include/lib/aarch64/xlat_tables.h
+++ b/include/lib/aarch64/xlat_tables.h
@@ -67,7 +67,7 @@ void mmap_add(const mmap_region_t *mm);
 
 void init_xlat_tables(void);
 
-void enable_mmu_el1(void);
-void enable_mmu_el3(void);
+void enable_mmu_el1(uint64_t tcr_extra);
+void enable_mmu_el3(uint64_t tcr_extra);
 
 #endif /* __XLAT_TABLES_H__ */

--- a/lib/aarch64/xlat_tables.c
+++ b/lib/aarch64/xlat_tables.c
@@ -249,8 +249,8 @@ void init_xlat_tables(void)
  *   _tlbi_fct:		Function to invalidate the TLBs at the current
  *			exception level
  ******************************************************************************/
-#define DEFINE_ENABLE_MMU_EL(_el, _tcr_extra, _tlbi_fct)		\
-	void enable_mmu_el##_el(void)					\
+#define DEFINE_ENABLE_MMU_EL(_el, _tlbi_fct)				\
+	void enable_mmu_el##_el(uint64_t tcr_extra)			\
 	{								\
 		uint64_t mair, tcr, ttbr;				\
 		uint32_t sctlr;						\
@@ -271,7 +271,7 @@ void init_xlat_tables(void)
 		/* Inner & outer WBWA & shareable + T0SZ = 32 */	\
 		tcr = TCR_SH_INNER_SHAREABLE | TCR_RGN_OUTER_WBA |	\
 			TCR_RGN_INNER_WBA | TCR_T0SZ_4GB;		\
-		tcr |= _tcr_extra;					\
+		tcr |= tcr_extra;					\
 		write_tcr_el##_el(tcr);					\
 									\
 		/* Set TTBR bits as well */				\
@@ -295,5 +295,5 @@ void init_xlat_tables(void)
 	}
 
 /* Define EL1 and EL3 variants of the function enabling the MMU */
-DEFINE_ENABLE_MMU_EL(1, 0, tlbivmalle1)
-DEFINE_ENABLE_MMU_EL(3, TCR_EL3_RES1, tlbialle3)
+DEFINE_ENABLE_MMU_EL(1, tlbivmalle1)
+DEFINE_ENABLE_MMU_EL(3, tlbialle3)

--- a/plat/common/aarch64/plat_common.c
+++ b/plat/common/aarch64/plat_common.c
@@ -28,6 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <arch.h>
 #include <xlat_tables.h>
 
 /*
@@ -40,10 +41,10 @@
 
 void bl31_plat_enable_mmu()
 {
-	enable_mmu_el3();
+	enable_mmu_el3(TCR_EL3_RES1);
 }
 
 void bl32_plat_enable_mmu()
 {
-	enable_mmu_el1();
+	enable_mmu_el1(0x0);
 }

--- a/plat/fvp/aarch64/fvp_common.c
+++ b/plat/fvp/aarch64/fvp_common.c
@@ -82,7 +82,7 @@ const mmap_region_t fvp_mmap[] = {
  * Macro generating the code for the function setting up the pagetables as per
  * the platform memory map & initialize the mmu, for the given exception level
  ******************************************************************************/
-#define DEFINE_CONFIGURE_MMU_EL(_el)					\
+#define DEFINE_CONFIGURE_MMU_EL(_el, _tcr_extra)			\
 	void fvp_configure_mmu_el##_el(unsigned long total_base,	\
 				   unsigned long total_size,		\
 				   unsigned long ro_start,		\
@@ -102,12 +102,12 @@ const mmap_region_t fvp_mmap[] = {
 		mmap_add(fvp_mmap);					\
 		init_xlat_tables();					\
 									\
-		enable_mmu_el##_el();					\
+		enable_mmu_el##_el(_tcr_extra);				\
 	}
 
 /* Define EL1 and EL3 variants of the function initialising the MMU */
-DEFINE_CONFIGURE_MMU_EL(1)
-DEFINE_CONFIGURE_MMU_EL(3)
+DEFINE_CONFIGURE_MMU_EL(1, 0x0)
+DEFINE_CONFIGURE_MMU_EL(3, TCR_EL3_RES1)
 
 /* Simple routine which returns a configuration variable value */
 unsigned long fvp_get_cfgvar(unsigned int var_id)


### PR DESCRIPTION
Current ATF uses a direct physical-to-virtual mapping, that is, a physical
address is mapped to the same address in the virtual space. For example,
physical address 0x8000_0000 is mapped to 0x8000_0000 virtual. This
approach works fine for FVP as all its physical addresses fall into 0 to
4GB range. But for other platform where all I/O addresses are 48-bit long,
If we follow the same direct mapping, we would need virtual address range
from 0 to 0x8fff_ffff_ffff, which is about 144TB. This requires a
significant amount of memory for MMU tables and it is not necessary to use
that much virtual space in ATF.

The patch is to enable mapping a physical address range to an arbitrary
virtual address range (instead of flat mapping)
Changed "base" to "base_va" and added "base_pa" in mmap_region_t and
modified functions such as mmap_add_region and init_xlation_table etc.
Fixes ARM-software/tf-issues#158
