### PR TITLE
Juno: clear DMA-330 SMMU security state

### DIFF
--- a/plat/juno/juno_def.h
+++ b/plat/juno/juno_def.h
@@ -244,4 +244,10 @@
 #define PRIMARY_CPU_SHIFT	8
 #define PRIMARY_CPU_MASK	0xf
 
+/*******************************************************************************
+ * MMU-401 related constants
+ ******************************************************************************/
+#define MMU401_SSD_OFFSET	0x4000
+#define MMU401_DMA330_BASE	0x7fb00000
+
 #endif /* __JUNO_DEF_H__ */

--- a/plat/juno/plat_security.c
+++ b/plat/juno/plat_security.c
@@ -29,6 +29,7 @@
  */
 
 #include <debug.h>
+#include <mmio.h>
 #include <tzc400.h>
 #include "juno_def.h"
 
@@ -94,6 +95,19 @@ static void init_tzc400(void)
 }
 
 /*******************************************************************************
+ * Set up the MMU-401 SSD tables. The power-on configuration has all stream IDs
+ * assigned to Non-Secure except some for the DMA-330. Assign those back to the
+ * Non-Secure world as well, otherwise EL1 may end up erroneously generating
+ * (untranslated) Secure transactions if it turns the SMMU on.
+ ******************************************************************************/
+static void init_mmu401(void)
+{
+	uint32_t reg = mmio_read_32(MMU401_DMA330_BASE + MMU401_SSD_OFFSET);
+	reg |= 0x1FF;
+	mmio_write_32(MMU401_DMA330_BASE + MMU401_SSD_OFFSET, reg);
+}
+
+/*******************************************************************************
  * Initialize the secure environment. At this moment only the TrustZone
  * Controller is initialized.
  ******************************************************************************/
@@ -101,4 +115,6 @@ void plat_security_setup(void)
 {
 	/* Initialize the TrustZone Controller */
 	init_tzc400();
+	/* Initialize the SMMU SSD tables*/
+	init_mmu401();
 }


### PR DESCRIPTION
By default the SMMU for the DMA-330 is configured to mark some stream IDs
as always belonging to the Secure world. As a result, if EL1 software turns
the SMMU on, certain Non-Secure accesses get rewritten as Secure, making
them bypass translation and access Secure physical addresses directly.

Since the current Juno board firmware configures the DMA-330 hardware as
Non-Secure, rewrite the SMMU's default SSD table as well to prevent any
unexpected behaviour in EL1.

Change-Id: Iaa81d883eecf28d80eb182b9ce475684bf9c718c