### PR TITLE
Fix the array size of mpidr_aff_map_nodes_t.

### DIFF
--- a/include/lib/aarch64/arch.h
+++ b/include/lib/aarch64/arch.h
@@ -61,7 +61,11 @@
 #define MPIDR_AFFLVL1		1
 #define MPIDR_AFFLVL2		2
 #define MPIDR_AFFLVL3		3
-/* TODO: Support only the first 3 affinity levels for now */
+/*
+ * The MPIDR_MAX_AFFLVL count starts from 0. Take care to
+ * add one while using this macro to define array sizes.
+ * TODO: Support only the first 3 affinity levels for now.
+ */
 #define MPIDR_MAX_AFFLVL	2
 
 /* Constant to highlight the assumption that MPIDR allocation starts from 0 */

--- a/services/std_svc/psci/psci_private.h
+++ b/services/std_svc/psci/psci_private.h
@@ -60,7 +60,7 @@ typedef struct aff_limits_node {
 	int max;
 } aff_limits_node_t;
 
-typedef aff_map_node_t (*mpidr_aff_map_nodes_t[MPIDR_MAX_AFFLVL]);
+typedef aff_map_node_t (*mpidr_aff_map_nodes_t[MPIDR_MAX_AFFLVL + 1]);
 typedef unsigned int (*afflvl_power_on_finisher_t)(aff_map_node_t *);
 
 /*******************************************************************************


### PR DESCRIPTION
This patch fixes the array size of mpidr_aff_map_nodes_t which
was less by one element.

Fixes ARM-software/tf-issues#264

Change-Id: I48264f6f9e7046a3d0f4cbcd63b9ba49657e8818
