### PR TITLE
fip_create: don't succeed if one of the passed files doesn't exist

### DIFF
--- a/tools/fip_create/fip_create.c
+++ b/tools/fip_create/fip_create.c
@@ -543,7 +543,7 @@ static int parse_cmdline(int argc, char **argv, struct option *options,
 					if (status != 0) {
 						printf("Failed to process %s\n",
 						       options[option_index].name);
-						break;
+						return status;
 					} else {
 						/* Update package */
 						*do_pack = 1;


### PR DESCRIPTION
If one of the files passed to fip_create on the command line doesn't
exist, it will print an error message but produce an incomplete
fip.bin file and report success. This behaviour could potentially
hide errors made in the command line arguments.

This patch addresses the issue by having the tool bail out if one of
the supplied files can't be processed.

Signed-off-by: Kévin Petit kevin.petit@arm.com

Fixes ARM-software/tf-issues#279
