### PR TITLE
Remove BSS section access by 'plat_print_gic' during crash reporting

### DIFF
--- a/plat/fvp/include/plat_macros.S
+++ b/plat/fvp/include/plat_macros.S
@@ -33,8 +33,8 @@
 #include "../fvp_def.h"
 
 .section .rodata.gic_reg_name, "aS"
-gic_regs:
-	.asciz "gic_hppir", "gic_ahppir", "gic_ctlr", ""
+gicc_regs:
+	.asciz "gicc_hppir", "gicc_ahppir", "gicc_ctlr", ""
 gicd_pend_reg:
 	.asciz "gicd_ispendr regs (Offsets 0x200 - 0x278)\n Offset:\t\t\tvalue\n"
 newline:
@@ -46,19 +46,33 @@ spacer:
 	 * The below macro prints out relevant GIC
 	 * registers whenever an unhandled exception is
 	 * taken in BL3-1.
-	 * Clobbers: x0 - x10, x16, sp
+	 * Clobbers: x0 - x10, x16, x17, sp
 	 * ---------------------------------------------
 	 */
 	.macro plat_print_gic_regs
-	adr	x0, plat_config
-	ldr	w16, [x0, #CONFIG_GICC_BASE_OFFSET]
-	cbz	x16, exit_print_gic_regs
-	/* gic base address is now in x16 */
-	adr	x6, gic_regs	/* Load the gic reg list to x6 */
-	/* Load the gic regs to gp regs used by str_in_crash_buf_print */
-	ldr	w8, [x16, #GICC_HPPIR]
-	ldr	w9, [x16, #GICC_AHPPIR]
-	ldr	w10, [x16, #GICC_CTLR]
+	mov_imm	x0, (VE_SYSREGS_BASE + V2M_SYS_ID)
+	ldr	w16, [x0]
+	/* Extract BLD (12th - 15th bits) from the SYS_ID */
+	ubfx	x16, x16, #SYS_ID_BLD_SHIFT, #4
+	/* Check if VE mmap */
+	cmp	w16, #BLD_GIC_VE_MMAP
+	b.eq	use_ve_mmap
+	/* Check if Cortex-A53/A57 mmap */
+	cmp	w16, #BLD_GIC_A53A57_MMAP
+	b.ne	exit_print_gic_regs
+	mov_imm	x17, BASE_GICC_BASE
+	mov_imm	x16, BASE_GICD_BASE
+	b	print_gicc_regs
+use_ve_mmap:
+	mov_imm	x17, VE_GICC_BASE
+	mov_imm	x16, VE_GICD_BASE
+print_gicc_regs:
+	/* gicc base address is now in x17 */
+	adr	x6, gicc_regs	/* Load the gicc reg list to x6 */
+	/* Load the gicc regs to gp regs used by str_in_crash_buf_print */
+	ldr	w8, [x17, #GICC_HPPIR]
+	ldr	w9, [x17, #GICC_AHPPIR]
+	ldr	w10, [x17, #GICC_CTLR]
 	/* Store to the crash buf and print to console */
 	bl	str_in_crash_buf_print
 

--- a/plat/juno/include/plat_macros.S
+++ b/plat/juno/include/plat_macros.S
@@ -34,8 +34,8 @@
 #include "../juno_def.h"
 
 .section .rodata.gic_reg_name, "aS"
-gic_regs:
-	.asciz "gic_hppir", "gic_ahppir", "gic_ctlr", ""
+gicc_regs:
+	.asciz "gicc_hppir", "gicc_ahppir", "gicc_ctlr", ""
 gicd_pend_reg:
 	.asciz "gicd_ispendr regs (Offsets 0x200 - 0x278)\n Offset:\t\t\tvalue\n"
 newline:
@@ -52,13 +52,14 @@ spacer:
 	 * ---------------------------------------------
 	 */
 	.macro plat_print_gic_regs
-	ldr	x16, =GICC_BASE
-	/* Load the gic reg list to x6 */
-	adr	x6, gic_regs
-	/* Load the gic regs to gp regs used by str_in_crash_buf_print */
-	ldr	w8, [x16, #GICC_HPPIR]
-	ldr	w9, [x16, #GICC_AHPPIR]
-	ldr	w10, [x16, #GICC_CTLR]
+	mov_imm	x16, GICD_BASE
+	mov_imm	x17, GICC_BASE
+	/* Load the gicc reg list to x6 */
+	adr	x6, gicc_regs
+	/* Load the gicc regs to gp regs used by str_in_crash_buf_print */
+	ldr	w8, [x17, #GICC_HPPIR]
+	ldr	w9, [x17, #GICC_AHPPIR]
+	ldr	w10, [x17, #GICC_CTLR]
 	/* Store to the crash buf and print to console */
 	bl	str_in_crash_buf_print
 


### PR DESCRIPTION
This patch avoids the problem of crash reporting mechanism accessing
global data in BSS by 'plat_print_gic_regs' for FVP platforms. Earlier
it depended on the global 'plat_config' object for the GIC Base address
in FVP platforms which would have caused exception if it were accessed
before the BSS was initialized. It is now fixed by dynamically
querying the V2M_SYS_ID to find the FVP model type and accordingly
selecting the appropriate GIC Base address.

This patch also fixes the 'plat_print_gic_regs' to use the correct GIC
Distributor base address for printing GICD_IS_PENDR register values
for both Juno and FVP platforms.

Fixes ARM-Software/tf-issues#236

Change-Id: I545c7b908b3111419bf27db0575ce86acf86784b
