### PR TITLE
Remove re-initialisation of system timers after warm boot for FVP

### DIFF
--- a/plat/fvp/fvp_pm.c
+++ b/plat/fvp/fvp_pm.c
@@ -290,7 +290,7 @@ int fvp_affinst_on_finish(unsigned long mpidr,
 	int rc = PSCI_E_SUCCESS;
 	unsigned long linear_id, cpu_setup;
 	mailbox_t *fvp_mboxes;
-	unsigned int gicd_base, gicc_base, reg_val, ectlr;
+	unsigned int gicd_base, gicc_base, ectlr;
 
 	switch (afflvl) {
 
@@ -353,17 +353,6 @@ int fvp_affinst_on_finish(unsigned long mpidr,
 
 		/* TODO: This setup is needed only after a cold boot */
 		gic_pcpu_distif_setup(gicd_base);
-
-		/* Allow access to the System counter timer module */
-		reg_val = (1 << CNTACR_RPCT_SHIFT) | (1 << CNTACR_RVCT_SHIFT);
-		reg_val |= (1 << CNTACR_RFRQ_SHIFT) | (1 << CNTACR_RVOFF_SHIFT);
-		reg_val |= (1 << CNTACR_RWVT_SHIFT) | (1 << CNTACR_RWPT_SHIFT);
-		mmio_write_32(SYS_TIMCTL_BASE + CNTACR_BASE(0), reg_val);
-		mmio_write_32(SYS_TIMCTL_BASE + CNTACR_BASE(1), reg_val);
-
-		reg_val = (1 << CNTNSAR_NS_SHIFT(0)) |
-			(1 << CNTNSAR_NS_SHIFT(1));
-		mmio_write_32(SYS_TIMCTL_BASE + CNTNSAR, reg_val);
 
 		break;
 


### PR DESCRIPTION
This patch removes the reinitialisation of memory mapped system timer
registers after a warm boot for the FVP. The system timers in FVP are
in the 'Always ON' power domain which meant the reinitialisation was
redundant and it could have conflicted with the setup the normal
world has done.

The programming of CNTACR(x) and CNTNSAR, the system timer registers,
are removed from the warm boot path with this patch.

Fixes ARM-software/tf-issues#169

Change-Id: Ie982eb03d1836b15ef3cf1568de2ea68a08b443e
