### PR TITLE
Calculate TCR bits based on VA and PA

### DIFF
--- a/include/lib/aarch64/arch.h
+++ b/include/lib/aarch64/arch.h
@@ -200,6 +200,8 @@
  * TCR defintions
  */
 #define TCR_EL3_RES1		((1UL << 31) | (1UL << 23))
+#define TCR_EL1_IPS_SHIFT 	32
+#define TCR_EL3_PS_SHIFT	16
 
 /* (internal) physical address size bits in EL3/EL1 */
 #define TCR_PS_BITS_4GB		(0x0)

--- a/lib/aarch64/xlat_tables.c
+++ b/lib/aarch64/xlat_tables.c
@@ -273,6 +273,7 @@ static unsigned int calc_physical_addr_size_bits(unsigned long max_addr)
 
 static unsigned int check_va_size(unsigned long max_addr)
 {
+	assert(ADDR_SPACE_SIZE > 0);
 	assert(max_addr < ADDR_SPACE_SIZE);
 	return (max_addr < ADDR_SPACE_SIZE);
 }
@@ -317,7 +318,7 @@ void init_xlat_tables(void)
 		/* Inner & outer WBWA & shareable + T0SZ = 32 */	\
 		tcr = TCR_SH_INNER_SHAREABLE | TCR_RGN_OUTER_WBA |	\
 			TCR_RGN_INNER_WBA |				\
-			(64 - ADDR_SPACE_SIZE_SHIFT);			\
+			(64 - __builtin_ctzl(ADDR_SPACE_SIZE));		\
 		tcr |= _tcr_extra;					\
 		write_tcr_el##_el(tcr);					\
 									\
@@ -342,5 +343,5 @@ void init_xlat_tables(void)
 	}
 
 /* Define EL1 and EL3 variants of the function enabling the MMU */
-DEFINE_ENABLE_MMU_EL(1, (tcr_ps_bits << 32), tlbivmalle1)
-DEFINE_ENABLE_MMU_EL(3, TCR_EL3_RES1 | (tcr_ps_bits << 16), tlbialle3)
+DEFINE_ENABLE_MMU_EL(1, (tcr_ps_bits << TCR_EL1_IPS_SHIFT), tlbivmalle1)
+DEFINE_ENABLE_MMU_EL(3, TCR_EL3_RES1 | (tcr_ps_bits << TCR_EL3_PS_SHIFT), tlbialle3)

--- a/plat/fvp/include/platform_def.h
+++ b/plat/fvp/include/platform_def.h
@@ -144,8 +144,7 @@
 /*******************************************************************************
  * Platform specific page table and MMU setup constants
  ******************************************************************************/
-#define ADDR_SPACE_SIZE_SHIFT		32
-#define ADDR_SPACE_SIZE			(1ull << ADDR_SPACE_SIZE_SHIFT)
+#define ADDR_SPACE_SIZE			(1ull << 32)
 #define MAX_XLAT_TABLES			3
 #define MAX_MMAP_REGIONS		16
 


### PR DESCRIPTION
Currently the TCR bits are hardcoded in xlat_tables.c. In order to
map higher physicall address into low virtual address, the TCR bits
need to be configured accordingly.

This patch is to save the max VA and PA and calculate the TCR.PS/IPS
and t0sz bits in init_xlat_tables function.
