### PR TITLE
Provide cm_get/set_context() for current CPU

### DIFF
--- a/bl31/bl31_main.c
+++ b/bl31/bl31_main.c
@@ -71,9 +71,6 @@ void bl31_lib_init()
  ******************************************************************************/
 void bl31_main(void)
 {
-#if DEBUG
-	unsigned long mpidr = read_mpidr();
-#endif
 
 	/* Perform remaining generic architectural setup from EL3 */
 	bl31_arch_setup();
@@ -98,7 +95,7 @@ void bl31_main(void)
 	 * structure which has an exception stack allocated.  The PSCI
 	 * service should have set the context.
 	 */
-	assert(cm_get_context(mpidr, NON_SECURE));
+	assert(cm_get_context(NON_SECURE));
 	cm_set_next_eret_context(NON_SECURE);
 	cm_init_pcpu_ptr_cache();
 	write_vbar_el3((uint64_t) runtime_exceptions);
@@ -195,7 +192,7 @@ void bl31_prepare_next_image_entry()
 	 * Save the args generated in BL2 for the image in the right context
 	 * used on its entry
 	 */
-	ctx = cm_get_context(read_mpidr(), image_type);
+	ctx = cm_get_context(image_type);
 	gp_regs = get_gpregs_ctx(ctx);
 	memcpy(gp_regs, (void *)&next_image_info->args, sizeof(aapcs64_params_t));
 

--- a/include/bl31/context_mgmt.h
+++ b/include/bl31/context_mgmt.h
@@ -37,10 +37,12 @@
  * Function & variable prototypes
  ******************************************************************************/
 void cm_init(void);
-void *cm_get_context(uint64_t mpidr, uint32_t security_state);
-void cm_set_context(uint64_t mpidr,
-		    void *context,
-		    uint32_t security_state);
+void *cm_get_context_by_mpidr(uint64_t mpidr, uint32_t security_state);
+void *cm_get_context(uint32_t security_state);
+void cm_set_context_by_mpidr(uint64_t mpidr,
+			     void *context,
+			     uint32_t security_state);
+void cm_set_context(void *context, uint32_t security_state);
 void cm_el3_sysregs_context_save(uint32_t security_state);
 void cm_el3_sysregs_context_restore(uint32_t security_state);
 void cm_el1_sysregs_context_save(uint32_t security_state);

--- a/services/spd/tspd/tspd_common.c
+++ b/services/spd/tspd/tspd_common.c
@@ -100,7 +100,7 @@ int32_t tspd_init_secure_context(uint64_t entrypoint,
 	/* Associate this context with the cpu specified */
 	tsp_ctx->mpidr = mpidr;
 
-	cm_set_context(mpidr, &tsp_ctx->cpu_ctx, SECURE);
+	cm_set_context(&tsp_ctx->cpu_ctx, SECURE);
 	spsr = SPSR_64(MODE_EL1, MODE_SP_ELX, DISABLE_ALL_EXCEPTIONS);
 	cm_set_el3_eret_context(SECURE, entrypoint, spsr, scr);
 
@@ -122,7 +122,7 @@ uint64_t tspd_synchronous_sp_entry(tsp_context_t *tsp_ctx)
 	assert(tsp_ctx->c_rt_ctx == 0);
 
 	/* Apply the Secure EL1 system register context and switch to it */
-	assert(cm_get_context(read_mpidr(), SECURE) == &tsp_ctx->cpu_ctx);
+	assert(cm_get_context(SECURE) == &tsp_ctx->cpu_ctx);
 	cm_el1_sysregs_context_restore(SECURE);
 	cm_set_next_eret_context(SECURE);
 
@@ -146,7 +146,7 @@ uint64_t tspd_synchronous_sp_entry(tsp_context_t *tsp_ctx)
 void tspd_synchronous_sp_exit(tsp_context_t *tsp_ctx, uint64_t ret)
 {
 	/* Save the Secure EL1 system register context */
-	assert(cm_get_context(read_mpidr(), SECURE) == &tsp_ctx->cpu_ctx);
+	assert(cm_get_context(SECURE) == &tsp_ctx->cpu_ctx);
 	cm_el1_sysregs_context_save(SECURE);
 
 	assert(tsp_ctx->c_rt_ctx != 0);

--- a/services/spd/tspd/tspd_main.c
+++ b/services/spd/tspd/tspd_main.c
@@ -95,7 +95,7 @@ static uint64_t tspd_sel1_interrupt_handler(uint32_t id,
 
 	/* Sanity check the pointer to this cpu's context */
 	mpidr = read_mpidr();
-	assert(handle == cm_get_context(mpidr, NON_SECURE));
+	assert(handle == cm_get_context(NON_SECURE));
 
 	/* Save the non-secure context before entering the TSP */
 	cm_el1_sysregs_context_save(NON_SECURE);
@@ -103,7 +103,7 @@ static uint64_t tspd_sel1_interrupt_handler(uint32_t id,
 	/* Get a reference to this cpu's TSP context */
 	linear_id = platform_get_core_pos(mpidr);
 	tsp_ctx = &tspd_sp_context[linear_id];
-	assert(&tsp_ctx->cpu_ctx == cm_get_context(mpidr, SECURE));
+	assert(&tsp_ctx->cpu_ctx == cm_get_context(SECURE));
 
 	/*
 	 * Determine if the TSP was previously preempted. Its last known
@@ -275,10 +275,10 @@ uint64_t tspd_smc_handler(uint32_t smc_fid,
 		if (ns)
 			SMC_RET1(handle, SMC_UNK);
 
-		assert(handle == cm_get_context(mpidr, SECURE));
+		assert(handle == cm_get_context(SECURE));
 		cm_el1_sysregs_context_save(SECURE);
 		/* Get a reference to the non-secure context */
-		ns_cpu_context = cm_get_context(mpidr, NON_SECURE);
+		ns_cpu_context = cm_get_context(NON_SECURE);
 		assert(ns_cpu_context);
 
 		/*
@@ -300,7 +300,7 @@ uint64_t tspd_smc_handler(uint32_t smc_fid,
 		if (ns)
 			SMC_RET1(handle, SMC_UNK);
 
-		assert(handle == cm_get_context(mpidr, SECURE));
+		assert(handle == cm_get_context(SECURE));
 
 		/*
 		 * Restore the relevant EL3 state which saved to service
@@ -316,7 +316,7 @@ uint64_t tspd_smc_handler(uint32_t smc_fid,
 		}
 
 		/* Get a reference to the non-secure context */
-		ns_cpu_context = cm_get_context(mpidr, NON_SECURE);
+		ns_cpu_context = cm_get_context(NON_SECURE);
 		assert(ns_cpu_context);
 
 		/*
@@ -339,7 +339,7 @@ uint64_t tspd_smc_handler(uint32_t smc_fid,
 		if (ns)
 			SMC_RET1(handle, SMC_UNK);
 
-		assert(handle == cm_get_context(mpidr, SECURE));
+		assert(handle == cm_get_context(SECURE));
 
 		/* Assert that standard SMC execution has been preempted */
 		assert(get_std_smc_active_flag(tsp_ctx->state));
@@ -348,7 +348,7 @@ uint64_t tspd_smc_handler(uint32_t smc_fid,
 		cm_el1_sysregs_context_save(SECURE);
 
 		/* Get a reference to the non-secure context */
-		ns_cpu_context = cm_get_context(mpidr, NON_SECURE);
+		ns_cpu_context = cm_get_context(NON_SECURE);
 		assert(ns_cpu_context);
 
 		/* Restore non-secure state */
@@ -434,7 +434,7 @@ uint64_t tspd_smc_handler(uint32_t smc_fid,
 			 * registers need to be preserved, save the non-secure
 			 * state and send the request to the secure payload.
 			 */
-			assert(handle == cm_get_context(mpidr, NON_SECURE));
+			assert(handle == cm_get_context(NON_SECURE));
 
 			/* Check if we are already preempted */
 			if (get_std_smc_active_flag(tsp_ctx->state))
@@ -457,7 +457,7 @@ uint64_t tspd_smc_handler(uint32_t smc_fid,
 			 * payload. Entry into S-EL1 will take place upon exit
 			 * from this function.
 			 */
-			assert(&tsp_ctx->cpu_ctx == cm_get_context(mpidr, SECURE));
+			assert(&tsp_ctx->cpu_ctx == cm_get_context(SECURE));
 
 			/* Set appropriate entry for SMC.
 			 * We expect the TSP to manage the PSTATE.I and PSTATE.F
@@ -482,11 +482,11 @@ uint64_t tspd_smc_handler(uint32_t smc_fid,
 			 * into the non-secure context, save the secure state
 			 * and return to the non-secure state.
 			 */
-			assert(handle == cm_get_context(mpidr, SECURE));
+			assert(handle == cm_get_context(SECURE));
 			cm_el1_sysregs_context_save(SECURE);
 
 			/* Get a reference to the non-secure context */
-			ns_cpu_context = cm_get_context(mpidr, NON_SECURE);
+			ns_cpu_context = cm_get_context(NON_SECURE);
 			assert(ns_cpu_context);
 
 			/* Restore non-secure state */
@@ -515,7 +515,7 @@ uint64_t tspd_smc_handler(uint32_t smc_fid,
 		 * save the non-secure state and send the request to
 		 * the secure payload.
 		 */
-		assert(handle == cm_get_context(mpidr, NON_SECURE));
+		assert(handle == cm_get_context(NON_SECURE));
 
 		/* Check if we are already preempted before resume */
 		if (!get_std_smc_active_flag(tsp_ctx->state))

--- a/services/std_svc/psci/psci_afflvl_on.c
+++ b/services/std_svc/psci/psci_afflvl_on.c
@@ -378,7 +378,7 @@ static unsigned int psci_afflvl0_on_finish(unsigned long mpidr,
 	 * structure. The calling cpu should have set the
 	 * context already
 	 */
-	assert(cm_get_context(mpidr, NON_SECURE));
+	assert(cm_get_context(NON_SECURE));
 	cm_set_next_eret_context(NON_SECURE);
 	cm_init_pcpu_ptr_cache();
 	write_vbar_el3((uint64_t) runtime_exceptions);

--- a/services/std_svc/psci/psci_afflvl_suspend.c
+++ b/services/std_svc/psci/psci_afflvl_suspend.c
@@ -180,7 +180,7 @@ static int psci_afflvl0_suspend(unsigned long mpidr,
 	 * The EL3 state to PoC since it will be accessed after a
 	 * reset with the caches turned off
 	 */
-	saved_el3_state = get_el3state_ctx(cm_get_context(mpidr, NON_SECURE));
+	saved_el3_state = get_el3state_ctx(cm_get_context(NON_SECURE));
 	flush_dcache_range((uint64_t) saved_el3_state, sizeof(*saved_el3_state));
 
 	/* Set the secure world (EL3) re-entry point after BL1 */
@@ -496,7 +496,6 @@ static unsigned int psci_afflvl0_suspend_finish(unsigned long mpidr,
 	 * structure. The non-secure context should have been
 	 * set on this cpu prior to suspension.
 	 */
-	assert(cm_get_context(mpidr, NON_SECURE));
 	cm_set_next_eret_context(NON_SECURE);
 	cm_init_pcpu_ptr_cache();
 	write_vbar_el3((uint64_t) runtime_exceptions);

--- a/services/std_svc/psci/psci_common.c
+++ b/services/std_svc/psci/psci_common.c
@@ -219,7 +219,6 @@ int psci_validate_mpidr(unsigned long mpidr, int level)
 void psci_get_ns_entry_info(unsigned int index)
 {
 	unsigned long sctlr = 0, scr, el_status, id_aa64pfr0;
-	uint64_t mpidr = read_mpidr();
 	cpu_context_t *ns_entry_context;
 	gp_regs_t *ns_entry_gpregs;
 
@@ -253,7 +252,7 @@ void psci_get_ns_entry_info(unsigned int index)
 		write_sctlr_el1(sctlr);
 
 	/* Fulfill the cpu_on entry reqs. as per the psci spec */
-	ns_entry_context = (cpu_context_t *) cm_get_context(mpidr, NON_SECURE);
+	ns_entry_context = (cpu_context_t *) cm_get_context(NON_SECURE);
 	assert(ns_entry_context);
 
 	/*

--- a/services/std_svc/psci/psci_setup.c
+++ b/services/std_svc/psci/psci_setup.c
@@ -210,9 +210,9 @@ static void psci_init_aff_map_node(unsigned long mpidr,
 		linear_id = platform_get_core_pos(mpidr);
 		assert(linear_id < PLATFORM_CORE_COUNT);
 
-		cm_set_context(mpidr,
-				(void *) &psci_ns_context[linear_id],
-				NON_SECURE);
+		cm_set_context_by_mpidr(mpidr,
+					(void *) &psci_ns_context[linear_id],
+					NON_SECURE);
 
 	}
 


### PR DESCRIPTION
All callers of `cm_get_context()` pass the calling CPU MPIDR to the
function. Providing a specialised version for the current
CPU results in a reduction in code size and better readability.

The current function has been renamed to `cm_get_context_by_mpidr()`
and the existing name is now used for the current-CPU version.

The same treatment has been done to `cm_set_context()`, although
only both forms are used at present in the PSCI and TSPD code.

Change-Id: I91cb0c2f7bfcb950a045dbd9ff7595751c0c0ffb
