### PR TITLE
Include 'platform_def.h' header file in 'crash_reporting.S'

### DIFF
--- a/bl31/aarch64/crash_reporting.S
+++ b/bl31/aarch64/crash_reporting.S
@@ -31,6 +31,7 @@
 #include <asm_macros.S>
 #include <context.h>
 #include <plat_macros.S>
+#include <platform_def.h>
 
 	.globl	get_crash_stack
 	.globl	dump_state_and_die


### PR DESCRIPTION
'crash_reporting.S' needs to include 'platform_def.h' to get the
definition of PLATFORM_CORE_COUNT.

Note: On FVP it was compiling because 'platform_def.h' gets included
through 'plat/fvp/include/plat_macros.S' but we don't want to rely on
that for other platforms.
