### PR TITLE
FVP: Ensure system reset wake-up results in cold boot

### DIFF
--- a/plat/fvp/aarch64/fvp_helpers.S
+++ b/plat/fvp/aarch64/fvp_helpers.S
@@ -122,8 +122,11 @@ func platform_get_entrypoint
 	str	w2, [x1, #PSYSR_OFF]
 	ldr	w2, [x1, #PSYSR_OFF]
 	ubfx	w2, w2, #PSYSR_WK_SHIFT, #PSYSR_WK_MASK
-	cbnz	w2, warm_reset
-	mov	x0, x2
+	cmp	w2, #WKUP_PPONR
+	beq	warm_reset
+	cmp	w2, #WKUP_GICREQ
+	beq	warm_reset
+	mov	x0, #0
 	b	exit
 warm_reset:
 	/* ---------------------------------------------


### PR DESCRIPTION
platform_get_entrypoint() did not consider that a wakeup due to
System Reset Pin (by reading the power controller's PSYSR) requires
a cold boot. As a result, the code would execute the warm boot path
and eventually panic because entrypoint mailboxes are empty.

This patch ensures that the following wake-up reasons result in cold
boot:
- Cold Power-on
- System Reset Pin (includes reset by software)

Fixes ARM-software/tf-issues#217

Change-Id: I65ae0a0f7a46548b575900a5aac107d352b0e2cd
