### PR TITLE
Allow secondary cores to wake up in Aarch64

### DIFF
--- a/bl31/aarch64/runtime_exceptions.S
+++ b/bl31/aarch64/runtime_exceptions.S
@@ -407,8 +407,9 @@ smc_handler64:
 	mrs	x16, spsr_el3
 	mrs	x17, elr_el3
 	mrs	x18, scr_el3
+	mrs	x19, hcr_el2
 	stp	x16, x17, [x6, #CTX_EL3STATE_OFFSET + CTX_SPSR_EL3]
-	str	x18, [x6, #CTX_EL3STATE_OFFSET + CTX_SCR_EL3]
+	stp	x18, x19, [x6, #CTX_EL3STATE_OFFSET + CTX_SCR_EL3]
 
 	/* Copy SCR_EL3.NS bit to the flag to indicate caller's security */
 	bfi	x7, x18, #0, #1
@@ -451,8 +452,9 @@ el3_exit: ; .type el3_exit, %function
 	 * Restore SPSR_EL3, ELR_EL3 and SCR_EL3 prior to ERET
 	 * -----------------------------------------------------
 	 */
-	ldr	x18, [sp, #CTX_EL3STATE_OFFSET + CTX_SCR_EL3]
+	ldp	x18, x19, [sp, #CTX_EL3STATE_OFFSET + CTX_SCR_EL3]
 	ldp	x16, x17, [sp, #CTX_EL3STATE_OFFSET + CTX_SPSR_EL3]
+	msr	hcr_el2, x19
 	msr	scr_el3, x18
 	msr	spsr_el3, x16
 	msr	elr_el3, x17

--- a/include/bl31/context.h
+++ b/include/bl31/context.h
@@ -77,10 +77,11 @@
  ******************************************************************************/
 #define CTX_EL3STATE_OFFSET	(CTX_GPREGS_OFFSET + CTX_GPREGS_END)
 #define CTX_SCR_EL3		0x0
-#define CTX_RUNTIME_SP		0x8
-#define CTX_SPSR_EL3		0x10
-#define CTX_ELR_EL3		0x18
-#define CTX_EL3STATE_END	0x20
+#define CTX_HCR_EL2		0x8
+#define CTX_RUNTIME_SP		0x10
+#define CTX_SPSR_EL3		0x18
+#define CTX_ELR_EL3		0x20
+#define CTX_EL3STATE_END	0x30
 
 /*******************************************************************************
  * Constants that allow assembler code to access members of and the


### PR DESCRIPTION
At boot time secondary cores may stand by in Aarch32 mode. Therefore if the
primary core has already switched to Aarch64 mode, they must be able to
switch to Aarch64 as well. As a consequence we must take care of HCR_EL2.RW
when there is no hypervisor to do so.

Fixes ARM-software/tf-issues#243

Signed-off-by: Gerald Lejeune gerald.lejeune@st.com
