### PR TITLE
Set correct value for SYS_ID_REV_SHIFT in FVP

### DIFF
--- a/plat/fvp/fvp_def.h
+++ b/plat/fvp/fvp_def.h
@@ -137,7 +137,7 @@
 #define SYS_LED_EC_MASK		0x1f
 
 /* V2M sysid register bits */
-#define SYS_ID_REV_SHIFT	27
+#define SYS_ID_REV_SHIFT	28
 #define SYS_ID_HBI_SHIFT	16
 #define SYS_ID_BLD_SHIFT	12
 #define SYS_ID_ARCH_SHIFT	8


### PR DESCRIPTION
According to documentation, the Rev field is located at bit 28 in
the V2M sysid register.

Fixes ARM-software/tf-issues#179

Change-Id: I2abb7bdc092ccd3f41f8962dc8d8d8e44e8dfdc3
