### PR TITLE
Create BL stage specific translation tables

### DIFF
--- a/include/lib/aarch64/xlat_tables.h
+++ b/include/lib/aarch64/xlat_tables.h
@@ -41,6 +41,16 @@
 #ifndef __ASSEMBLY__
 #include <stdint.h>
 
+/* Helper macro to define entries for mmap_region_t. It creates
+ * identity mappings for each region.
+ */
+#define MAP_REGION_FLAT(adr, sz, attr) MAP_REGION(adr, adr, sz, attr)
+
+/* Helper macro to define entries for mmap_region_t. It allows to
+ * re-map address mappings from 'pa' to 'va' for each region.
+ */
+#define MAP_REGION(pa, va, sz, attr) {(pa), (va), (sz), (attr)}
+
 /*
  * Flags for building up memory mapping attributes.
  * These are organised so that a clear bit gives a more restrictive  mapping

--- a/plat/fvp/aarch64/fvp_common.c
+++ b/plat/fvp/aarch64/fvp_common.c
@@ -36,6 +36,7 @@
 #include <debug.h>
 #include <mmio.h>
 #include <platform.h>
+#include <platform_def.h>
 #include <plat_config.h>
 #include <xlat_tables.h>
 #include "../fvp_def.h"
@@ -49,33 +50,70 @@
  ******************************************************************************/
 plat_config_t plat_config;
 
+#define MAP_SHARED_RAM	MAP_REGION_FLAT(FVP_SHARED_RAM_BASE,		\
+					FVP_SHARED_RAM_SIZE,		\
+					MT_MEMORY | MT_RW | MT_SECURE)
+
+#define MAP_FLASH0	MAP_REGION_FLAT(FLASH0_BASE,			\
+					FLASH0_SIZE,			\
+					MT_MEMORY | MT_RO | MT_SECURE)
+
+#define MAP_DEVICE0	MAP_REGION_FLAT(DEVICE0_BASE,			\
+					DEVICE0_SIZE,			\
+					MT_DEVICE | MT_RW | MT_SECURE)
+
+#define MAP_DEVICE1	MAP_REGION_FLAT(DEVICE1_BASE,			\
+					DEVICE1_SIZE,			\
+					MT_DEVICE | MT_RW | MT_SECURE)
+
+#define MAP_DRAM1	MAP_REGION_FLAT(DRAM1_BASE,			\
+					DRAM1_SIZE,			\
+					MT_MEMORY | MT_RW | MT_NS)
+
+#define MAP_TSP_SEC_MEM	MAP_REGION_FLAT(TSP_SEC_MEM_BASE,		\
+					TSP_SEC_MEM_SIZE,		\
+					MT_MEMORY | MT_RW | MT_SECURE)
+
 /*
- * Table of regions to map using the MMU.
+ * Table of regions for various BL stages to map using the MMU.
  * This doesn't include TZRAM as the 'mem_layout' argument passed to
  * configure_mmu_elx() will give the available subset of that,
  */
+#if IMAGE_BL1
 const mmap_region_t fvp_mmap[] = {
-	{ FVP_SHARED_RAM_BASE,	FVP_SHARED_RAM_BASE,	FVP_SHARED_RAM_SIZE,
-						MT_MEMORY | MT_RW | MT_SECURE },
-	{ FVP_TRUSTED_DRAM_BASE, FVP_TRUSTED_DRAM_BASE,	FVP_TRUSTED_DRAM_SIZE,
-						MT_MEMORY | MT_RW | MT_SECURE },
-	{ FLASH0_BASE,	FLASH0_BASE,	FLASH0_SIZE,
-						MT_MEMORY | MT_RO | MT_SECURE },
-	{ FLASH1_BASE,	FLASH1_BASE,	FLASH1_SIZE,
-						MT_MEMORY | MT_RO | MT_SECURE },
-	{ VRAM_BASE,	VRAM_BASE,	VRAM_SIZE,
-						MT_MEMORY | MT_RW | MT_SECURE },
-	{ DEVICE0_BASE,	DEVICE0_BASE,	DEVICE0_SIZE,
-						MT_DEVICE | MT_RW | MT_SECURE },
-	{ DEVICE1_BASE,	DEVICE1_BASE,	DEVICE1_SIZE,
-						MT_DEVICE | MT_RW | MT_SECURE },
-	/* 2nd GB as device for now...*/
-	{ 0x40000000,	0x40000000,	0x40000000,
-						MT_DEVICE | MT_RW | MT_SECURE },
-	{ DRAM1_BASE,	DRAM1_BASE,	DRAM1_SIZE,
-						MT_MEMORY | MT_RW | MT_NS },
+	MAP_SHARED_RAM,
+	MAP_FLASH0,
+	MAP_DEVICE0,
+	MAP_DEVICE1,
 	{0}
 };
+#endif
+#if IMAGE_BL2
+const mmap_region_t fvp_mmap[] = {
+	MAP_SHARED_RAM,
+	MAP_FLASH0,
+	MAP_DEVICE0,
+	MAP_DEVICE1,
+	MAP_DRAM1,
+	MAP_TSP_SEC_MEM,
+	{0}
+};
+#endif
+#if IMAGE_BL31
+const mmap_region_t fvp_mmap[] = {
+	MAP_SHARED_RAM,
+	MAP_DEVICE0,
+	MAP_DEVICE1,
+	{0}
+};
+#endif
+#if IMAGE_BL32
+const mmap_region_t fvp_mmap[] = {
+	MAP_DEVICE0,
+	MAP_DEVICE1,
+	{0}
+};
+#endif
 
 /* Array of secure interrupts to be configured by the gic driver */
 const unsigned int irq_sec_array[] = {

--- a/plat/juno/aarch64/juno_common.c
+++ b/plat/juno/aarch64/juno_common.c
@@ -38,23 +38,74 @@
 #include <xlat_tables.h>
 #include "../juno_def.h"
 
+#define MAP_MHU_SECURE	MAP_REGION_FLAT(MHU_SECURE_BASE,		\
+					MHU_SECURE_SIZE,		\
+					(MHU_PAYLOAD_CACHED ?		\
+					 MT_MEMORY : MT_DEVICE)		\
+					| MT_RW | MT_SECURE)
+
+#define MAP_FLASH	MAP_REGION_FLAT(FLASH_BASE,			\
+					FLASH_SIZE,			\
+					MT_MEMORY | MT_RO | MT_SECURE)
+
+#define MAP_IOFPGA	MAP_REGION_FLAT(IOFPGA_BASE,			\
+					IOFPGA_SIZE,			\
+					MT_DEVICE | MT_RW | MT_SECURE)
+
+#define MAP_DEVICE0	MAP_REGION_FLAT(DEVICE0_BASE,			\
+					DEVICE0_SIZE,			\
+					MT_DEVICE | MT_RW | MT_SECURE)
+
+#define MAP_DEVICE1	MAP_REGION_FLAT(DEVICE1_BASE,			\
+					DEVICE1_SIZE,			\
+					MT_DEVICE | MT_RW | MT_SECURE)
+
+#define MAP_DRAM	MAP_REGION_FLAT(DRAM_BASE,			\
+					DRAM_SIZE,			\
+					MT_MEMORY | MT_RW | MT_NS)
 /*
- * Table of regions to map using the MMU.
+ * Table of regions for different BL stages to map using the MMU.
  * This doesn't include Trusted RAM as the 'mem_layout' argument passed to
  * configure_mmu_elx() will give the available subset of that,
  */
+#if IMAGE_BL1
 static const mmap_region_t juno_mmap[] = {
-	{ TZROM_BASE,		TZROM_BASE,		TZROM_SIZE,		MT_MEMORY | MT_RO | MT_SECURE },
-	{ MHU_SECURE_BASE,	MHU_SECURE_BASE,	MHU_SECURE_SIZE,	(MHU_PAYLOAD_CACHED ? MT_MEMORY : MT_DEVICE) | MT_RW | MT_SECURE },
-	{ FLASH_BASE,		FLASH_BASE,		FLASH_SIZE,		MT_MEMORY | MT_RO | MT_SECURE },
-	{ EMMC_BASE,		EMMC_BASE,		EMMC_SIZE,		MT_MEMORY | MT_RO | MT_SECURE },
-	{ PSRAM_BASE,		PSRAM_BASE,		PSRAM_SIZE,		MT_MEMORY | MT_RW | MT_SECURE }, /* Used for 'TZDRAM' */
-	{ IOFPGA_BASE,		IOFPGA_BASE,		IOFPGA_SIZE,		MT_DEVICE | MT_RW | MT_SECURE },
-	{ DEVICE0_BASE,		DEVICE0_BASE,		DEVICE0_SIZE,		MT_DEVICE | MT_RW | MT_SECURE },
-	{ DEVICE1_BASE,		DEVICE1_BASE,		DEVICE1_SIZE,		MT_DEVICE | MT_RW | MT_SECURE },
-	{ DRAM_BASE,		DRAM_BASE,		DRAM_SIZE,		MT_MEMORY | MT_RW | MT_NS },
+	MAP_MHU_SECURE,
+	MAP_FLASH,
+	MAP_IOFPGA,
+	MAP_DEVICE0,
+	MAP_DEVICE1,
 	{0}
 };
+#endif
+#if IMAGE_BL2
+static const mmap_region_t juno_mmap[] = {
+	MAP_MHU_SECURE,
+	MAP_FLASH,
+	MAP_IOFPGA,
+	MAP_DEVICE0,
+	MAP_DEVICE1,
+	MAP_DRAM,
+	{0}
+};
+#endif
+#if IMAGE_BL31
+static const mmap_region_t juno_mmap[] = {
+	MAP_MHU_SECURE,
+	MAP_IOFPGA,
+	MAP_DEVICE0,
+	MAP_DEVICE1,
+	{0}
+};
+#endif
+#if IMAGE_BL32
+static const mmap_region_t juno_mmap[] = {
+	MAP_IOFPGA,
+	MAP_DEVICE0,
+	MAP_DEVICE1,
+	{0}
+};
+#endif
 
 /*******************************************************************************
  * Macro generating the code for the function setting up the pagetables as per


### PR DESCRIPTION
This patch uses the IMAGE_BL<x> constants to create translation tables specific
to a boot loader stage. This allows each stage to create mappings only for areas
in the memory map that it needs.

Fixes ARM-software/tf-issues#209

Change-Id: Ie4861407ddf9317f0fb890fc7575eaa88d0de51c
