### PR TITLE
Remove current CPU mpidr from PSCI common code

### DIFF
--- a/services/std_svc/psci/psci_afflvl_on.c
+++ b/services/std_svc/psci/psci_afflvl_on.c
@@ -285,7 +285,6 @@ int psci_afflvl_on(unsigned long target_cpu,
 {
 	int rc = PSCI_E_SUCCESS;
 	mpidr_aff_map_nodes_t target_cpu_nodes;
-	unsigned long mpidr = read_mpidr() & MPIDR_AFFINITY_MASK;
 
 	/*
 	 * Collect the pointers to the nodes in the topology tree for
@@ -306,8 +305,7 @@ int psci_afflvl_on(unsigned long target_cpu,
 	 * level so that by the time all locks are taken, the system topology
 	 * is snapshot and state management can be done safely.
 	 */
-	psci_acquire_afflvl_locks(mpidr,
-				  start_afflvl,
+	psci_acquire_afflvl_locks(start_afflvl,
 				  end_afflvl,
 				  target_cpu_nodes);
 
@@ -323,8 +321,7 @@ int psci_afflvl_on(unsigned long target_cpu,
 	 * This loop releases the lock corresponding to each affinity level
 	 * in the reverse order to which they were acquired.
 	 */
-	psci_release_afflvl_locks(mpidr,
-				  start_afflvl,
+	psci_release_afflvl_locks(start_afflvl,
 				  end_afflvl,
 				  target_cpu_nodes);
 
@@ -335,8 +332,7 @@ int psci_afflvl_on(unsigned long target_cpu,
  * The following functions finish an earlier affinity power on request. They
  * are called by the common finisher routine in psci_common.c.
  ******************************************************************************/
-static unsigned int psci_afflvl0_on_finish(unsigned long mpidr,
-					   aff_map_node_t *cpu_node)
+static unsigned int psci_afflvl0_on_finish(aff_map_node_t *cpu_node)
 {
 	unsigned int plat_state, state, rc;
 
@@ -356,7 +352,7 @@ static unsigned int psci_afflvl0_on_finish(unsigned long mpidr,
 
 		/* Get the physical state of this cpu */
 		plat_state = get_phys_state(state);
-		rc = psci_plat_pm_ops->affinst_on_finish(mpidr,
+		rc = psci_plat_pm_ops->affinst_on_finish(read_mpidr_el1(),
 							 cpu_node->level,
 							 plat_state);
 		assert(rc == PSCI_E_SUCCESS);
@@ -399,8 +395,7 @@ static unsigned int psci_afflvl0_on_finish(unsigned long mpidr,
 	return rc;
 }
 
-static unsigned int psci_afflvl1_on_finish(unsigned long mpidr,
-					   aff_map_node_t *cluster_node)
+static unsigned int psci_afflvl1_on_finish(aff_map_node_t *cluster_node)
 {
 	unsigned int plat_state, rc = PSCI_E_SUCCESS;
 
@@ -418,7 +413,7 @@ static unsigned int psci_afflvl1_on_finish(unsigned long mpidr,
 
 		/* Get the physical state of this cluster */
 		plat_state = psci_get_phys_state(cluster_node);
-		rc = psci_plat_pm_ops->affinst_on_finish(mpidr,
+		rc = psci_plat_pm_ops->affinst_on_finish(read_mpidr_el1(),
 							 cluster_node->level,
 							 plat_state);
 		assert(rc == PSCI_E_SUCCESS);
@@ -431,8 +426,7 @@ static unsigned int psci_afflvl1_on_finish(unsigned long mpidr,
 }
 
 
-static unsigned int psci_afflvl2_on_finish(unsigned long mpidr,
-					   aff_map_node_t *system_node)
+static unsigned int psci_afflvl2_on_finish(aff_map_node_t *system_node)
 {
 	unsigned int plat_state, rc = PSCI_E_SUCCESS;
 
@@ -456,7 +450,7 @@ static unsigned int psci_afflvl2_on_finish(unsigned long mpidr,
 
 		/* Get the physical state of the system */
 		plat_state = psci_get_phys_state(system_node);
-		rc = psci_plat_pm_ops->affinst_on_finish(mpidr,
+		rc = psci_plat_pm_ops->affinst_on_finish(read_mpidr_el1(),
 							 system_node->level,
 							 plat_state);
 		assert(rc == PSCI_E_SUCCESS);

--- a/services/std_svc/psci/psci_entry.S
+++ b/services/std_svc/psci/psci_entry.S
@@ -58,8 +58,6 @@ psci_aff_suspend_finish_entry:
 	adr	x23, psci_afflvl_suspend_finishers
 
 psci_aff_common_finish_entry:
-	adr	x22, psci_afflvl_power_on_finish
-
 	/* ---------------------------------------------
 	 * Initialise the pcpu cache pointer for the CPU
 	 * ---------------------------------------------
@@ -92,11 +90,10 @@ psci_aff_common_finish_entry:
 	bl	get_power_on_target_afflvl
 	cmp	x0, xzr
 	b.lt	_panic
-	mov	x3, x23
-	mov	x2, x0
-	mov	x1, #MPIDR_AFFLVL0
-	mrs	x0, mpidr_el1
-	blr	x22
+	mov	x2, x23
+	mov	x1, x0
+	mov	x0, #MPIDR_AFFLVL0
+	bl	psci_afflvl_power_on_finish
 
 	/* --------------------------------------------
 	 * Give ourselves a stack allocated in Normal

--- a/services/std_svc/psci/psci_main.c
+++ b/services/std_svc/psci/psci_main.c
@@ -78,7 +78,6 @@ int psci_cpu_suspend(unsigned int power_state,
 		     unsigned long context_id)
 {
 	int rc;
-	unsigned long mpidr;
 	unsigned int target_afflvl, pstate_type;
 
 	/* Check SBZ bits in power state are zero */
@@ -111,9 +110,7 @@ int psci_cpu_suspend(unsigned int power_state,
 	 * enter the final wfi which will power down this cpu else return
 	 * an error.
 	 */
-	mpidr = read_mpidr();
-	rc = psci_afflvl_suspend(mpidr,
-				 entrypoint,
+	rc = psci_afflvl_suspend(entrypoint,
 				 context_id,
 				 power_state,
 				 MPIDR_AFFLVL0,
@@ -127,10 +124,7 @@ int psci_cpu_suspend(unsigned int power_state,
 int psci_cpu_off(void)
 {
 	int rc;
-	unsigned long mpidr;
 	int target_afflvl = get_max_afflvl();
-
-	mpidr = read_mpidr();
 
 	/*
 	 * Traverse from the highest to the lowest affinity level. When the
@@ -138,7 +132,7 @@ int psci_cpu_off(void)
 	 * management is done immediately followed by cpu, cluster ...
 	 * ..target_afflvl specific actions as this function unwinds back.
 	 */
-	rc = psci_afflvl_off(mpidr, MPIDR_AFFLVL0, target_afflvl);
+	rc = psci_afflvl_off(MPIDR_AFFLVL0, target_afflvl);
 
 	/*
 	 * Check if all actions needed to safely power down this cpu have

--- a/services/std_svc/psci/psci_private.h
+++ b/services/std_svc/psci/psci_private.h
@@ -62,8 +62,7 @@ typedef struct aff_limits_node {
 } aff_limits_node_t;
 
 typedef aff_map_node_t (*mpidr_aff_map_nodes_t[MPIDR_MAX_AFFLVL]);
-typedef unsigned int (*afflvl_power_on_finisher_t)(unsigned long,
-						 aff_map_node_t *);
+typedef unsigned int (*afflvl_power_on_finisher_t)(aff_map_node_t *);
 
 /*******************************************************************************
  * Data prototypes
@@ -87,20 +86,17 @@ void psci_set_state(aff_map_node_t *node, unsigned short state);
 unsigned long mpidr_set_aff_inst(unsigned long, unsigned char, int);
 int psci_validate_mpidr(unsigned long, int);
 int get_power_on_target_afflvl(unsigned long mpidr);
-void psci_afflvl_power_on_finish(unsigned long,
-				int,
+void psci_afflvl_power_on_finish(int,
 				int,
 				afflvl_power_on_finisher_t *);
 int psci_save_ns_entry(uint64_t mpidr,
 		       uint64_t entrypoint, uint64_t context_id,
 		       uint32_t caller_scr_el3, uint32_t caller_sctlr_el1);
 int psci_check_afflvl_range(int start_afflvl, int end_afflvl);
-void psci_acquire_afflvl_locks(unsigned long mpidr,
-				int start_afflvl,
+void psci_acquire_afflvl_locks(int start_afflvl,
 				int end_afflvl,
 				mpidr_aff_map_nodes_t mpidr_nodes);
-void psci_release_afflvl_locks(unsigned long mpidr,
-				int start_afflvl,
+void psci_release_afflvl_locks(int start_afflvl,
 				int end_afflvl,
 				mpidr_aff_map_nodes_t mpidr_nodes);
 
@@ -119,7 +115,7 @@ int psci_afflvl_on(unsigned long,
 			int);
 
 /* Private exported functions from psci_affinity_off.c */
-int psci_afflvl_off(unsigned long, int, int);
+int psci_afflvl_off(int, int);
 
 /* Private exported functions from psci_affinity_suspend.c */
 void psci_set_suspend_power_state(aff_map_node_t *node,
@@ -127,11 +123,10 @@ void psci_set_suspend_power_state(aff_map_node_t *node,
 int psci_get_aff_map_node_suspend_afflvl(aff_map_node_t *node);
 int psci_afflvl_suspend(unsigned long,
 			unsigned long,
-			unsigned long,
 			unsigned int,
 			int,
 			int);
-unsigned int psci_afflvl_suspend_finish(unsigned long, int, int);
+unsigned int psci_afflvl_suspend_finish(int, int);
 
 
 #endif /* __PSCI_PRIVATE_H__ */


### PR DESCRIPTION
Many of the interfaces internal to PSCI pass the current CPU
MPIDR_EL1 value from function to function. This is not required,
and with inline access to the system registers is less efficient
than requiring the code to read that register whenever required.

This patch remove the mpidr parameter from the affected interfaces.

Change-Id: I16120a7c6944de37232016d7e109976540775602
