### PR TITLE
FVP: keep shared data in Trusted SRAM

### DIFF
--- a/docs/firmware-design.md
+++ b/docs/firmware-design.md
@@ -1199,16 +1199,12 @@ sections must not overstep. The platform code must provide those.
 The following list describes the memory layout on the FVP:
 
 *   A 4KB page of shared memory is used to store the entrypoint mailboxes
-    and the parameters passed between bootloaders. The shared memory can be
-    allocated either at the top of Trusted SRAM or at the base of Trusted
-    DRAM at build time. When allocated in Trusted SRAM, the amount of Trusted
-    SRAM available to load the bootloader images will be reduced by the size
-    of the shared memory.
+    and the parameters passed between bootloaders. The shared memory is located
+    at the base of the Trusted SRAM. The amount of Trusted SRAM available to
+    load the bootloader images will be reduced by the size of the shared memory.
 
 *   BL1 is originally sitting in the Trusted ROM at address `0x0`. Its
     read-write data are relocated at the top of the Trusted SRAM at runtime.
-    If the shared memory is allocated in Trusted SRAM, the BL1 read-write data
-    is relocated just below the shared memory.
 
 *   BL3-1 is loaded at the top of the Trusted SRAM, such that its NOBITS
     sections will overwrite BL1 R/W data.
@@ -1217,21 +1213,17 @@ The following list describes the memory layout on the FVP:
 
 *   The TSP is loaded as the BL3-2 image at the base of either the Trusted
     SRAM or Trusted DRAM. When loaded into Trusted SRAM, its NOBITS sections
-    are allowed to overlay BL2. When loaded into Trusted DRAM, an offset
-    corresponding to the size of the shared memory is applied to avoid
-    overlap.
+    are allowed to overlay BL2.
 
 This memory layout is designed to give the BL3-2 image as much memory as
 possible when it is loaded into Trusted SRAM. Depending on the location of the
-shared memory page and the TSP, it will result in different memory maps,
-illustrated by the following diagrams.
+TSP, it will result in different memory maps, illustrated by the following
+diagrams.
 
-**Shared data & TSP in Trusted SRAM (default option):**
+**TSP in Trusted SRAM (default option):**
 
                Trusted SRAM
-    0x04040000 +----------+
-               |  Shared  |
-    0x0403F000 +----------+  loaded by BL2  ------------------
+    0x04040000 +----------+  loaded by BL2  ------------------
                | BL1 (rw) |  <<<<<<<<<<<<<  |  BL3-1 NOBITS  |
                |----------|  <<<<<<<<<<<<<  |----------------|
                |          |  <<<<<<<<<<<<<  | BL3-1 PROGBITS |
@@ -1239,7 +1231,9 @@ illustrated by the following diagrams.
                |   BL2    |  <<<<<<<<<<<<<  |  BL3-2 NOBITS  |
                |----------|  <<<<<<<<<<<<<  |----------------|
                |          |  <<<<<<<<<<<<<  | BL3-2 PROGBITS |
-    0x04000000 +----------+                 ------------------
+    0x04001000 +----------+                 ------------------
+               |  Shared  |
+    0x04000000 +----------+
 
                Trusted ROM
     0x04000000 +----------+
@@ -1247,15 +1241,11 @@ illustrated by the following diagrams.
     0x00000000 +----------+
 
 
-**Shared data & TSP in Trusted DRAM:**
+**TSP in Trusted DRAM:**
 
                Trusted DRAM
     0x08000000 +----------+
-               |          |
                |  BL3-2   |
-               |          |
-    0x06001000 |----------|
-               |  Shared  |
     0x06000000 +----------+
 
                Trusted SRAM
@@ -1267,34 +1257,9 @@ illustrated by the following diagrams.
                |   BL2    |
                |----------|
                |          |
-    0x04000000 +----------+
-
-               Trusted ROM
-    0x04000000 +----------+
-               | BL1 (ro) |
-    0x00000000 +----------+
-
-**Shared data in Trusted DRAM, TSP in Trusted SRAM:**
-
-               Trusted DRAM
-    0x08000000 +----------+
-               |          |
-               |          |
-               |          |
-    0x06001000 |----------|
+    0x04001000 +----------+
                |  Shared  |
-    0x06000000 +----------+
-
-               Trusted SRAM
-    0x04040000 +----------+  loaded by BL2  ------------------
-               | BL1 (rw) |  <<<<<<<<<<<<<  |  BL3-1 NOBITS  |
-               |----------|  <<<<<<<<<<<<<  |----------------|
-               |          |  <<<<<<<<<<<<<  | BL3-1 PROGBITS |
-               |----------|                 ------------------
-               |   BL2    |  <<<<<<<<<<<<<  |  BL3-2 NOBITS  |
-               |----------|  <<<<<<<<<<<<<  |----------------|
-               |          |  <<<<<<<<<<<<<  | BL3-2 PROGBITS |
-    0x04000000 +----------+                 ------------------
+    0x04000000 +----------+
 
                Trusted ROM
     0x04000000 +----------+

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -244,14 +244,9 @@ performed.
 
 #### FVP specific build options
 
-*   `FVP_SHARED_DATA_LOCATION`: location of the shared memory page. Available
-    options:
-    -   `tsram` (default) : top of Trusted SRAM
-    -   `tdram` : base of Trusted DRAM
-
 *   `FVP_TSP_RAM_LOCATION`: location of the TSP binary. Options:
-    -   `tsram` (default) : base of Trusted SRAM
-    -   `tdram` : Trusted DRAM (above shared data)
+    -   `tsram` (default) : Trusted SRAM
+    -   `tdram` : Trusted DRAM
 
 For a better understanding of FVP options, the FVP memory map is explained in
 the [Firmware Design].

--- a/plat/fvp/aarch64/fvp_common.c
+++ b/plat/fvp/aarch64/fvp_common.c
@@ -50,8 +50,8 @@
  ******************************************************************************/
 plat_config_t plat_config;
 
-#define MAP_SHARED_RAM	MAP_REGION_FLAT(FVP_SHARED_RAM_BASE,		\
-					FVP_SHARED_RAM_SIZE,		\
+#define MAP_SHARED_RAM	MAP_REGION_FLAT(FVP_SHARED_MEM_BASE,		\
+					FVP_SHARED_MEM_SIZE,		\
 					MT_MEMORY | MT_RW | MT_SECURE)
 
 #define MAP_FLASH0	MAP_REGION_FLAT(FLASH0_BASE,			\

--- a/plat/fvp/bl2_fvp_setup.c
+++ b/plat/fvp/bl2_fvp_setup.c
@@ -74,7 +74,7 @@ __attribute__ ((aligned(PLATFORM_CACHE_LINE_SIZE),
 
 /* Assert that BL3-1 parameters fit in shared memory */
 CASSERT((PARAMS_BASE + sizeof(bl2_to_bl31_params_mem_t)) <
-	(FVP_SHARED_RAM_BASE + FVP_SHARED_RAM_SIZE),
+	(FVP_SHARED_MEM_BASE + FVP_SHARED_MEM_SIZE),
 	assert_bl31_params_do_not_fit_in_shared_memory);
 
 /*******************************************************************************

--- a/plat/fvp/fvp_def.h
+++ b/plat/fvp/fvp_def.h
@@ -35,7 +35,7 @@
 #define FIP_IMAGE_NAME			"fip.bin"
 #define FVP_PRIMARY_CPU			0x0
 
-/* Memory location options for Shared data and TSP in FVP */
+/* Memory location options for TSP */
 #define FVP_IN_TRUSTED_SRAM		0
 #define FVP_IN_TRUSTED_DRAM		1
 
@@ -46,8 +46,13 @@
 #define FVP_TRUSTED_ROM_BASE	0x00000000
 #define FVP_TRUSTED_ROM_SIZE	0x04000000	/* 64 MB */
 
-#define FVP_TRUSTED_SRAM_BASE	0x04000000
-#define FVP_TRUSTED_SRAM_SIZE	0x00040000	/* 256 KB */
+/* The first 4KB of Trusted SRAM are used as shared memory */
+#define FVP_SHARED_MEM_BASE	0x04000000
+#define FVP_SHARED_MEM_SIZE	0x00001000	/* 4 KB */
+
+/* The remaining Trusted SRAM is used to load the BL images */
+#define FVP_TRUSTED_SRAM_BASE	0x04001000
+#define FVP_TRUSTED_SRAM_SIZE	0x0003F000	/* 252 KB */
 
 #define FVP_TRUSTED_DRAM_BASE	0x06000000
 #define FVP_TRUSTED_DRAM_SIZE	0x02000000	/* 32 MB */
@@ -73,28 +78,6 @@
 
 #define NSRAM_BASE		0x2e000000
 #define NSRAM_SIZE		0x10000
-
-/* 4KB shared memory */
-#define FVP_SHARED_RAM_SIZE	0x1000
-
-/* Location of shared memory */
-#if (FVP_SHARED_DATA_LOCATION_ID == FVP_IN_TRUSTED_DRAM)
-/* Shared memory at the base of Trusted DRAM */
-# define FVP_SHARED_RAM_BASE		FVP_TRUSTED_DRAM_BASE
-# define FVP_TRUSTED_SRAM_LIMIT		(FVP_TRUSTED_SRAM_BASE \
-					+ FVP_TRUSTED_SRAM_SIZE)
-#elif (FVP_SHARED_DATA_LOCATION_ID == FVP_IN_TRUSTED_SRAM)
-# if (FVP_TSP_RAM_LOCATION_ID == FVP_IN_TRUSTED_DRAM)
-#  error "Shared data in Trusted SRAM and TSP in Trusted DRAM is not supported"
-# endif
-/* Shared memory at the top of the Trusted SRAM */
-# define FVP_SHARED_RAM_BASE		(FVP_TRUSTED_SRAM_BASE \
-					+ FVP_TRUSTED_SRAM_SIZE \
-					- FVP_SHARED_RAM_SIZE)
-# define FVP_TRUSTED_SRAM_LIMIT		FVP_SHARED_RAM_BASE
-#else
-# error "Unsupported FVP_SHARED_DATA_LOCATION_ID value"
-#endif
 
 #define DRAM1_BASE		0x80000000ull
 #define DRAM1_SIZE		0x80000000ull
@@ -268,7 +251,7 @@
  ******************************************************************************/
 
 /* Entrypoint mailboxes */
-#define MBOX_BASE		FVP_SHARED_RAM_BASE
+#define MBOX_BASE		FVP_SHARED_MEM_BASE
 #define MBOX_SIZE		0x200
 
 /* Base address where parameters to BL31 are stored */

--- a/plat/fvp/include/platform_def.h
+++ b/plat/fvp/include/platform_def.h
@@ -93,12 +93,13 @@
 #define BL1_RO_LIMIT			(FVP_TRUSTED_ROM_BASE \
 					+ FVP_TRUSTED_ROM_SIZE)
 /*
- * Put BL1 RW at the top of the Trusted SRAM (just below the shared memory, if
- * present). BL1_RW_BASE is calculated using the current BL1 RW debug size plus
- * a little space for growth.
+ * Put BL1 RW at the top of the Trusted SRAM. BL1_RW_BASE is calculated using
+ * the current BL1 RW debug size plus a little space for growth.
  */
-#define BL1_RW_BASE			(FVP_TRUSTED_SRAM_LIMIT - 0x6000)
-#define BL1_RW_LIMIT			FVP_TRUSTED_SRAM_LIMIT
+#define BL1_RW_BASE			(FVP_TRUSTED_SRAM_BASE \
+					+ FVP_TRUSTED_SRAM_SIZE - 0x6000)
+#define BL1_RW_LIMIT			(FVP_TRUSTED_SRAM_BASE \
+					+ FVP_TRUSTED_SRAM_SIZE)
 
 /*******************************************************************************
  * BL2 specific defines.
@@ -114,13 +115,14 @@
  * BL31 specific defines.
  ******************************************************************************/
 /*
- * Put BL3-1 at the top of the Trusted SRAM (just below the shared memory, if
- * present). BL31_BASE is calculated using the current BL3-1 debug size plus a
- * little space for growth.
+ * Put BL3-1 at the top of the Trusted SRAM. BL31_BASE is calculated using the
+ * current BL3-1 debug size plus a little space for growth.
  */
-#define BL31_BASE			(FVP_TRUSTED_SRAM_LIMIT - 0x1D000)
+#define BL31_BASE			(FVP_TRUSTED_SRAM_BASE \
+					+ FVP_TRUSTED_SRAM_SIZE - 0x1D000)
 #define BL31_PROGBITS_LIMIT		BL1_RW_BASE
-#define BL31_LIMIT			FVP_TRUSTED_SRAM_LIMIT
+#define BL31_LIMIT			(FVP_TRUSTED_SRAM_BASE \
+					+ FVP_TRUSTED_SRAM_SIZE)
 
 /*******************************************************************************
  * BL32 specific defines.
@@ -137,8 +139,7 @@
 #elif FVP_TSP_RAM_LOCATION_ID == FVP_IN_TRUSTED_DRAM
 # define TSP_SEC_MEM_BASE		FVP_TRUSTED_DRAM_BASE
 # define TSP_SEC_MEM_SIZE		FVP_TRUSTED_DRAM_SIZE
-# define BL32_BASE			(FVP_TRUSTED_DRAM_BASE \
-					+ FVP_SHARED_RAM_SIZE)
+# define BL32_BASE			FVP_TRUSTED_DRAM_BASE
 # define BL32_LIMIT			(FVP_TRUSTED_DRAM_BASE + (1 << 21))
 #else
 # error "Unsupported FVP_TSP_RAM_LOCATION_ID value"

--- a/plat/fvp/platform.mk
+++ b/plat/fvp/platform.mk
@@ -28,17 +28,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-# Shared memory may be allocated at the top of Trusted SRAM (tsram) or at the
-# base of Trusted SRAM (tdram)
-FVP_SHARED_DATA_LOCATION	:=	tsram
-ifeq (${FVP_SHARED_DATA_LOCATION}, tsram)
-  FVP_SHARED_DATA_LOCATION_ID := FVP_IN_TRUSTED_SRAM
-else ifeq (${FVP_SHARED_DATA_LOCATION}, tdram)
-  FVP_SHARED_DATA_LOCATION_ID := FVP_IN_TRUSTED_DRAM
-else
-  $(error "Unsupported FVP_SHARED_DATA_LOCATION value")
-endif
-
 # On FVP, the TSP can execute either from Trusted SRAM or Trusted DRAM.
 # Trusted SRAM is the default.
 FVP_TSP_RAM_LOCATION	:=	tsram
@@ -50,14 +39,7 @@ else
   $(error "Unsupported FVP_TSP_RAM_LOCATION value")
 endif
 
-ifeq (${FVP_SHARED_DATA_LOCATION}, tsram)
-  ifeq (${FVP_TSP_RAM_LOCATION}, tdram)
-    $(error Shared data in Trusted SRAM and TSP in Trusted DRAM is not supported)
-  endif
-endif
-
 # Process flags
-$(eval $(call add_define,FVP_SHARED_DATA_LOCATION_ID))
 $(eval $(call add_define,FVP_TSP_RAM_LOCATION_ID))
 
 PLAT_INCLUDES		:=	-Iplat/fvp/include/


### PR DESCRIPTION
This patch deprecates the build option to relocate the shared data
into Trusted DRAM in FVP. After this change, shared data is always
located at the base of Trusted SRAM. This reduces the complexity
of the memory map and the number of combinations in the build
options.

Fixes ARM-software/tf-issues#257

Change-Id: I68426472567b9d8c6d22d8884cb816f6b61bcbd3
