### PR TITLE
Rationalize UART usage among different BL stages

### DIFF
--- a/plat/fvp/tsp/tsp_fvp_setup.c
+++ b/plat/fvp/tsp/tsp_fvp_setup.c
@@ -72,7 +72,7 @@ void tsp_early_platform_setup(void)
 	 * Initialize a different console than already in use to display
 	 * messages from TSP
 	 */
-	console_init(PL011_UART1_BASE, PL011_UART1_CLK_IN_HZ, PL011_BAUDRATE);
+	console_init(PL011_UART2_BASE, PL011_UART2_CLK_IN_HZ, PL011_BAUDRATE);
 
 	/* Initialize the platform config for future decision making */
 	fvp_config_setup();

--- a/plat/juno/bl1_plat_setup.c
+++ b/plat/juno/bl1_plat_setup.c
@@ -75,7 +75,7 @@ void bl1_early_platform_setup(void)
 	const size_t bl1_size = BL1_RAM_LIMIT - BL1_RAM_BASE;
 
 	/* Initialize the console to provide early debug support */
-	console_init(PL011_UART0_BASE, PL011_UART0_CLK_IN_HZ, PL011_BAUDRATE);
+	console_init(PL011_UART2_BASE, PL011_UART2_CLK_IN_HZ, PL011_BAUDRATE);
 
 	/*
 	 * Enable CCI-400 for this cluster. No need for locks as no other cpu is

--- a/plat/juno/bl2_plat_setup.c
+++ b/plat/juno/bl2_plat_setup.c
@@ -158,7 +158,7 @@ struct entry_point_info *bl2_plat_get_bl31_ep_info(void)
 void bl2_early_platform_setup(meminfo_t *mem_layout)
 {
 	/* Initialize the console to provide early debug support */
-	console_init(PL011_UART0_BASE, PL011_UART0_CLK_IN_HZ, PL011_BAUDRATE);
+	console_init(PL011_UART2_BASE, PL011_UART2_CLK_IN_HZ, PL011_BAUDRATE);
 
 	/* Setup the BL2 memory layout */
 	bl2_tzram_layout = *mem_layout;

--- a/plat/juno/bl31_plat_setup.c
+++ b/plat/juno/bl31_plat_setup.c
@@ -108,7 +108,7 @@ void bl31_early_platform_setup(bl31_params_t *from_bl2,
 			       void *plat_params_from_bl2)
 {
 	/* Initialize the console to provide early debug support */
-	console_init(PL011_UART0_BASE, PL011_UART0_CLK_IN_HZ, PL011_BAUDRATE);
+	console_init(PL011_UART2_BASE, PL011_UART2_CLK_IN_HZ, PL011_BAUDRATE);
 
 	/*
 	 * Initialise the CCI-400 driver for BL31 so that it is accessible after

--- a/plat/juno/juno_def.h
+++ b/plat/juno/juno_def.h
@@ -138,6 +138,8 @@
 
 #define PL011_UART0_CLK_IN_HZ		24000000
 #define PL011_UART1_CLK_IN_HZ		24000000
+#define PL011_UART2_CLK_IN_HZ		7273800
+#define PL011_UART3_CLK_IN_HZ		7273800
 
 /*******************************************************************************
  * NIC-400 related constants

--- a/plat/juno/tsp/tsp_plat_setup.c
+++ b/plat/juno/tsp/tsp_plat_setup.c
@@ -72,7 +72,7 @@ void tsp_early_platform_setup(void)
 	 * Initialize a different console than already in use to display
 	 * messages from TSP
 	 */
-	console_init(PL011_UART1_BASE, PL011_UART1_CLK_IN_HZ, PL011_BAUDRATE);
+	console_init(PL011_UART0_BASE, PL011_UART0_CLK_IN_HZ, PL011_BAUDRATE);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
This patch changes the UART port assignment for various BL stages
so as to make it consistent on the platform ports. The BL1, BL2 and
BL3-1 now uses UART0 on the FVP port and SoC UART0 on the Juno port.
The BL3-2 uses UART2 on the FVP port and FPGA UART0 on the Juno
port.

This provides an interim fix to ARM-software/tf-issues#220 until
support is added for changing the UART port for a BL image between
cold boot and runtime.

Change-Id: Iae5faea90be3d59e41e597b34a902f93e737505a
