### PR TITLE
Precede a 'sev' with a 'dsb' in bakery lock code

### DIFF
--- a/lib/locks/bakery/bakery_lock.c
+++ b/lib/locks/bakery/bakery_lock.c
@@ -107,6 +107,7 @@ static unsigned int bakery_get_ticket(bakery_lock_t *bakery, unsigned int me)
 	++my_ticket;
 	bakery->number[me] = my_ticket;
 	bakery->entering[me] = 0;
+	dsb();
 	sev();
 
 	return my_ticket;
@@ -189,5 +190,6 @@ void bakery_lock_release(bakery_lock_t *bakery)
 	 */
 	bakery->owner = NO_OWNER;
 	bakery->number[me] = 0;
+	dsb();
 	sev();
 }


### PR DESCRIPTION
This patch fixes a bug in the bakery lock implementation where a data
synchronisation barrier instruction is not issued before sending an event as
mandated by the ARMv8 ARM. This can cause a event to be signalled before the
related memory accesses have completed resulting in erroneous execution.

Fixes ARM-software/tf-issues#272

Change-Id: I5ce02bf70afb001d967b9fa4c3f77442931d5349
