### PR TITLE
Remove calling CPU mpidr from bakery lock API

### DIFF
--- a/include/lib/bakery_lock.h
+++ b/include/lib/bakery_lock.h
@@ -44,8 +44,8 @@ typedef struct bakery_lock {
 #define NO_OWNER (-1)
 
 void bakery_lock_init(bakery_lock_t *bakery);
-void bakery_lock_get(unsigned long mpidr, bakery_lock_t *bakery);
-void bakery_lock_release(unsigned long mpidr, bakery_lock_t *bakery);
-int bakery_lock_try(unsigned long mpidr, bakery_lock_t *bakery);
+void bakery_lock_get(bakery_lock_t *bakery);
+void bakery_lock_release(bakery_lock_t *bakery);
+int bakery_lock_try(bakery_lock_t *bakery);
 
 #endif /* __BAKERY_LOCK_H__ */

--- a/lib/locks/bakery/bakery_lock.c
+++ b/lib/locks/bakery/bakery_lock.c
@@ -124,12 +124,12 @@ static unsigned int bakery_get_ticket(bakery_lock_t *bakery, unsigned int me)
  * of others'. The CPU with the highest priority (lowest numerical value)
  * acquires the lock
  */
-void bakery_lock_get(unsigned long mpidr, bakery_lock_t *bakery)
+void bakery_lock_get(bakery_lock_t *bakery)
 {
 	unsigned int they, me;
 	unsigned int my_ticket, my_prio, their_ticket;
 
-	me = platform_get_core_pos(mpidr);
+	me = platform_get_core_pos(read_mpidr_el1());
 
 	assert_bakery_entry_valid(me, bakery);
 
@@ -176,9 +176,9 @@ void bakery_lock_get(unsigned long mpidr, bakery_lock_t *bakery)
 
 
 /* Release the lock and signal contenders */
-void bakery_lock_release(unsigned long mpidr, bakery_lock_t *bakery)
+void bakery_lock_release(bakery_lock_t *bakery)
 {
-	unsigned int me = platform_get_core_pos(mpidr);
+	unsigned int me = platform_get_core_pos(read_mpidr_el1());
 
 	assert_bakery_entry_valid(me, bakery);
 	assert(bakery->owner == me);

--- a/plat/fvp/drivers/pwrc/fvp_pwrc.c
+++ b/plat/fvp/drivers/pwrc/fvp_pwrc.c
@@ -41,59 +41,54 @@ static bakery_lock_t pwrc_lock __attribute__ ((section("tzfw_coherent_mem")));
 
 unsigned int fvp_pwrc_get_cpu_wkr(unsigned long mpidr)
 {
-	unsigned int rc = 0;
-	bakery_lock_get(mpidr, &pwrc_lock);
-	mmio_write_32(PWRC_BASE + PSYSR_OFF, (unsigned int) mpidr);
-	rc = PSYSR_WK(mmio_read_32(PWRC_BASE + PSYSR_OFF));
-	bakery_lock_release(mpidr, &pwrc_lock);
-	return rc;
+	return PSYSR_WK(fvp_pwrc_read_psysr(mpidr));
 }
 
 unsigned int fvp_pwrc_read_psysr(unsigned long mpidr)
 {
-	unsigned int rc = 0;
-	bakery_lock_get(mpidr, &pwrc_lock);
+	unsigned int rc;
+	bakery_lock_get(&pwrc_lock);
 	mmio_write_32(PWRC_BASE + PSYSR_OFF, (unsigned int) mpidr);
 	rc = mmio_read_32(PWRC_BASE + PSYSR_OFF);
-	bakery_lock_release(mpidr, &pwrc_lock);
+	bakery_lock_release(&pwrc_lock);
 	return rc;
 }
 
 void fvp_pwrc_write_pponr(unsigned long mpidr)
 {
-	bakery_lock_get(mpidr, &pwrc_lock);
+	bakery_lock_get(&pwrc_lock);
 	mmio_write_32(PWRC_BASE + PPONR_OFF, (unsigned int) mpidr);
-	bakery_lock_release(mpidr, &pwrc_lock);
+	bakery_lock_release(&pwrc_lock);
 }
 
 void fvp_pwrc_write_ppoffr(unsigned long mpidr)
 {
-	bakery_lock_get(mpidr, &pwrc_lock);
+	bakery_lock_get(&pwrc_lock);
 	mmio_write_32(PWRC_BASE + PPOFFR_OFF, (unsigned int) mpidr);
-	bakery_lock_release(mpidr, &pwrc_lock);
+	bakery_lock_release(&pwrc_lock);
 }
 
 void fvp_pwrc_set_wen(unsigned long mpidr)
 {
-	bakery_lock_get(mpidr, &pwrc_lock);
+	bakery_lock_get(&pwrc_lock);
 	mmio_write_32(PWRC_BASE + PWKUPR_OFF,
 		      (unsigned int) (PWKUPR_WEN | mpidr));
-	bakery_lock_release(mpidr, &pwrc_lock);
+	bakery_lock_release(&pwrc_lock);
 }
 
 void fvp_pwrc_clr_wen(unsigned long mpidr)
 {
-	bakery_lock_get(mpidr, &pwrc_lock);
+	bakery_lock_get(&pwrc_lock);
 	mmio_write_32(PWRC_BASE + PWKUPR_OFF,
 		      (unsigned int) mpidr);
-	bakery_lock_release(mpidr, &pwrc_lock);
+	bakery_lock_release(&pwrc_lock);
 }
 
 void fvp_pwrc_write_pcoffr(unsigned long mpidr)
 {
-	bakery_lock_get(mpidr, &pwrc_lock);
+	bakery_lock_get(&pwrc_lock);
 	mmio_write_32(PWRC_BASE + PCOFFR_OFF, (unsigned int) mpidr);
-	bakery_lock_release(mpidr, &pwrc_lock);
+	bakery_lock_release(&pwrc_lock);
 }
 
 /* Nothing else to do here apart from initializing the lock */

--- a/services/std_svc/psci/psci_common.c
+++ b/services/std_svc/psci/psci_common.c
@@ -173,7 +173,7 @@ void psci_acquire_afflvl_locks(unsigned long mpidr,
 	for (level = start_afflvl; level <= end_afflvl; level++) {
 		if (mpidr_nodes[level] == NULL)
 			continue;
-		bakery_lock_get(mpidr, &mpidr_nodes[level]->lock);
+		bakery_lock_get(&mpidr_nodes[level]->lock);
 	}
 }
 
@@ -192,7 +192,7 @@ void psci_release_afflvl_locks(unsigned long mpidr,
 	for (level = end_afflvl; level >= start_afflvl; level--) {
 		if (mpidr_nodes[level] == NULL)
 			continue;
-		bakery_lock_release(mpidr, &mpidr_nodes[level]->lock);
+		bakery_lock_release(&mpidr_nodes[level]->lock);
 	}
 }
 


### PR DESCRIPTION
The bakery lock code currently expects the calling code to pass
the MPIDR_EL1 of the current CPU.

This is not always done correctly. Also the change to provide
inline access to system registers makes it more efficient for the
bakery lock code to obtain the MPIDR_EL1 directly.

This change removes the mpidr parameter from the bakery lock
interface, and results in a code reduction of 160 bytes for the
ARM FVP port.

Fixes ARM-software/tf-issues#213

Change-Id: I7ec7bd117bcc9794a0d948990fcf3336a367d543
