### PR TITLE
Make the BL3-1 crash reporting optional

### DIFF
--- a/bl31/aarch64/crash_reporting.S
+++ b/bl31/aarch64/crash_reporting.S
@@ -36,6 +36,7 @@
 	.globl	dump_state_and_die
 	.globl	dump_intr_state_and_die
 
+#if CRASH_REPORTING
 	/* ------------------------------------------------------
 	 * The below section deals with dumping the system state
 	 * when an unhandled exception is taken in EL3.
@@ -264,9 +265,15 @@ print_state:
 	print_el3_sys_regs
 	print_non_el3_sys_0_regs
 	print_non_el3_sys_1_regs
-	b	infinite_loop
 
-func infinite_loop
+#else	/* CRASH_REPORING */
+
+func dump_state_and_die
+dump_intr_state_and_die:
+
+#endif	/* CRASH_REPORING */
+
+infinite_loop:
 	b	infinite_loop
 
 

--- a/bl31/bl31.mk
+++ b/bl31/bl31.mk
@@ -59,3 +59,11 @@ IMF_READ_INTERRUPT_ID	:=	0
 $(eval $(call assert_boolean,IMF_READ_INTERRUPT_ID))
 $(eval $(call add_define,IMF_READ_INTERRUPT_ID))
 
+# Flag used to inidicate if Crash reporting via console should be included
+# in BL3-1. This defaults to being present in DEBUG builds only
+ifndef CRASH_REPORTING
+CRASH_REPORTING		:=	$(DEBUG)
+endif
+
+$(eval $(call assert_boolean,CRASH_REPORTING))
+$(eval $(call add_define,CRASH_REPORTING))

--- a/bl31/context_mgmt.c
+++ b/bl31/context_mgmt.c
@@ -285,7 +285,9 @@ void cm_init_pcpu_ptr_cache()
 
 	pcpu_ptr_cache = &per_cpu_ptr_cache_space[linear_id];
 	assert(pcpu_ptr_cache);
+#if CRASH_REPORTING
 	pcpu_ptr_cache->crash_stack = get_crash_stack(mpidr);
+#endif
 
 	cm_set_pcpu_ptr_cache(pcpu_ptr_cache);
 }

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -172,6 +172,10 @@ performed.
     entrypoint) or 1 (CPU reset to BL3-1 entrypoint).
     The default value is 0.
 
+*   `CRASH_REPORTING`: A non-zero value enables a console dump of processor
+    register state when an unexpected exception occurs during execution of
+    BL3-1. This option defaults to the value of `DEBUG` - i.e. by default
+    this is only enabled for a debug build of the firmware.
 
 ### Creating a Firmware Image Package
 


### PR DESCRIPTION
This patch makes the console crash dump of processor register
state optional based on the CRASH_REPORTING make variable.

This defaults to only being enabled for DEBUG builds. This can
be overridden by setting a different value in the platform
makefile or on the make command line.

Change-Id: Icfa1b2d7ff0145cf0a85e8ad732f9cee7e7e993f
