### PR TITLE
Fix model command line for legacy VE memory map

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1038,6 +1038,7 @@ legacy VE memory map. They must added to the parameters described in the
     -C cluster1.gic.GICV-offset=0x6000                  \
     -C cluster1.gic.PERIPH-size=0x8000                  \
     -C gic_distributor.GICD-alias=0x2c001000            \
+    -C gicv3.gicv2-only=1                               \
     -C bp.variant=0x0
 
 The `bp.variant` parameter corresponds to the build variant field of the


### PR DESCRIPTION
The command line options specified in the User Guide to run the AEMv8 Base FVP
with the legacy VE memory map apply only when the model is configured to use GIC
v2.0. This patch adds the 'gicv3.gicv2-only=1' to the command line to ensure
that the right version of GIC is used.

Change-Id: I34c44e19fd42c29818b734ac8f6aa9bf97b4e891