### PR TITLE
Juno: Add support for image overlaying in Trusted SRAM

### DIFF
--- a/plat/juno/juno_def.h
+++ b/plat/juno/juno_def.h
@@ -37,6 +37,21 @@
 /*******************************************************************************
  * Juno memory map related constants
  ******************************************************************************/
+#define FLASH_BASE		0x08000000
+#define FLASH_SIZE		0x04000000
+
+/* Bypass offset from start of NOR flash */
+#define BL1_ROM_BYPASS_OFFSET	0x03EC0000
+
+#ifndef TZROM_BASE
+/* Use the bypass address */
+#define TZROM_BASE		FLASH_BASE + BL1_ROM_BYPASS_OFFSET
+#endif
+#define TZROM_SIZE		0x00010000
+
+#define TZRAM_BASE		0x04001000
+#define TZRAM_SIZE		0x0003F000
+
 #define PLAT_TRUSTED_SRAM_ID	0
 #define PLAT_DRAM_ID		1
 


### PR DESCRIPTION
This patch allows the BL3-1 NOBITS section to overlap the BL1 R/W
section since the former will always be used after the latter.
Similarly, the BL3-2 NOBITS section can overlay the BL2 image
when BL3-2 is loaded in Trusted SRAM.

Due to the current size of the images, there is no actual overlap.
Nevertheless, this reorganization may help to optimise the Trusted
SRAM usage when the images size grows.

Note that because BL3-1 NOBITS section is allowed to overlap the
BL1 R/W section, BL1 global variables will remain valid only until
execution reaches the BL3-1 entry point during a cold boot.

Documentation updated accordingly.

Fixes ARM-software/tf-issues#254

Change-Id: Id538f4d1c7f1f7858108280fd7b97e138572b879