### PR TITLE
Use the BL3-1 runtime console as the crash console.

### DIFF
--- a/plat/fvp/aarch64/fvp_helpers.S
+++ b/plat/fvp/aarch64/fvp_helpers.S
@@ -199,7 +199,7 @@ func platform_is_primary_cpu
 	ret
 
 	/* Define a crash console for the plaform */
-#define FVP_CRASH_CONSOLE_BASE		PL011_UART0_BASE
+#define FVP_CRASH_CONSOLE_BASE		PL011_UART1_BASE
 
 	/* ---------------------------------------------
 	 * int plat_crash_console_init(void)
@@ -210,7 +210,7 @@ func platform_is_primary_cpu
 	 */
 func plat_crash_console_init
 	mov_imm	x0, FVP_CRASH_CONSOLE_BASE
-	mov_imm	x1, PL011_UART0_CLK_IN_HZ
+	mov_imm	x1, PL011_UART1_CLK_IN_HZ
 	mov_imm	x2, PL011_BAUDRATE
 	b	console_core_init
 

--- a/plat/juno/aarch64/plat_helpers.S
+++ b/plat/juno/aarch64/plat_helpers.S
@@ -44,7 +44,7 @@
 	.globl	platform_mem_init
 
 	/* Define a crash console for the plaform */
-#define JUNO_CRASH_CONSOLE_BASE		PL011_UART0_BASE
+#define JUNO_CRASH_CONSOLE_BASE		PL011_UART3_BASE
 
 	/* ---------------------------------------------
 	 * int plat_crash_console_init(void)
@@ -55,7 +55,7 @@
 	 */
 func plat_crash_console_init
 	mov_imm	x0, JUNO_CRASH_CONSOLE_BASE
-	mov_imm	x1, PL011_UART0_CLK_IN_HZ
+	mov_imm	x1, PL011_UART3_CLK_IN_HZ
 	mov_imm	x2, PL011_BAUDRATE
 	b	console_core_init
 


### PR DESCRIPTION
This patch reassigns the crash console on Juno and FVP to use the runtime
BL3-1 console. The crash console is changed to SoC UART0 (UART2) from the
previous FPGA UART0 (UART0) on Juno. In FVP, it is changed from UART0 to
UART1.

Fixes ARM-software/tf-issues#256

Change-Id: I7df54f86ca00ec2652c27261dd66a94c12610816
