### PR TITLE
PL011: Fix a bug in the UART FIFO polling

### DIFF
--- a/drivers/arm/pl011/pl011_console.c
+++ b/drivers/arm/pl011/pl011_console.c
@@ -65,8 +65,10 @@ void console_init(unsigned long base_addr)
 
 }
 
-#define WAIT_UNTIL_UART_FREE(base) while ((pl011_read_fr(base)\
-					& PL011_UARTFR_TXFF) == 1)
+#define WAIT_UNTIL_UART_FREE(base)				\
+	while ((pl011_read_fr(base) & PL011_UARTFR_TXFF))	\
+		continue
+
 int console_putc(int c)
 {
 	assert(uart_base);


### PR DESCRIPTION
Before attempting to write a character, the PL011 driver polls
the PL011_UARTFR_TXFF bit to know whether the UART FIFO is full.
However, the comparison with 1 was incorrect because
PL011_UARTFR_TXFF is not at bit 0. This patch fixes it.
