### PR TITLE
Initialise CPU contexts from entry_point_info (v2)

### DIFF
--- a/bl1/aarch64/bl1_arch_setup.c
+++ b/bl1/aarch64/bl1_arch_setup.c
@@ -46,11 +46,10 @@ void bl1_arch_setup(void)
 	isb();
 
 	/*
-	 * Enable HVCs, route FIQs to EL3, set the next EL to be AArch64, route
-	 * external abort and SError interrupts to EL3
+	 * Set the next EL to be AArch64, route external abort and SError
+	 * interrupts to EL3
 	 */
-	tmp_reg = SCR_RES1_BITS | SCR_RW_BIT | SCR_HCE_BIT | SCR_EA_BIT |
-		  SCR_FIQ_BIT;
+	tmp_reg = SCR_RES1_BITS | SCR_RW_BIT | SCR_EA_BIT;
 	write_scr(tmp_reg);
 
 	/*

--- a/bl31/aarch64/context.S
+++ b/bl31/aarch64/context.S
@@ -43,9 +43,8 @@
 	.global el3_sysregs_context_save
 func el3_sysregs_context_save
 
-	mrs	x9, scr_el3
 	mrs	x10, sctlr_el3
-	stp	x9, x10, [x0, #CTX_SCR_EL3]
+	str	x10, [x0, #CTX_SCTLR_EL3]
 
 	mrs	x11, cptr_el3
 	stp	x11, xzr, [x0, #CTX_CPTR_EL3]
@@ -98,8 +97,7 @@ func el3_sysregs_context_restore
 	/* Make sure all the above changes are observed */
 	isb
 
-	ldp	x9, x10, [x0, #CTX_SCR_EL3]
-	msr	scr_el3, x9
+	ldr	x10, [x0, #CTX_SCTLR_EL3]
 	msr	sctlr_el3, x10
 	isb
 

--- a/bl31/bl31_main.c
+++ b/bl31/bl31_main.c
@@ -140,53 +140,18 @@ uint32_t bl31_get_next_image_type(void)
 void bl31_prepare_next_image_entry()
 {
 	entry_point_info_t *next_image_info;
-	uint32_t scr, image_type;
-	cpu_context_t *ctx;
-	gp_regs_t *gp_regs;
+	uint32_t image_type;
 
 	/* Determine which image to execute next */
 	image_type = bl31_get_next_image_type();
-
-	/*
-	 * Setup minimal architectural state of the next highest EL to
-	 * allow execution in it immediately upon entering it.
-	 */
-	bl31_next_el_arch_setup(image_type);
 
 	/* Program EL3 registers to enable entry into the next EL */
 	next_image_info = bl31_plat_get_next_image_ep_info(image_type);
 	assert(next_image_info);
 	assert(image_type == GET_SECURITY_STATE(next_image_info->h.attr));
 
-	scr = read_scr();
-	scr &= ~SCR_NS_BIT;
-	if (image_type == NON_SECURE)
-		scr |= SCR_NS_BIT;
-
-	scr &= ~SCR_RW_BIT;
-	if ((next_image_info->spsr & (1 << MODE_RW_SHIFT)) ==
-				(MODE_RW_64 << MODE_RW_SHIFT))
-		scr |= SCR_RW_BIT;
-
-	/*
-	 * Tell the context mgmt. library to ensure that SP_EL3 points to
-	 * the right context to exit from EL3 correctly.
-	 */
-	cm_set_el3_eret_context(image_type,
-			next_image_info->pc,
-			next_image_info->spsr,
-			scr);
-
-	/*
-	 * Save the args generated in BL2 for the image in the right context
-	 * used on its entry
-	 */
-	ctx = cm_get_context(image_type);
-	gp_regs = get_gpregs_ctx(ctx);
-	memcpy(gp_regs, (void *)&next_image_info->args, sizeof(aapcs64_params_t));
-
-	/* Finally set the next context */
-	cm_set_next_eret_context(image_type);
+	cm_init_context(read_mpidr_el1(), next_image_info);
+	cm_prepare_el3_exit(image_type);
 }
 
 /*******************************************************************************

--- a/include/bl31/context_mgmt.h
+++ b/include/bl31/context_mgmt.h
@@ -35,6 +35,11 @@
 #include <stdint.h>
 
 /*******************************************************************************
+ * Forward declarations
+ ******************************************************************************/
+struct entry_point_info;
+
+/*******************************************************************************
  * Function & variable prototypes
  ******************************************************************************/
 void cm_init(void);
@@ -45,12 +50,14 @@ void cm_set_context_by_mpidr(uint64_t mpidr,
 			     uint32_t security_state);
 static inline void cm_set_context(void *context, uint32_t security_state);
 void cm_el3_sysregs_context_save(uint32_t security_state);
+void cm_init_context(uint64_t mpidr, const struct entry_point_info *ep);
+void cm_prepare_el3_exit(uint32_t security_state);
 void cm_el3_sysregs_context_restore(uint32_t security_state);
 void cm_el1_sysregs_context_save(uint32_t security_state);
 void cm_el1_sysregs_context_restore(uint32_t security_state);
-void cm_set_el3_eret_context(uint32_t security_state, uint64_t entrypoint,
-			     uint32_t spsr, uint32_t scr);
 void cm_set_elr_el3(uint32_t security_state, uint64_t entrypoint);
+void cm_set_elr_spsr_el3(uint32_t security_state,
+			 uint64_t entrypoint, uint32_t spsr);
 void cm_write_scr_el3_bit(uint32_t security_state,
 			  uint32_t bit_pos,
 			  uint32_t value);

--- a/include/common/bl_common.h
+++ b/include/common/bl_common.h
@@ -33,7 +33,6 @@
 
 #define SECURE		0x0
 #define NON_SECURE	0x1
-#define PARAM_EP_SECURITY_MASK    0x1
 
 #define UP	1
 #define DOWN	0
@@ -64,9 +63,22 @@
 #define ENTRY_POINT_INFO_PC_OFFSET	0x08
 #define ENTRY_POINT_INFO_ARGS_OFFSET	0x18
 
+#define PARAM_EP_SECURITY_MASK    0x1
 #define GET_SECURITY_STATE(x) (x & PARAM_EP_SECURITY_MASK)
 #define SET_SECURITY_STATE(x, security) \
 			((x) = ((x) & ~PARAM_EP_SECURITY_MASK) | (security))
+
+#define EP_EE_MASK	0x2
+#define EP_EE_LITTLE	0x0
+#define EP_EE_BIG	0x2
+#define EP_GET_EE(x) (x & EP_EE_MASK)
+#define EP_SET_EE(x, ee) ((x) = ((x) & ~EP_EE_MASK) | (ee))
+
+#define EP_ST_MASK	0x4
+#define EP_ST_DISABLE	0x0
+#define EP_ST_ENABLE	0x4
+#define EP_GET_ST(x) (x & EP_ST_MASK)
+#define EP_SET_ST(x, ee) ((x) = ((x) & ~EP_ST_MASK) | (ee))
 
 #define PARAM_EP     0x01
 #define PARAM_IMAGE_BINARY  0x02

--- a/include/lib/aarch64/arch.h
+++ b/include/lib/aarch64/arch.h
@@ -167,6 +167,7 @@
 #define HCR_FMO_BIT		(1 << 3)
 
 /* CNTHCTL_EL2 definitions */
+#define EVNTEN_BIT		(1 << 2)
 #define EL1PCEN_BIT		(1 << 1)
 #define EL1PCTEN_BIT		(1 << 0)
 

--- a/include/lib/aarch64/arch_helpers.h
+++ b/include/lib/aarch64/arch_helpers.h
@@ -262,6 +262,9 @@ DEFINE_SYSREG_RW_FUNCS(cnthctl_el2)
 
 DEFINE_SYSREG_RW_FUNCS(tpidr_el3)
 
+DEFINE_SYSREG_RW_FUNCS(vpidr_el2)
+DEFINE_SYSREG_RW_FUNCS(vmpidr_el2)
+
 /* Implementation specific registers */
 
 DEFINE_RENAME_SYSREG_RW_FUNCS(cpuectlr_el1, CPUECTLR_EL1)

--- a/services/spd/tspd/tspd_main.c
+++ b/services/spd/tspd/tspd_main.c
@@ -122,13 +122,9 @@ static uint64_t tspd_sel1_interrupt_handler(uint32_t id,
 						     CTX_ELR_EL3);
 	}
 
-	SMC_SET_EL3(&tsp_ctx->cpu_ctx,
-		    CTX_SPSR_EL3,
-		    SPSR_64(MODE_EL1, MODE_SP_ELX, DISABLE_ALL_EXCEPTIONS));
-	SMC_SET_EL3(&tsp_ctx->cpu_ctx,
-		    CTX_ELR_EL3,
-		    (uint64_t) &tsp_vectors->fiq_entry);
 	cm_el1_sysregs_context_restore(SECURE);
+	cm_set_elr_spsr_el3(SECURE, (uint64_t) &tsp_vectors->fiq_entry,
+		    SPSR_64(MODE_EL1, MODE_SP_ELX, DISABLE_ALL_EXCEPTIONS));
 	cm_set_next_eret_context(SECURE);
 
 	/*

--- a/services/std_svc/psci/psci_afflvl_off.c
+++ b/services/std_svc/psci/psci_afflvl_off.c
@@ -42,8 +42,8 @@ typedef int (*afflvl_off_handler_t)(unsigned long, aff_map_node_t *);
  ******************************************************************************/
 static int psci_afflvl0_off(unsigned long mpidr, aff_map_node_t *cpu_node)
 {
-	unsigned int index, plat_state;
-	int rc = PSCI_E_SUCCESS;
+	unsigned int plat_state;
+	int rc;
 	unsigned long sctlr;
 
 	assert(cpu_node->level == MPIDR_AFFLVL0);
@@ -66,9 +66,6 @@ static int psci_afflvl0_off(unsigned long mpidr, aff_map_node_t *cpu_node)
 		if (rc)
 			return rc;
 	}
-
-	index = cpu_node->data;
-	memset(&psci_ns_entry_info[index], 0, sizeof(psci_ns_entry_info[index]));
 
 	/*
 	 * Arch. management. Perform the necessary steps to flush all
@@ -96,6 +93,7 @@ static int psci_afflvl0_off(unsigned long mpidr, aff_map_node_t *cpu_node)
 	 * Plat. management: Perform platform specific actions to turn this
 	 * cpu off e.g. exit cpu coherency, program the power controller etc.
 	 */
+	rc = PSCI_E_SUCCESS;
 	if (psci_plat_pm_ops->affinst_off) {
 
 		/* Get the current physical state of this cpu */

--- a/services/std_svc/psci/psci_common.c
+++ b/services/std_svc/psci/psci_common.c
@@ -36,6 +36,7 @@
 #include <context_mgmt.h>
 #include <debug.h>
 #include <platform.h>
+#include <string.h>
 #include "psci_private.h"
 
 /*
@@ -50,7 +51,6 @@ const spd_pm_ops_t *psci_spd_pm;
  * array during startup.
  ******************************************************************************/
 suspend_context_t psci_suspend_context[PSCI_NUM_AFFS];
-ns_entry_info_t psci_ns_entry_info[PSCI_NUM_AFFS];
 
 /*******************************************************************************
  * Grand array that holds the platform's topology information for state
@@ -212,97 +212,36 @@ int psci_validate_mpidr(unsigned long mpidr, int level)
 }
 
 /*******************************************************************************
- * This function retrieves all the stashed information needed to correctly
- * resume a cpu's execution in the non-secure state after it has been physically
- * powered on i.e. turned ON or resumed from SUSPEND
+ * This function determines the full entrypoint information for the requested
+ * PSCI entrypoint on power on/resume and saves this in the non-secure CPU
+ * cpu_context, ready for when the core boots.
  ******************************************************************************/
-void psci_get_ns_entry_info(unsigned int index)
+int psci_save_ns_entry(uint64_t mpidr,
+		       uint64_t entrypoint, uint64_t context_id,
+		       uint32_t ns_scr_el3, uint32_t ns_sctlr_el1)
 {
-	unsigned long sctlr = 0, scr, el_status, id_aa64pfr0;
-	cpu_context_t *ns_entry_context;
-	gp_regs_t *ns_entry_gpregs;
+	uint32_t ep_attr, mode, sctlr, daif, ee;
+	entry_point_info_t ep;
 
-	scr = read_scr();
+	sctlr = ns_scr_el3 & SCR_HCE_BIT ? read_sctlr_el2() : ns_sctlr_el1;
+	ee = 0;
 
-	/* Find out which EL we are going to */
-	id_aa64pfr0 = read_id_aa64pfr0_el1();
-	el_status = (id_aa64pfr0 >> ID_AA64PFR0_EL2_SHIFT) &
-		ID_AA64PFR0_ELX_MASK;
+	ep_attr = NON_SECURE | EP_ST_DISABLE;
+	if (sctlr & SCTLR_EE_BIT) {
+		ep_attr |= EP_EE_BIG;
+		ee = 1;
+	}
+	SET_PARAM_HEAD(&ep, PARAM_EP, VERSION_1, ep_attr);
 
-	/* Restore endianess */
-	if (psci_ns_entry_info[index].sctlr & SCTLR_EE_BIT)
-		sctlr |= SCTLR_EE_BIT;
-	else
-		sctlr &= ~SCTLR_EE_BIT;
-
-	/* Turn off MMU and Caching */
-	sctlr &= ~(SCTLR_M_BIT | SCTLR_C_BIT | SCTLR_M_BIT);
-
-	/* Set the register width */
-	if (psci_ns_entry_info[index].scr & SCR_RW_BIT)
-		scr |= SCR_RW_BIT;
-	else
-		scr &= ~SCR_RW_BIT;
-
-	scr |= SCR_NS_BIT;
-
-	if (el_status)
-		write_sctlr_el2(sctlr);
-	else
-		write_sctlr_el1(sctlr);
-
-	/* Fulfill the cpu_on entry reqs. as per the psci spec */
-	ns_entry_context = (cpu_context_t *) cm_get_context(NON_SECURE);
-	assert(ns_entry_context);
-
-	/*
-	 * Setup general purpose registers to return the context id and
-	 * prevent leakage of secure information into the normal world.
-	 */
-	ns_entry_gpregs = get_gpregs_ctx(ns_entry_context);
-	write_ctx_reg(ns_entry_gpregs,
-		      CTX_GPREG_X0,
-		      psci_ns_entry_info[index].context_id);
-
-	/*
-	 * Tell the context management library to setup EL3 system registers to
-	 * be able to ERET into the ns state, and SP_EL3 points to the right
-	 * context to exit from EL3 correctly.
-	 */
-	cm_set_el3_eret_context(NON_SECURE,
-			psci_ns_entry_info[index].eret_info.entrypoint,
-			psci_ns_entry_info[index].eret_info.spsr,
-			scr);
-
-	cm_set_next_eret_context(NON_SECURE);
-}
-
-/*******************************************************************************
- * This function retrieves and stashes all the information needed to correctly
- * resume a cpu's execution in the non-secure state after it has been physically
- * powered on i.e. turned ON or resumed from SUSPEND. This is done prior to
- * turning it on or before suspending it.
- ******************************************************************************/
-int psci_set_ns_entry_info(unsigned int index,
-			   unsigned long entrypoint,
-			   unsigned long context_id)
-{
-	int rc = PSCI_E_SUCCESS;
-	unsigned int rw, mode, ee, spsr = 0;
-	unsigned long id_aa64pfr0 = read_id_aa64pfr0_el1(), scr = read_scr();
-	unsigned long el_status;
-	unsigned long daif;
-
-	/* Figure out what mode do we enter the non-secure world in */
-	el_status = (id_aa64pfr0 >> ID_AA64PFR0_EL2_SHIFT) &
-		ID_AA64PFR0_ELX_MASK;
+	ep.pc = entrypoint;
+	memset(&ep.args, 0, sizeof(ep.args));
+	ep.args.arg0 = context_id;
 
 	/*
 	 * Figure out whether the cpu enters the non-secure address space
 	 * in aarch32 or aarch64
 	 */
-	rw = scr & SCR_RW_BIT;
-	if (rw) {
+	if (ns_scr_el3 & SCR_RW_BIT) {
 
 		/*
 		 * Check whether a Thumb entry point has been provided for an
@@ -311,28 +250,12 @@ int psci_set_ns_entry_info(unsigned int index,
 		if (entrypoint & 0x1)
 			return PSCI_E_INVALID_PARAMS;
 
-		if (el_status && (scr & SCR_HCE_BIT)) {
-			mode = MODE_EL2;
-			ee = read_sctlr_el2() & SCTLR_EE_BIT;
-		} else {
-			mode = MODE_EL1;
-			ee = read_sctlr_el1() & SCTLR_EE_BIT;
-		}
+		mode = ns_scr_el3 & SCR_HCE_BIT ? MODE_EL2 : MODE_EL1;
 
-		spsr = SPSR_64(mode, MODE_SP_ELX, DISABLE_ALL_EXCEPTIONS);
-
-		psci_ns_entry_info[index].sctlr |= ee;
-		psci_ns_entry_info[index].scr |= SCR_RW_BIT;
+		ep.spsr = SPSR_64(mode, MODE_SP_ELX, DISABLE_ALL_EXCEPTIONS);
 	} else {
 
-
-		if (el_status && (scr & SCR_HCE_BIT)) {
-			mode = MODE32_hyp;
-			ee = read_sctlr_el2() & SCTLR_EE_BIT;
-		} else {
-			mode = MODE32_svc;
-			ee = read_sctlr_el1() & SCTLR_EE_BIT;
-		}
+		mode = ns_scr_el3 & SCR_HCE_BIT ? MODE32_hyp : MODE32_svc;
 
 		/*
 		 * TODO: Choose async. exception bits if HYP mode is not
@@ -340,18 +263,13 @@ int psci_set_ns_entry_info(unsigned int index,
 		 */
 		daif = DAIF_ABT_BIT | DAIF_IRQ_BIT | DAIF_FIQ_BIT;
 
-		spsr = SPSR_MODE32(mode, entrypoint & 0x1, ee, daif);
-
-		/* Ensure that the CSPR.E and SCTLR.EE bits match */
-		psci_ns_entry_info[index].sctlr |= ee;
-		psci_ns_entry_info[index].scr &= ~SCR_RW_BIT;
+		ep.spsr = SPSR_MODE32(mode, entrypoint & 0x1, ee, daif);
 	}
 
-	psci_ns_entry_info[index].eret_info.entrypoint = entrypoint;
-	psci_ns_entry_info[index].eret_info.spsr = spsr;
-	psci_ns_entry_info[index].context_id = context_id;
+	/* initialise an entrypoint to set up the CPU context */
+	cm_init_context(mpidr, &ep);
 
-	return rc;
+	return PSCI_E_SUCCESS;
 }
 
 /*******************************************************************************

--- a/services/std_svc/psci/psci_private.h
+++ b/services/std_svc/psci/psci_private.h
@@ -36,22 +36,6 @@
 #include <psci.h>
 
 /*******************************************************************************
- * The following two data structures hold the generic information to bringup
- * a suspended/hotplugged out cpu
- ******************************************************************************/
-typedef struct eret_params {
-	unsigned long entrypoint;
-	unsigned long spsr;
-} eret_params_t;
-
-typedef struct ns_entry_info {
-	eret_params_t eret_info;
-	unsigned long context_id;
-	unsigned int scr;
-	unsigned int sctlr;
-} ns_entry_info_t;
-
-/*******************************************************************************
  * The following two data structures hold the topology tree which in turn tracks
  * the state of the all the affinity instances supported by the platform.
  ******************************************************************************/
@@ -85,7 +69,6 @@ typedef unsigned int (*afflvl_power_on_finisher_t)(unsigned long,
  * Data prototypes
  ******************************************************************************/
 extern suspend_context_t psci_suspend_context[PSCI_NUM_AFFS];
-extern ns_entry_info_t psci_ns_entry_info[PSCI_NUM_AFFS];
 extern const plat_pm_ops_t *psci_plat_pm_ops;
 extern aff_map_node_t psci_aff_map[PSCI_NUM_AFFS];
 
@@ -102,7 +85,6 @@ int get_max_afflvl(void);
 unsigned short psci_get_state(aff_map_node_t *node);
 unsigned short psci_get_phys_state(aff_map_node_t *node);
 void psci_set_state(aff_map_node_t *node, unsigned short state);
-void psci_get_ns_entry_info(unsigned int index);
 unsigned long mpidr_set_aff_inst(unsigned long, unsigned char, int);
 int psci_validate_mpidr(unsigned long, int);
 int get_power_on_target_afflvl(unsigned long mpidr);
@@ -110,9 +92,9 @@ void psci_afflvl_power_on_finish(unsigned long,
 				int,
 				int,
 				afflvl_power_on_finisher_t *);
-int psci_set_ns_entry_info(unsigned int index,
-				unsigned long entrypoint,
-				unsigned long context_id);
+int psci_save_ns_entry(uint64_t mpidr,
+		       uint64_t entrypoint, uint64_t context_id,
+		       uint32_t caller_scr_el3, uint32_t caller_sctlr_el1);
 int psci_check_afflvl_range(int start_afflvl, int end_afflvl);
 void psci_acquire_afflvl_locks(unsigned long mpidr,
 				int start_afflvl,

--- a/services/std_svc/psci/psci_setup.c
+++ b/services/std_svc/psci/psci_setup.c
@@ -59,7 +59,7 @@ static aff_limits_node_t psci_aff_limits[MPIDR_MAX_AFFLVL + 1];
 
 /*******************************************************************************
  * 'psci_ns_einfo_idx' keeps track of the next free index in the
- * 'psci_ns_entry_info' & 'psci_suspend_context' arrays.
+ * 'psci_suspend_context' arrays.
  ******************************************************************************/
 static unsigned int psci_ns_einfo_idx;
 


### PR DESCRIPTION
This rebases #139

Consolidate all BL3-1 CPU context initialization for cold boot, PSCI
and SPDs into two functions:
-  The first uses entry_point_info to initialize the relevant
  cpu_context for first entry into a lower exception level on a CPU
-  The second populates the EL1 and EL2 system registers as needed
  from the cpu_context to ensure correct entry into the lower EL

This patch alters the way that BL3-1 determines which exception level
is used when first entering EL1 or EL2 during cold boot - this is now
fully determined by the SPSR value in the entry_point_info for BL3-3,
as set up by the platform code in BL2 (or otherwise provided to BL3-1).

In the situation that EL1 (or svc mode) is selected for a processor
that supports EL2, the context management code will now configure all
essential EL2 register state to ensure correct execution of EL1. This
allows the platform code to run non-secure EL1 payloads directly
without requiring a small EL2 stub or OS loader.

Change-Id: If9fbb2417e82d2226e47568203d5a369f39d3b0f
