### PR TITLE
Simplify entry point information generation code on FVP

### DIFF
--- a/bl1/aarch64/bl1_entrypoint.S
+++ b/bl1/aarch64/bl1_entrypoint.S
@@ -98,13 +98,9 @@ func bl1_entrypoint
 	bic	w0, w0, #TFP_BIT
 	msr	cptr_el3, x0
 
-	/* ---------------------------------------------
-	 * Find the type of reset and jump to handler
-	 * if present. If the handler is null then it is
-	 * a cold boot. The primary cpu will set up the
-	 * platform while the secondaries wait for
-	 * their turn to be woken up
-	 * ---------------------------------------------
+	/* -------------------------------------------------------
+	 * Will not return from this macro if it is a warm boot.
+	 * -------------------------------------------------------
 	 */
 	wait_for_entrypoint
 

--- a/bl31/aarch64/bl31_entrypoint.S
+++ b/bl31/aarch64/bl31_entrypoint.S
@@ -102,6 +102,10 @@ func bl31_entrypoint
 	msr	cptr_el3, x1
 
 #if RESET_TO_BL31
+	/* -------------------------------------------------------
+	 * Will not return from this macro if it is a warm boot.
+	 * -------------------------------------------------------
+	 */
 	wait_for_entrypoint
 	bl	platform_mem_init
 #else

--- a/plat/fvp/aarch64/fvp_common.c
+++ b/plat/fvp/aarch64/fvp_common.c
@@ -224,25 +224,25 @@ void fvp_cci_setup(void)
 
 
 /*******************************************************************************
- * Set SPSR and secure state for BL32 image
+ * Gets SPSR for BL32 entry
  ******************************************************************************/
-void fvp_set_bl32_ep_info(entry_point_info_t *bl32_ep_info)
+uint32_t fvp_get_spsr_for_bl32_entry(void)
 {
-	SET_SECURITY_STATE(bl32_ep_info->h.attr, SECURE);
 	/*
 	 * The Secure Payload Dispatcher service is responsible for
 	 * setting the SPSR prior to entry into the BL32 image.
 	 */
-	bl32_ep_info->spsr = 0;
+	return 0;
 }
 
 /*******************************************************************************
- * Set SPSR and secure state for BL33 image
+ * Gets SPSR for BL33 entry
  ******************************************************************************/
-void fvp_set_bl33_ep_info(entry_point_info_t *bl33_ep_info)
+uint32_t fvp_get_spsr_for_bl33_entry(void)
 {
 	unsigned long el_status;
 	unsigned int mode;
+	uint32_t spsr;
 
 	/* Figure out what mode we enter the non-secure world in */
 	el_status = read_id_aa64pfr0_el1() >> ID_AA64PFR0_EL2_SHIFT;
@@ -258,6 +258,6 @@ void fvp_set_bl33_ep_info(entry_point_info_t *bl33_ep_info)
 	 * the FIP ToC and allowing the platform to have a say as
 	 * well.
 	 */
-	bl33_ep_info->spsr = SPSR_64(mode, MODE_SP_ELX, DISABLE_ALL_EXCEPTIONS);
-	SET_SECURITY_STATE(bl33_ep_info->h.attr, NON_SECURE);
+	spsr = SPSR_64(mode, MODE_SP_ELX, DISABLE_ALL_EXCEPTIONS);
+	return spsr;
 }

--- a/plat/fvp/bl2_fvp_setup.c
+++ b/plat/fvp/bl2_fvp_setup.c
@@ -246,7 +246,8 @@ void bl2_plat_set_bl31_ep_info(image_info_t *bl31_image_info,
 void bl2_plat_set_bl32_ep_info(image_info_t *bl32_image_info,
 					entry_point_info_t *bl32_ep_info)
 {
-	fvp_set_bl32_ep_info(bl32_ep_info);
+	SET_SECURITY_STATE(bl32_ep_info->h.attr, SECURE);
+	bl32_ep_info->spsr = fvp_get_spsr_for_bl32_entry();
 }
 
 /*******************************************************************************
@@ -258,7 +259,8 @@ void bl2_plat_set_bl32_ep_info(image_info_t *bl32_image_info,
 void bl2_plat_set_bl33_ep_info(image_info_t *image,
 					entry_point_info_t *bl33_ep_info)
 {
-	fvp_set_bl33_ep_info(bl33_ep_info);
+	SET_SECURITY_STATE(bl33_ep_info->h.attr, NON_SECURE);
+	bl33_ep_info->spsr = fvp_get_spsr_for_bl33_entry();
 }
 
 

--- a/plat/fvp/bl31_fvp_setup.c
+++ b/plat/fvp/bl31_fvp_setup.c
@@ -72,8 +72,7 @@ extern unsigned long __COHERENT_RAM_END__;
 
 
 #if RESET_TO_BL31
-static entry_point_info_t  bl32_entrypoint_info;
-static entry_point_info_t  bl33_entrypoint_info;
+static entry_point_info_t  next_image_ep_info;
 #else
 /*******************************************************************************
  * Reference to structure which holds the arguments that have been passed to
@@ -90,30 +89,42 @@ static bl31_params_t *bl2_to_bl31_params;
  ******************************************************************************/
 entry_point_info_t *bl31_plat_get_next_image_ep_info(uint32_t type)
 {
-	entry_point_info_t *next_image_info;
-
 #if RESET_TO_BL31
 
-	if (type == NON_SECURE)
-		fvp_get_entry_point_info(NON_SECURE, &bl33_entrypoint_info);
-	else
-		fvp_get_entry_point_info(SECURE, &bl32_entrypoint_info);
+	assert(type <= NON_SECURE);
+	SET_PARAM_HEAD(&next_image_ep_info,
+				PARAM_EP,
+				VERSION_1,
+				0);
 
-	next_image_info = (type == NON_SECURE) ?
-		&bl33_entrypoint_info :
-		&bl32_entrypoint_info;
+	SET_SECURITY_STATE(next_image_ep_info.h.attr, type);
+
+	if (type == NON_SECURE) {
+		/*
+		 * Tell BL31 where the non-trusted software image
+		 * is located and the entry state information
+		 */
+		next_image_ep_info.pc = plat_get_ns_image_entrypoint();
+		next_image_ep_info.spsr = fvp_get_spsr_for_bl33_entry();
+	} else {
+		next_image_ep_info.pc = BL32_BASE;
+		next_image_ep_info.spsr = fvp_get_spsr_for_bl32_entry();
+	}
+
+	return &next_image_ep_info;
 #else
+	entry_point_info_t *next_image_info;
+
 	next_image_info = (type == NON_SECURE) ?
 		bl2_to_bl31_params->bl33_ep_info :
 		bl2_to_bl31_params->bl32_ep_info;
-#endif
-
 
 	/* None of the images on this platform can have 0x0 as the entrypoint */
 	if (next_image_info->pc)
 		return next_image_info;
 	else
 		return NULL;
+#endif
 }
 
 /*******************************************************************************
@@ -220,38 +231,3 @@ void bl31_plat_arch_setup()
 			      BL31_COHERENT_RAM_BASE,
 			      BL31_COHERENT_RAM_LIMIT);
 }
-
-#if RESET_TO_BL31
-/*******************************************************************************
- * Generate the entry point info for Non Secure and Secure images
- * for transferring control from BL31
- ******************************************************************************/
-void fvp_get_entry_point_info(unsigned long target_security,
-					entry_point_info_t *target_entry_info)
-{
-	if (target_security == NON_SECURE) {
-		SET_PARAM_HEAD(target_entry_info,
-					PARAM_EP,
-					VERSION_1,
-					0);
-		/*
-		 * Tell BL31 where the non-trusted software image
-		 * is located and the entry state information
-		 */
-		target_entry_info->pc =  plat_get_ns_image_entrypoint();
-
-		fvp_set_bl33_ep_info(target_entry_info);
-
-	} else {
-		SET_PARAM_HEAD(target_entry_info,
-				PARAM_EP,
-				VERSION_1,
-				0);
-		if (BL32_BASE != 0) {
-			/* Hard coding entry point to the base of the BL32 */
-			target_entry_info->pc = BL32_BASE;
-			fvp_set_bl32_ep_info(target_entry_info);
-		}
-	}
-}
-#endif

--- a/plat/fvp/fvp_private.h
+++ b/plat/fvp/fvp_private.h
@@ -78,10 +78,6 @@ void fvp_configure_mmu_el3(unsigned long total_base,
 unsigned long fvp_get_cfgvar(unsigned int);
 int fvp_config_setup(void);
 
-#if RESET_TO_BL31
-void fvp_get_entry_point_info(unsigned long target_security,
-				struct entry_point_info *target_entry_info);
-#endif
 void fvp_cci_setup(void);
 
 /* Declarations for fvp_gic.c */
@@ -99,11 +95,11 @@ void fvp_io_setup(void);
 /* Declarations for fvp_security.c */
 void fvp_security_setup(void);
 
-/* Sets the entrypoint for BL32 */
-void fvp_set_bl32_ep_info(struct entry_point_info *bl32_ep);
+/* Gets the SPR for BL32 entry */
+uint32_t fvp_get_spsr_for_bl32_entry(void);
 
-/* Sets the entrypoint for BL33 */
-void fvp_set_bl33_ep_info(struct entry_point_info *bl33_ep);
+/* Gets the SPSR for BL33 entry */
+uint32_t fvp_get_spsr_for_bl33_entry(void);
 
 
 #endif /* __FVP_PRIVATE_H__ */

--- a/plat/fvp/platform.mk
+++ b/plat/fvp/platform.mk
@@ -69,22 +69,19 @@ BL2_SOURCES		+=	drivers/arm/tzc400/tzc400.c			\
 				plat/fvp/fvp_security.c				\
 				plat/fvp/aarch64/fvp_common.c
 
-BL31_SOURCES		+=	drivers/arm/gic/gic_v2.c			\
+BL31_SOURCES		+=	drivers/arm/cci400/cci400.c			\
+				drivers/arm/gic/gic_v2.c			\
 				drivers/arm/gic/gic_v3.c			\
-				drivers/arm/cci400/cci400.c			\
+				drivers/arm/tzc400/tzc400.c			\
 				plat/common/aarch64/platform_mp_stack.S		\
 				plat/fvp/bl31_fvp_setup.c			\
 				plat/fvp/fvp_gic.c				\
 				plat/fvp/fvp_pm.c				\
+				plat/fvp/fvp_security.c				\
 				plat/fvp/fvp_topology.c				\
 				plat/fvp/aarch64/fvp_helpers.S			\
 				plat/fvp/aarch64/fvp_common.c			\
 				plat/fvp/drivers/pwrc/fvp_pwrc.c
-
-ifeq (${RESET_TO_BL31}, 1)
-BL31_SOURCES		+=	drivers/arm/tzc400/tzc400.c			\
-				plat/fvp/fvp_security.c
-endif
 
 # Flag used by the FVP port to determine the version of ARM GIC architecture
 # to use for interrupt management in EL3.


### PR DESCRIPTION
This patch reworks FVP specific code responsible for determining
the entry point information for BL3-2 and BL3-3 stages when BL3-1
is configured as the reset handler.

Change-Id: Ia661ff0a6a44c7aabb0b6c1684b2e8d3642d11ec
