### PR TITLE
Add support for printing version at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,12 @@
 #
 
 #
+# Trusted Firmware Version
+#
+VERSION_MAJOR		:= 0
+VERSION_MINOR		:= 4
+
+#
 # Default values for build configurations
 #
 
@@ -72,6 +78,13 @@ ifneq (${DEBUG}, 0)
 else
 	BUILD_TYPE	:=	release
 endif
+
+# Default build string (git branch and commit)
+ifeq (${BUILD_STRING},)
+	BUILD_STRING	:=	$(shell git log -n 1 --pretty=format:"%h")
+endif
+
+VERSION_STRING		:=	v${VERSION_MAJOR}.${VERSION_MINOR}(${BUILD_TYPE}):${BUILD_STRING}
 
 BL_COMMON_SOURCES	:=	common/bl_common.c			\
 				common/debug.c				\
@@ -369,7 +382,8 @@ $(BUILD_DIR) :
 
 $(ELF) : $(OBJS) $(LINKERFILE)
 	@echo "  LD      $$@"
-	@echo 'const char build_message[] = "Built : "__TIME__", "__DATE__;' | \
+	@echo 'const char build_message[] = "Built : "__TIME__", "__DATE__; \
+	       const char version_string[] = "${VERSION_STRING}";' | \
 		$$(CC) $$(CFLAGS) -xc - -o $(BUILD_DIR)/build_message.o
 	$$(Q)$$(LD) -o $$@ $$(LDFLAGS) -Map=$(MAPFILE) --script $(LINKERFILE) \
 					$(BUILD_DIR)/build_message.o $(OBJS)

--- a/bl1/bl1_main.c
+++ b/bl1/bl1_main.c
@@ -131,7 +131,8 @@ void bl1_main(void)
 
 	/* Announce our arrival */
 	printf(FIRMWARE_WELCOME_STR);
-	printf("%s\n\r", build_message);
+	printf("%s\n", version_string);
+	printf("%s\n", build_message);
 
 	SET_PARAM_HEAD(&bl2_image_info, PARAM_IMAGE_BINARY, VERSION_1, 0);
 	SET_PARAM_HEAD(&bl2_ep, PARAM_EP, VERSION_1, 0);

--- a/bl2/bl2_main.c
+++ b/bl2/bl2_main.c
@@ -196,7 +196,8 @@ void bl2_main(void)
 	/* Perform platform setup in BL2 */
 	bl2_platform_setup();
 
-	printf("BL2 %s\n\r", build_message);
+	printf("BL2 %s\n", version_string);
+	printf("BL2 %s\n", build_message);
 
 	/*
 	 * Load the subsequent bootloader images

--- a/bl31/bl31_main.c
+++ b/bl31/bl31_main.c
@@ -77,7 +77,8 @@ void bl31_main(void)
 	/* Perform platform setup in BL1 */
 	bl31_platform_setup();
 
-	printf("BL31 %s\n\r", build_message);
+	printf("BL31 %s\n", version_string);
+	printf("BL31 %s\n", build_message);
 
 	/* Initialise helper libraries */
 	bl31_lib_init();

--- a/bl32/tsp/tsp_main.c
+++ b/bl32/tsp/tsp_main.c
@@ -121,7 +121,8 @@ uint64_t tsp_main(void)
 	tsp_stats[linear_id].cpu_on_count++;
 
 	spin_lock(&console_lock);
-	printf("TSP %s\n\r", build_message);
+	printf("TSP %s\n", version_string);
+	printf("TSP %s\n", build_message);
 	INFO("Total memory base : 0x%x\n", (unsigned long)BL32_TOTAL_BASE);
 	INFO("Total memory size : 0x%x bytes\n",
 			 (unsigned long)(BL32_TOTAL_LIMIT - BL32_TOTAL_BASE));

--- a/include/common/bl_common.h
+++ b/include/common/bl_common.h
@@ -210,6 +210,7 @@ int load_image(meminfo_t *mem_layout,
 	       image_info_t *image_data,
 	       entry_point_info_t *entry_point_info);
 extern const char build_message[];
+extern const char version_string[];
 
 void reserve_mem(uint64_t *free_base, size_t *free_size,
 		uint64_t addr, size_t size);


### PR DESCRIPTION
Print out Trusted Firmware version at runtime at each BL stage.
Message consists of TF version as defined statically in the Makefile
(e.g. v0.4), build mode (debug|release) and a customizable build
string:
1. By defining BUILD_STRING in command line when building TF
2. Default string is git commit ID
3. Empty if git meta-data is not available

Fixes ARM-software/tf-issues#203

Change-Id: I5c5ba438f66ab68810427d76b49c5b9177a957d6
