### PR TITLE
Remove NSRAM from FVP memory map

### DIFF
--- a/plat/fvp/aarch64/fvp_common.c
+++ b/plat/fvp/aarch64/fvp_common.c
@@ -66,8 +66,6 @@ const mmap_region_t fvp_mmap[] = {
 						MT_MEMORY | MT_RW | MT_SECURE },
 	{ DEVICE0_BASE,	DEVICE0_BASE,	DEVICE0_SIZE,
 						MT_DEVICE | MT_RW | MT_SECURE },
-	{ NSRAM_BASE,	NSRAM_BASE,	NSRAM_SIZE,
-						MT_MEMORY | MT_RW | MT_NS },
 	{ DEVICE1_BASE,	DEVICE1_BASE,	DEVICE1_SIZE,
 						MT_DEVICE | MT_RW | MT_SECURE },
 	/* 2nd GB as device for now...*/

--- a/plat/fvp/include/platform_def.h
+++ b/plat/fvp/include/platform_def.h
@@ -145,7 +145,7 @@
  * Platform specific page table and MMU setup constants
  ******************************************************************************/
 #define ADDR_SPACE_SIZE			(1ull << 32)
-#define MAX_XLAT_TABLES			3
+#define MAX_XLAT_TABLES			2
 #define MAX_MMAP_REGIONS		16
 
 /*******************************************************************************


### PR DESCRIPTION
This memory is not used by the FVP port and requires an additional
4KB translation table.

This patch removes the entry from the memory map and reduces the
number of allocated translation tables.

Fixes ARM-software/tf-issues#196

Change-Id: I5b959e4fe92f5f892ed127c40dbe6c85eed3ed72
