### PR TITLE
Minimize MAX_MMAP_REGIONS for each BL stage

### DIFF
--- a/plat/fvp/aarch64/fvp_common.c
+++ b/plat/fvp/aarch64/fvp_common.c
@@ -115,6 +115,9 @@ const mmap_region_t fvp_mmap[] = {
 };
 #endif
 
+CASSERT((sizeof(fvp_mmap)/sizeof(fvp_mmap[0])) + FVP_BL_REGIONS \
+		<= MAX_MMAP_REGIONS, assert_max_mmap_regions);
+
 /* Array of secure interrupts to be configured by the gic driver */
 const unsigned int irq_sec_array[] = {
 	IRQ_TZ_WDOG,

--- a/plat/fvp/fvp_def.h
+++ b/plat/fvp/fvp_def.h
@@ -150,6 +150,33 @@
 #define FUNC_SHUTDOWN		0x08
 #define FUNC_REBOOT		0x09
 
+/*
+ * The number of regions like RO(code), coherent and data required by
+ * different BL stages which need to be mapped in the MMU.
+ */
+#if USE_COHERENT_MEM
+#define FVP_BL_REGIONS		3
+#else
+#define FVP_BL_REGIONS		2
+#endif
+
+/*
+ * The FVP_MAX_MMAP_REGIONS depend on the number of entries in fvp_mmap[]
+ * defined for each BL stage in fvp_common.c.
+ */
+#if IMAGE_BL1
+#define FVP_MMAP_ENTRIES		5
+#endif
+#if IMAGE_BL2
+#define FVP_MMAP_ENTRIES		7
+#endif
+#if IMAGE_BL31
+#define FVP_MMAP_ENTRIES		4
+#endif
+#if IMAGE_BL32
+#define FVP_MMAP_ENTRIES		3
+#endif
+
 /* Load address of BL33 in the FVP port */
 #define NS_IMAGE_OFFSET		(DRAM1_BASE + 0x8000000) /* DRAM + 128MB */
 

--- a/plat/fvp/include/platform_def.h
+++ b/plat/fvp/include/platform_def.h
@@ -208,7 +208,7 @@
 # endif
 #endif
 
-#define MAX_MMAP_REGIONS		16
+#define MAX_MMAP_REGIONS		(FVP_MMAP_ENTRIES + FVP_BL_REGIONS)
 
 /*******************************************************************************
  * Declarations and constants to access the mailboxes safely. Each mailbox is

--- a/plat/juno/aarch64/juno_common.c
+++ b/plat/juno/aarch64/juno_common.c
@@ -114,6 +114,9 @@ static const mmap_region_t juno_mmap[] = {
 };
 #endif
 
+CASSERT((sizeof(juno_mmap)/sizeof(juno_mmap[0])) + JUNO_BL_REGIONS \
+		<= MAX_MMAP_REGIONS, assert_max_mmap_regions);
+
 /* Array of secure interrupts to be configured by the gic driver */
 const unsigned int irq_sec_array[] = {
 	IRQ_MHU,

--- a/plat/juno/include/platform_def.h
+++ b/plat/juno/include/platform_def.h
@@ -183,7 +183,7 @@
 # define MAX_XLAT_TABLES		3
 #endif
 
-#define MAX_MMAP_REGIONS		16
+#define MAX_MMAP_REGIONS		(JUNO_MMAP_ENTRIES + JUNO_BL_REGIONS)
 
 /*******************************************************************************
  * ID of the secure physical generic timer interrupt used by the TSP

--- a/plat/juno/juno_def.h
+++ b/plat/juno/juno_def.h
@@ -140,6 +140,33 @@
 #define SYS_LED_EL_SHIFT		0x1
 #define SYS_LED_EC_SHIFT		0x3
 
+/*
+ * The number of regions like RO(code), coherent and data required by
+ * different BL stages which need to be mapped in the MMU.
+ */
+#if USE_COHERENT_MEM
+#define JUNO_BL_REGIONS		3
+#else
+#define JUNO_BL_REGIONS		2
+#endif
+
+/*
+ * The JUNO_MAX_MMAP_REGIONS depend on the number of entries in juno_mmap[]
+ * defined for each BL stage in juno_common.c.
+ */
+#if IMAGE_BL1
+#define JUNO_MMAP_ENTRIES		6
+#endif
+#if IMAGE_BL2
+#define JUNO_MMAP_ENTRIES		8
+#endif
+#if IMAGE_BL31
+#define JUNO_MMAP_ENTRIES		5
+#endif
+#if IMAGE_BL32
+#define JUNO_MMAP_ENTRIES		4
+#endif
+
 /*******************************************************************************
  * GIC-400 & interrupt handling related constants
  ******************************************************************************/


### PR DESCRIPTION
This patch defines MAX_MMAP_REGIONS separately for each BL stage
as per its requirements. This minimizes the size of the mmap[]
array.

Fixes ARM-Software/tf-issues#201

Change-Id: I19b15e1a91a8365b2ecf24e2cd71937cb73916b2