### PR TITLE
Compile with '-Wmissing-include-dirs' flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,9 +148,7 @@ endif
 .PHONY:			all msg_start clean realclean distclean cscope locate-checkpatch checkcodebase checkpatch fiptool fip
 .SUFFIXES:
 
-INCLUDES		+=	-Iinclude/bl1			\
-				-Iinclude/bl2			\
-				-Iinclude/bl31			\
+INCLUDES		+=	-Iinclude/bl31			\
 				-Iinclude/bl31/services		\
 				-Iinclude/bl32			\
 				-Iinclude/bl32/payloads		\
@@ -184,10 +182,12 @@ $(eval $(call assert_boolean,RESET_TO_BL31))
 $(eval $(call add_define,RESET_TO_BL31))
 
 ASFLAGS			+= 	-nostdinc -ffreestanding -Wa,--fatal-warnings	\
+				-Werror -Wmissing-include-dirs			\
 				-mgeneral-regs-only -D__ASSEMBLY__		\
 				${DEFINES} ${INCLUDES}
 CFLAGS			+= 	-nostdinc -pedantic -ffreestanding -Wall	\
-				-Werror -mgeneral-regs-only -std=c99 -c -Os	\
+				-Werror -Wmissing-include-dirs			\
+				-mgeneral-regs-only -std=c99 -c -Os		\
 				${DEFINES} ${INCLUDES}
 CFLAGS			+=	-ffunction-sections -fdata-sections
 


### PR DESCRIPTION
Add the '-Wmissing-include-dirs' flag to the CFLAGS and ASFLAGS
to make the build fail if the compiler or the assembler is given
a nonexistant directory in the list of directories to be searched
for header files.

Also remove 'include/bl1' and 'include/bl2' directories from the
search path for header files as they don't exist anymore.
