### PR TITLE
Define ARM_GIC_ARCH default value for all platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,9 @@ NS_TIMER_SWITCH		:= 0
 RESET_TO_BL31		:= 0
 # Include FP registers in cpu context
 CTX_INCLUDE_FPREGS		:= 0
+# Determine the version of ARM GIC architecture to use for interrupt management
+# in EL3. The platform port can change this value if needed.
+ARM_GIC_ARCH		:=	2
 
 
 # Checkpatch ignores
@@ -186,6 +189,10 @@ $(eval $(call add_define,RESET_TO_BL31))
 # Process CTX_INCLUDE_FPREGS flag
 $(eval $(call assert_boolean,CTX_INCLUDE_FPREGS))
 $(eval $(call add_define,CTX_INCLUDE_FPREGS))
+
+# Process ARM_GIC_ARCH flag
+$(eval $(call add_define,ARM_GIC_ARCH))
+
 
 ASFLAGS			+= 	-nostdinc -ffreestanding -Wa,--fatal-warnings	\
 				-Werror -Wmissing-include-dirs			\

--- a/plat/fvp/platform.mk
+++ b/plat/fvp/platform.mk
@@ -82,8 +82,3 @@ BL31_SOURCES		+=	drivers/arm/cci400/cci400.c			\
 				plat/fvp/aarch64/fvp_helpers.S			\
 				plat/fvp/aarch64/fvp_common.c			\
 				plat/fvp/drivers/pwrc/fvp_pwrc.c
-
-# Flag used by the platform port to determine the version of ARM GIC
-# architecture to use for interrupt management in EL3.
-ARM_GIC_ARCH		:=	2
-$(eval $(call add_define,ARM_GIC_ARCH))


### PR DESCRIPTION
The ARM_GIC_ARCH build option was supposed to default to 2 on all
platforms. However, the default value was set in the FVP makefile
so for all other platforms it wasn't even defined.

This patch moves the default value to the main Makefile. The platform
port can then override it if needed.
