### PR TITLE
Remove broken assertion in console_putc()

### DIFF
--- a/drivers/arm/pl011/pl011_console.c
+++ b/drivers/arm/pl011/pl011_console.c
@@ -71,7 +71,12 @@ void console_init(unsigned long base_addr)
 
 int console_putc(int c)
 {
-	assert(uart_base);
+	/* If the console has not been initialized then return an error
+	 * code. Asserting here would result in recursion and stack
+	 * exhaustion
+	 */
+	if (!uart_base)
+		return -1;
 
 	if (c == '\n') {
 		WAIT_UNTIL_UART_FREE(uart_base);


### PR DESCRIPTION
The assertion in console_putc() would trigger a recursion that
exhausts the stack and eventually aborts.

This patch replaces the assertion with an error return if the
console has not been initialized yet.

Fixes ARM-software/tf-issues#208

Change-Id: I95f736ff215d69655eb5ba7ceac70dc1409d986a
