### PR TITLE
fvp: Fix register name in 'plat_print_gic_regs' macro

### DIFF
--- a/plat/fvp/include/plat_macros.S
+++ b/plat/fvp/include/plat_macros.S
@@ -47,7 +47,7 @@ gic_regs: .asciz "gic_iar", "gic_ctlr", ""
 	bl	fvp_get_cfgvar
 	/* gic base address is now in x0 */
 	ldr	w1, [x0, #GICC_IAR]
-	ldr	w2, [x0, #GICD_CTLR]
+	ldr	w2, [x0, #GICC_CTLR]
 	sub	sp, sp, #GIC_REG_SIZE
 	stp	x1, x2, [sp] /* we store the gic registers as 64 bit */
 	adr	x0, gic_regs


### PR DESCRIPTION
The 'plat_print_gic_regs' macro was accessing the GICC_CTLR register
using the GICD_CTLR offset. This still generates the right code in
the end because GICD_CTLR == GICC_CTLR but this patch fixes it for
the logic of the code.
