### PR TITLE
Fix problem of dependencies on the fiptool makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,11 +290,9 @@ checkpatch:		locate-checkpatch
 			@echo "  CHECKING STYLE"
 			@git format-patch --stdout ${BASE_COMMIT} | ${CHECKPATCH} ${CHECKPATCH_ARGS} - || true
 
+.PHONY: ${FIPTOOL}
 ${FIPTOOL}:
 			${Q}${MAKE} --no-print-directory -C ${FIPTOOLPATH}
-			@echo
-			@echo "Built $@ successfully"
-			@echo
 
 define match_goals
 $(strip $(foreach goal,$(1),$(filter $(goal),$(MAKECMDGOALS))))

--- a/tools/fip_create/Makefile
+++ b/tools/fip_create/Makefile
@@ -52,6 +52,9 @@ all: ${PROJECT}
 ${PROJECT}: ${OBJECTS} Makefile
 	@echo "  LD      $@"
 	${Q}${CC} ${OBJECTS} -o $@
+	@echo
+	@echo "Built $@ successfully"
+	@echo
 
 %.o: %.c %.h Makefile
 	@echo "  CC      $<"


### PR DESCRIPTION
The 'fiptool' target doesn't depend on fip_create's source files,
neither directly nor indirectly. As a result, the FIP tool is not
rebuilt whenever its source files change.

This patch makes the ${FIPTOOL} target into a phony target so that the
FIP tool's sub-makefile is always called. The sub-makefile correctly
handles the dependencies. It also moves the completion message into
the sub-makefile so that it is only displayed when the tool is
actually recompiled.

Fixes ARM-software/tf-issues#278

Change-Id: Ia027519fe51d3c42be30665d1ad20a7b89fa350f
