### PR TITLE
User Guide: Enable secure memory on Foundation FVP

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -697,7 +697,7 @@ Trusted Firmware" section above).
 
     <path-to>/Foundation_v8                   \
     --cores=4                                 \
-    --no-secure-memory                        \
+    --secure-memory                           \
     --visualization                           \
     --gicv3                                   \
     --data="<path-to>/<bl1-binary>"@0x0       \
@@ -900,7 +900,7 @@ legacy VE memory map:
 
     <path-to>/Foundation_v8                   \
     --cores=4                                 \
-    --no-secure-memory                        \
+    --secure-memory                           \
     --visualization                           \
     --no-gicv3                                \
     --data="<path-to>/<bl1-binary>"@0x0       \


### PR DESCRIPTION
Previously, the User Guide recommended launching the Foundation
FVP with the parameter --no-secure-memory, which disabled security
control of the address map. This was due to missing support for
secure memory regions in v1 of the Foundation FVP. This is no longer
needed as secure memory is now supported on the Foundation FVP.

This patch updates the User Guide to recommend enabling secure
memory instead.
