### PR TITLE
Bug fix: initialize bl30_image_info fields before use

### DIFF
--- a/bl2/bl2_main.c
+++ b/bl2/bl2_main.c
@@ -61,6 +61,7 @@ static int load_bl30(void)
 	 */
 	INFO("BL2: Loading BL3-0\n");
 	bl2_plat_get_bl30_meminfo(&bl30_mem_info);
+	bl30_image_info.h.version = VERSION_1;
 	e = load_image(&bl30_mem_info,
 		       BL30_IMAGE_NAME,
 		       BL30_BASE,


### PR DESCRIPTION
This patch initializes the version field in the bl30_image_info
structure when loading BL30. This initialization must be done before
calling load_image().

Fixes ARM-software/tf-issues#274

Change-Id: I74a05167d66fff51d257ad611abc7b5436e5d912