### PR TITLE
Unmask SError interrupt and clear SCR_EL3.EA bit

### DIFF
--- a/bl1/aarch64/bl1_arch_setup.c
+++ b/bl1/aarch64/bl1_arch_setup.c
@@ -37,17 +37,8 @@
  ******************************************************************************/
 void bl1_arch_setup(void)
 {
-	/*
-	 * Set the next EL to be AArch64, route external abort and SError
-	 * interrupts to EL3
-	 */
-	write_scr_el3(SCR_RES1_BITS | SCR_RW_BIT | SCR_EA_BIT);
-
-	/*
-	 * Enable SError and Debug exceptions
-	 */
-	enable_serror();
-	enable_debug_exceptions();
+	/* Set the next EL to be AArch64 */
+	write_scr_el3(SCR_RES1_BITS | SCR_RW_BIT);
 }
 
 /*******************************************************************************

--- a/bl1/aarch64/bl1_entrypoint.S
+++ b/bl1/aarch64/bl1_entrypoint.S
@@ -76,6 +76,14 @@ func bl1_entrypoint
 	 */
 	adr	x0, bl1_exceptions
 	msr	vbar_el3, x0
+	isb
+
+	/* ---------------------------------------------
+	 * Enable the SError interrupt now that the
+	 * exception vectors have been setup.
+	 * ---------------------------------------------
+	 */
+	msr	daifclr, #DAIF_ABT_BIT
 
 	/* ---------------------------------------------------------------------
 	 * The initial state of the Architectural feature trap register

--- a/bl1/aarch64/bl1_exceptions.S
+++ b/bl1/aarch64/bl1_exceptions.S
@@ -112,6 +112,9 @@ SErrorSPx:
 	 */
 	.align	7
 SynchronousExceptionA64:
+	/* Enable the SError interrupt */
+	msr	daifclr, #DAIF_ABT_BIT
+
 	/* ------------------------------------------------
 	 * Only a single SMC exception from BL2 to ask
 	 * BL1 to pass EL3 control to BL31 is expected

--- a/bl2/aarch64/bl2_entrypoint.S
+++ b/bl2/aarch64/bl2_entrypoint.S
@@ -53,6 +53,14 @@ func bl2_entrypoint
 	 */
 	adr	x0, early_exceptions
 	msr	vbar_el1, x0
+	isb
+
+	/* ---------------------------------------------
+	 * Enable the SError interrupt now that the
+	 * exception vectors have been setup.
+	 * ---------------------------------------------
+	 */
+	msr	daifclr, #DAIF_ABT_BIT
 
 	/* ---------------------------------------------
 	 * Enable the instruction cache, stack pointer

--- a/bl31/aarch64/bl31_arch_setup.c
+++ b/bl31/aarch64/bl31_arch_setup.c
@@ -42,18 +42,8 @@
  ******************************************************************************/
 void bl31_arch_setup(void)
 {
-	/*
-	 * Route external abort and SError interrupts to EL3
-	 * other SCR bits will be configured before exiting to a lower exception
-	 * level
-	 */
-	write_scr_el3(SCR_RES1_BITS | SCR_EA_BIT);
-
-	/*
-	 * Enable SError and Debug exceptions
-	 */
-	enable_serror();
-	enable_debug_exceptions();
+	/* Set the RES1 bits in the SCR_EL3 */
+	write_scr_el3(SCR_RES1_BITS);
 
 	/* Program the counter frequency */
 	write_cntfrq_el0(plat_get_syscnt_freq());

--- a/bl31/aarch64/bl31_entrypoint.S
+++ b/bl31/aarch64/bl31_entrypoint.S
@@ -98,6 +98,14 @@ func bl31_entrypoint
 	 */
 	adr	x1, runtime_exceptions
 	msr	vbar_el3, x1
+	isb
+
+	/* ---------------------------------------------
+	 * Enable the SError interrupt now that the
+	 * exception vectors have been setup.
+	 * ---------------------------------------------
+	 */
+	msr	daifclr, #DAIF_ABT_BIT
 
 	/* ---------------------------------------------------------------------
 	 * The initial state of the Architectural feature trap register

--- a/bl31/aarch64/runtime_exceptions.S
+++ b/bl31/aarch64/runtime_exceptions.S
@@ -44,6 +44,9 @@
 	 * -----------------------------------------------------
 	 */
 	.macro	handle_sync_exception
+	/* Enable the SError interrupt */
+	msr	daifclr, #DAIF_ABT_BIT
+
 	str	x30, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_LR]
 	mrs	x30, esr_el3
 	ubfx	x30, x30, #ESR_EC_SHIFT, #ESR_EC_LENGTH
@@ -70,6 +73,9 @@
 	 * -----------------------------------------------------
 	 */
 	.macro	handle_interrupt_exception label
+	/* Enable the SError interrupt */
+	msr	daifclr, #DAIF_ABT_BIT
+
 	str	x30, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_LR]
 	bl	save_gp_registers
 

--- a/bl32/tsp/aarch64/tsp_entrypoint.S
+++ b/bl32/tsp/aarch64/tsp_entrypoint.S
@@ -77,6 +77,14 @@ func tsp_entrypoint
 	 */
 	adr	x0, tsp_exceptions
 	msr	vbar_el1, x0
+	isb
+
+	/* ---------------------------------------------
+	 * Enable the SError interrupt now that the
+	 * exception vectors have been setup.
+	 * ---------------------------------------------
+	 */
+	msr	daifclr, #DAIF_ABT_BIT
 
 	/* ---------------------------------------------
 	 * Enable the instruction cache, stack pointer
@@ -186,6 +194,10 @@ func tsp_cpu_on_entry
 	 */
 	adr	x0, tsp_exceptions
 	msr	vbar_el1, x0
+	isb
+
+	/* Enable the SError interrupt */
+	msr	daifclr, #DAIF_ABT_BIT
 
 	/* ---------------------------------------------
 	 * Enable the instruction cache, stack pointer

--- a/bl32/tsp/aarch64/tsp_exceptions.S
+++ b/bl32/tsp/aarch64/tsp_exceptions.S
@@ -120,6 +120,9 @@ sync_exception_sp_elx:
 
 	.align	7
 irq_sp_elx:
+	/* Enable the SError interrupt */
+	msr	daifclr, #DAIF_ABT_BIT
+
 	save_caller_regs_and_lr
 	/* We just update some statistics in the handler */
 	bl	tsp_irq_received
@@ -132,6 +135,9 @@ irq_sp_elx:
 
 	.align	7
 fiq_sp_elx:
+	/* Enable the SError interrupt */
+	msr	daifclr, #DAIF_ABT_BIT
+
 	save_caller_regs_and_lr
 	bl	tsp_fiq_handler
 	cbz	x0, fiq_sp_elx_done

--- a/services/std_svc/psci/psci_entry.S
+++ b/services/std_svc/psci/psci_entry.S
@@ -88,6 +88,13 @@ psci_aff_common_finish_entry:
 	isb
 
 	/* ---------------------------------------------
+	 * Enable the SError interrupt now that the
+	 * exception vectors have been setup.
+	 * ---------------------------------------------
+	 */
+	msr	daifclr, #DAIF_ABT_BIT
+
+	/* ---------------------------------------------
 	 * Use SP_EL0 for the C runtime stack.
 	 * ---------------------------------------------
 	 */


### PR DESCRIPTION
This patch disables routing of external aborts from lower exception levels to
EL3 and ensures that a SError interrupt generated as a result of execution in
EL3 is taken locally instead of a lower exception level.

The SError interrupt is enabled in the TSP code only when the operation has not
been directly initiated by the normal world. This is to prevent the possibility
of an asynchronous external abort which originated in normal world from being
taken when execution is in S-EL1.

Fixes ARM-software/tf-issues#153

Change-Id: I157b996c75996d12fd86d27e98bc73dd8bce6cd5
