### PR TITLE
Remove IRQ_SEC_SGI_8 constant

### DIFF
--- a/plat/fvp/fvp_def.h
+++ b/plat/fvp/fvp_def.h
@@ -209,7 +209,6 @@
 #define IRQ_SEC_SGI_5			13
 #define IRQ_SEC_SGI_6			14
 #define IRQ_SEC_SGI_7			15
-#define IRQ_SEC_SGI_8			16
 
 /*******************************************************************************
  * PL011 related constants

--- a/plat/juno/juno_def.h
+++ b/plat/juno/juno_def.h
@@ -143,7 +143,6 @@
 #define IRQ_SEC_SGI_5			13
 #define IRQ_SEC_SGI_6			14
 #define IRQ_SEC_SGI_7			15
-#define IRQ_SEC_SGI_8			16
 
 /*******************************************************************************
  * PL011 related constants


### PR DESCRIPTION
In both FVP and Juno ports, IRQ #16, which is a PPI, is incorrectly
identified as secure SGI #8 through the constant IRQ_SEC_SGI_8.
This patch removes it.

Fixes ARM-software/tf-issues#282
