### PR TITLE
Specify FIP filename at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,8 @@ ARM_GIC_ARCH		:=	2
 # Flag used to indicate if ASM_ASSERTION should be enabled for the build.
 # This defaults to being present in DEBUG builds only.
 ASM_ASSERTION		:=	${DEBUG}
+# Default FIP file name
+FIP_NAME		:= fip.bin
 
 # Checkpatch ignores
 CHECK_IGNORE		=	--ignore COMPLEX_MACRO
@@ -256,7 +258,7 @@ PP			:=	${CROSS_COMPILE}gcc -E ${CFLAGS}
 FIPTOOLPATH		?=	tools/fip_create
 FIPTOOL			?=	${FIPTOOLPATH}/fip_create
 fiptool:		${FIPTOOL}
-fip:			${BUILD_PLAT}/fip.bin
+fip:			${BUILD_PLAT}/${FIP_NAME}
 
 locate-checkpatch:
 ifndef CHECKPATCH
@@ -485,7 +487,7 @@ check_bl33:
 endif
 
 
-${BUILD_PLAT}/fip.bin: ${FIP_DEPS} ${FIPTOOL} check_bl30 check_bl33
+${BUILD_PLAT}/${FIP_NAME}: ${FIP_DEPS} ${FIPTOOL} check_bl30 check_bl33
 			${Q}${FIPTOOL} --dump \
 				${FIP_ARGS} \
 				$@

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -176,6 +176,9 @@ performed.
     BL3-2 image for the `fip` target. In this case, the BL3-2 in the ARM
     Trusted Firmware will not be built.
 
+*   `FIP_NAME`: This is an optional build option which specifies the FIP
+    filename for the `fip` target. Default is `fip.bin`.
+
 *   `CROSS_COMPILE`: Prefix to toolchain binaries. Please refer to examples in
     this document for usage.
 


### PR DESCRIPTION
This patch allows to define the name of the FIP at build time by
defining the FIP_NAME variable. If FIP_NAME is not defined, default
name 'fip.bin' is used.

Documentation updated accordingly.

Change-Id: Ic41f42aac379b0c958b3dfd02863ba8ba7108710