### PR TITLE
TBB: fix build target 'all' dependency on certificates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -600,7 +600,7 @@ endif
 
 # Add the dependency on the certificates
 ifneq (${GENERATE_COT},0)
-    all: certificates
+    fip: certificates
 endif
 
 certificates: ${CRT_DEPS} ${CRTTOOL} check_bl30 check_bl33


### PR DESCRIPTION
Build target 'all' fails when GENERATE_COT=1 and no BL3-3 or
BL3-0 (if required) images are specified. The reason is that,
when GENERATE_COT=1, a dependency on the certificates is added
to the target 'all', and the certificates depend on the BL3-3
and BL3-0 images, causing the build process to fail if the
images are not specified.

This patch moves the dependency on the certificates from 'all' to
'fip'. Target 'all' may be used to build the individual images.
The certificates will be created by calling the target 'fip', where
BL3-3 and BL3-0 (if required) must be specified.

Change-Id: I870beb4e8f9f1bfad1d35b09c850a7ce3c9f4ec6