### PR TITLE
Ignore C library files when checking coding style

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,10 +77,12 @@ TRUSTED_BOARD_BOOT	:= 0
 AUTH_MOD		:= none
 
 # Checkpatch ignores
-CHECK_IGNORE		=	--ignore COMPLEX_MACRO
+CHECK_IGNORE		=	--ignore COMPLEX_MACRO --ignore GERRIT_CHANGE_ID
 
 CHECKPATCH_ARGS		=	--no-tree --no-signoff ${CHECK_IGNORE}
 CHECKCODE_ARGS		=	--no-patch --no-tree --no-signoff ${CHECK_IGNORE}
+# Do not check the coding style on C library files
+CHECK_PATHS		=	$(shell ls -I include -I lib) $(shell ls -I stdlib include) $(shell ls -I stdlib lib)
 
 ifeq (${V},0)
 	Q=@
@@ -361,7 +363,7 @@ checkcodebase:		locate-checkpatch
 
 checkpatch:		locate-checkpatch
 			@echo "  CHECKING STYLE"
-			@git format-patch --stdout ${BASE_COMMIT} | ${CHECKPATCH} ${CHECKPATCH_ARGS} - || true
+			@git log -p ${BASE_COMMIT}..HEAD -- ${CHECK_PATHS} | ${CHECKPATCH} ${CHECKPATCH_ARGS} - || true
 
 .PHONY: ${CRTTOOL}
 ${CRTTOOL}:

--- a/common/tf_printf.c
+++ b/common/tf_printf.c
@@ -38,7 +38,7 @@ static void unsigned_num_print(unsigned long int unum, unsigned int radix)
 {
 	/* Just need enough space to store 64 bit decimal integer */
 	unsigned char num_buf[20];
-	int i = 0 , rem;
+	int i = 0, rem;
 
 	do {
 		rem = unum % radix;

--- a/plat/fvp/fvp_pm.c
+++ b/plat/fvp/fvp_pm.c
@@ -64,7 +64,7 @@ static void fvp_program_mailbox(uint64_t mpidr, uint64_t address)
  * Function which implements the common FVP specific operations to power down a
  * cpu in response to a CPU_OFF or CPU_SUSPEND request.
  ******************************************************************************/
-static void fvp_cpu_pwrdwn_common()
+static void fvp_cpu_pwrdwn_common(void)
 {
 	/* Prevent interrupts from spuriously waking up this cpu */
 	arm_gic_cpuif_deactivate();
@@ -77,7 +77,7 @@ static void fvp_cpu_pwrdwn_common()
  * Function which implements the common FVP specific operations to power down a
  * cluster in response to a CPU_OFF or CPU_SUSPEND request.
  ******************************************************************************/
-static void fvp_cluster_pwrdwn_common()
+static void fvp_cluster_pwrdwn_common(void)
 {
 	uint64_t mpidr = read_mpidr_el1();
 

--- a/plat/juno/bl31_plat_setup.c
+++ b/plat/juno/bl31_plat_setup.c
@@ -182,7 +182,7 @@ void bl31_platform_setup(void)
  * Perform the very early platform specific architectural setup here. At the
  * moment this is only intializes the mmu in a quick and dirty way.
  ******************************************************************************/
-void bl31_plat_arch_setup()
+void bl31_plat_arch_setup(void)
 {
 	configure_mmu_el3(BL31_RO_BASE,
 			  (BL31_END - BL31_RO_BASE),

--- a/plat/juno/plat_topology.c
+++ b/plat/juno/plat_topology.c
@@ -48,7 +48,7 @@ unsigned int plat_get_aff_state(unsigned int aff_lvl, unsigned long mpidr)
 	return aff_lvl <= MPIDR_AFFLVL1 ? PSCI_AFF_PRESENT : PSCI_AFF_ABSENT;
 }
 
-int plat_setup_topology()
+int plat_setup_topology(void)
 {
 	/* Juno todo: Make topology configurable via SCC */
 	return 0;

--- a/services/std_svc/psci/psci_afflvl_suspend.c
+++ b/services/std_svc/psci/psci_afflvl_suspend.c
@@ -58,7 +58,7 @@ void psci_set_suspend_power_state(unsigned int power_state)
  * powered down during a cpu_suspend call. Returns PSCI_INVALID_DATA if the
  * power state is invalid.
  ******************************************************************************/
-int psci_get_suspend_afflvl()
+int psci_get_suspend_afflvl(void)
 {
 	unsigned int power_state;
 
@@ -73,7 +73,7 @@ int psci_get_suspend_afflvl()
  * parameter saved in the per-cpu data array. Returns PSCI_INVALID_DATA if the
  * power state saved is invalid.
  ******************************************************************************/
-int psci_get_suspend_stateid()
+int psci_get_suspend_stateid(void)
 {
 	unsigned int power_state;
 

--- a/services/std_svc/psci/psci_common.c
+++ b/services/std_svc/psci/psci_common.c
@@ -133,7 +133,7 @@ uint32_t psci_get_max_phys_off_afflvl(void)
  * been physically powered up. It is expected to be called immediately after
  * reset from assembler code.
  ******************************************************************************/
-int get_power_on_target_afflvl()
+int get_power_on_target_afflvl(void)
 {
 	int afflvl;
 


### PR DESCRIPTION
The C library source files embedded into the Trusted Firmware
tree are not required to comply to the Linux Coding Style.
Unfortunately, 'make checkpatch' does take them into account.

This patch modifies the Makefile so that the C library source
and header files are now ignored by 'make checkpatch'.

It also instructs the checkpatch.pl script to not treat the
presence of a 'Change-Id' line in the commit message as an error.
