### PR TITLE
Enable type-checking of arguments passed to printf() et al.

### DIFF
--- a/bl31/runtime_svc.c
+++ b/bl31/runtime_svc.c
@@ -103,8 +103,8 @@ void runtime_svc_init(void)
 		 */
 		rc = validate_rt_svc_desc(&rt_svc_descs[index]);
 		if (rc) {
-			ERROR("Invalid runtime service descriptor 0x%x (%s)\n",
-					&rt_svc_descs[index],
+			ERROR("Invalid runtime service descriptor 0x%lx (%s)\n",
+					(uintptr_t) &rt_svc_descs[index],
 					rt_svc_descs[index].name);
 			goto error;
 		}

--- a/bl32/tsp/tsp_main.c
+++ b/bl32/tsp/tsp_main.c
@@ -109,9 +109,9 @@ uint64_t tsp_main(void)
 {
 	NOTICE("TSP: %s\n", version_string);
 	NOTICE("TSP: %s\n", build_message);
-	INFO("TSP: Total memory base : 0x%x\n", (unsigned long)BL32_TOTAL_BASE);
-	INFO("TSP: Total memory size : 0x%x bytes\n",
-			 (unsigned long)(BL32_TOTAL_LIMIT - BL32_TOTAL_BASE));
+	INFO("TSP: Total memory base : 0x%lx\n", BL32_TOTAL_BASE);
+	INFO("TSP: Total memory size : 0x%lx bytes\n",
+			 BL32_TOTAL_LIMIT - BL32_TOTAL_BASE);
 
 	uint64_t mpidr = read_mpidr();
 	uint32_t linear_id = platform_get_core_pos(mpidr);
@@ -129,7 +129,7 @@ uint64_t tsp_main(void)
 
 #if LOG_LEVEL >= LOG_LEVEL_INFO
 	spin_lock(&console_lock);
-	INFO("TSP: cpu 0x%x: %d smcs, %d erets %d cpu on requests\n", mpidr,
+	INFO("TSP: cpu 0x%lx: %d smcs, %d erets %d cpu on requests\n", mpidr,
 	     tsp_stats[linear_id].smc_count,
 	     tsp_stats[linear_id].eret_count,
 	     tsp_stats[linear_id].cpu_on_count);
@@ -158,8 +158,8 @@ tsp_args_t *tsp_cpu_on_main(void)
 
 #if LOG_LEVEL >= LOG_LEVEL_INFO
 	spin_lock(&console_lock);
-	INFO("TSP: cpu 0x%x turned on\n", mpidr);
-	INFO("TSP: cpu 0x%x: %d smcs, %d erets %d cpu on requests\n", mpidr,
+	INFO("TSP: cpu 0x%lx turned on\n", mpidr);
+	INFO("TSP: cpu 0x%lx: %d smcs, %d erets %d cpu on requests\n", mpidr,
 		tsp_stats[linear_id].smc_count,
 		tsp_stats[linear_id].eret_count,
 		tsp_stats[linear_id].cpu_on_count);
@@ -199,8 +199,8 @@ tsp_args_t *tsp_cpu_off_main(uint64_t arg0,
 
 #if LOG_LEVEL >= LOG_LEVEL_INFO
 	spin_lock(&console_lock);
-	INFO("TSP: cpu 0x%x off request\n", mpidr);
-	INFO("TSP: cpu 0x%x: %d smcs, %d erets %d cpu off requests\n", mpidr,
+	INFO("TSP: cpu 0x%lx off request\n", mpidr);
+	INFO("TSP: cpu 0x%lx: %d smcs, %d erets %d cpu off requests\n", mpidr,
 		tsp_stats[linear_id].smc_count,
 		tsp_stats[linear_id].eret_count,
 		tsp_stats[linear_id].cpu_off_count);
@@ -242,7 +242,7 @@ tsp_args_t *tsp_cpu_suspend_main(uint64_t arg0,
 
 #if LOG_LEVEL >= LOG_LEVEL_INFO
 	spin_lock(&console_lock);
-	INFO("TSP: cpu 0x%x: %d smcs, %d erets %d cpu suspend requests\n",
+	INFO("TSP: cpu 0x%lx: %d smcs, %d erets %d cpu suspend requests\n",
 		mpidr,
 		tsp_stats[linear_id].smc_count,
 		tsp_stats[linear_id].eret_count,
@@ -281,9 +281,9 @@ tsp_args_t *tsp_cpu_resume_main(uint64_t suspend_level,
 
 #if LOG_LEVEL >= LOG_LEVEL_INFO
 	spin_lock(&console_lock);
-	INFO("TSP: cpu 0x%x resumed. suspend level %d\n",
+	INFO("TSP: cpu 0x%lx resumed. suspend level %ld\n",
 		mpidr, suspend_level);
-	INFO("TSP: cpu 0x%x: %d smcs, %d erets %d cpu suspend requests\n",
+	INFO("TSP: cpu 0x%lx: %d smcs, %d erets %d cpu suspend requests\n",
 		mpidr,
 		tsp_stats[linear_id].smc_count,
 		tsp_stats[linear_id].eret_count,
@@ -316,8 +316,8 @@ tsp_args_t *tsp_system_off_main(uint64_t arg0,
 
 #if LOG_LEVEL >= LOG_LEVEL_INFO
 	spin_lock(&console_lock);
-	INFO("TSP: cpu 0x%x SYSTEM_OFF request\n", mpidr);
-	INFO("TSP: cpu 0x%x: %d smcs, %d erets requests\n", mpidr,
+	INFO("TSP: cpu 0x%lx SYSTEM_OFF request\n", mpidr);
+	INFO("TSP: cpu 0x%lx: %d smcs, %d erets requests\n", mpidr,
 	     tsp_stats[linear_id].smc_count,
 	     tsp_stats[linear_id].eret_count);
 	spin_unlock(&console_lock);
@@ -349,8 +349,8 @@ tsp_args_t *tsp_system_reset_main(uint64_t arg0,
 
 #if LOG_LEVEL >= LOG_LEVEL_INFO
 	spin_lock(&console_lock);
-	INFO("TSP: cpu 0x%x SYSTEM_RESET request\n", mpidr);
-	INFO("TSP: cpu 0x%x: %d smcs, %d erets requests\n", mpidr,
+	INFO("TSP: cpu 0x%lx SYSTEM_RESET request\n", mpidr);
+	INFO("TSP: cpu 0x%lx: %d smcs, %d erets requests\n", mpidr,
 	     tsp_stats[linear_id].smc_count,
 	     tsp_stats[linear_id].eret_count);
 	spin_unlock(&console_lock);
@@ -384,10 +384,10 @@ tsp_args_t *tsp_smc_handler(uint64_t func,
 	tsp_stats[linear_id].smc_count++;
 	tsp_stats[linear_id].eret_count++;
 
-	INFO("TSP: cpu 0x%x received %s smc 0x%x\n", read_mpidr(),
+	INFO("TSP: cpu 0x%lx received %s smc 0x%lx\n", mpidr,
 		((func >> 31) & 1) == 1 ? "fast" : "standard",
 		func);
-	INFO("TSP: cpu 0x%x: %d smcs, %d erets\n", mpidr,
+	INFO("TSP: cpu 0x%lx: %d smcs, %d erets\n", mpidr,
 		tsp_stats[linear_id].smc_count,
 		tsp_stats[linear_id].eret_count);
 

--- a/include/common/debug.h
+++ b/include/common/debug.h
@@ -84,6 +84,6 @@
 void __dead2 do_panic(void);
 #define panic()	do_panic()
 
-void tf_printf(const char *fmt, ...);
+void tf_printf(const char *fmt, ...) __printflike(1, 2);
 
 #endif /* __DEBUG_H__ */

--- a/include/stdlib/stdio.h
+++ b/include/stdlib/stdio.h
@@ -58,12 +58,13 @@ typedef	__ssize_t	ssize_t;
 
 #define	EOF	(-1)
 
-int	 printf(const char * __restrict, ...);
+int	 printf(const char * __restrict, ...) __printflike(1, 2);
 int	 putchar(int);
 int	 puts(const char *);
-int	 sprintf(char * __restrict, const char * __restrict, ...);
+int	 sprintf(char * __restrict, const char * __restrict, ...)
+	__printflike(2, 3);
 int	 vsprintf(char * __restrict, const char * __restrict,
-	   __va_list);
+	   __va_list) __printflike(2, 0);
 
 int	 sscanf(const char *__restrict, char const *__restrict, ...);
 

--- a/plat/juno/bl1_plat_setup.c
+++ b/plat/juno/bl1_plat_setup.c
@@ -99,7 +99,7 @@ void bl1_early_platform_setup(void)
 		    BL1_RAM_BASE,
 		    bl1_size);
 
-	INFO("BL1: 0x%lx - 0x%lx [size = %u]\n", BL1_RAM_BASE, BL1_RAM_LIMIT,
+	INFO("BL1: 0x%lx - 0x%lx [size = %lu]\n", BL1_RAM_BASE, BL1_RAM_LIMIT,
 	     bl1_size);
 }
 


### PR DESCRIPTION
This patch modifies the declarations of the functions printf() et al.
and adds the right GCC attribute to request the compiler to check
the type of the arguments passed to these functions against the given
format string. This will ensure that the compiler outputs warning
messages like the following whenever it detects an inconsistency:

 file.c:42: warning: format ‘%d’ expects type ‘int’, but argument 3 has type ‘long int’

It also fixes the type mismatch inconsistencies that it revealed
across the code base.

NOTE: THIS PATCH MAY FORCE PLATFORM PORTS OR SP/SPDS THAT USE THE
PRINTF FAMILY OF FUNCTIONS TO FIX ANY TYPE MISMATCH INCONSISTENCIES.
