### PR TITLE
Support later revisions of the Foundation FVP

### DIFF
--- a/plat/fvp/fvp_def.h
+++ b/plat/fvp/fvp_def.h
@@ -1,4 +1,4 @@
-/*
+#/*
  * Copyright (c) 2014, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -151,9 +151,12 @@
 
 #define SYS_ID_BLD_LENGTH	4
 
-#define REV_FVP		0x0
 #define HBI_FVP_BASE		0x020
+#define REV_FVP_BASE_V0		0x0
+
 #define HBI_FOUNDATION		0x010
+#define REV_FOUNDATION_V2_0	0x0
+#define REV_FOUNDATION_V2_1	0x1
 
 #define BLD_GIC_VE_MMAP	0x0
 #define BLD_GIC_A53A57_MMAP	0x1


### PR DESCRIPTION
The code in the FVP port which checks the platform type and
revision information in the SYS_ID register strictly supported
only the first revision of the Base and Foundation FVPs.

The current check also does not reflect the fact that the
board revision field is 'local' to the board type (HBI field).

Support for a new Foundation model is required now, and the
checking code is relaxed to allow execution (with a diagnostic)
on unrecognised revisions of the Base and Foundation FVP.

Change-Id: I7cd3519dfb56954aafe5f52ce1fcea0ee257ba9f
