### PR TITLE
checkpatch: ignore GIT_COMMIT_ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,9 @@ TRUSTED_BOARD_BOOT	:= 0
 AUTH_MOD		:= none
 
 # Checkpatch ignores
-CHECK_IGNORE		=	--ignore COMPLEX_MACRO --ignore GERRIT_CHANGE_ID
+CHECK_IGNORE		=	--ignore COMPLEX_MACRO \
+				--ignore GERRIT_CHANGE_ID \
+				--ignore GIT_COMMIT_ID
 
 CHECKPATCH_ARGS		=	--no-tree --no-signoff ${CHECK_IGNORE}
 CHECKCODE_ARGS		=	--no-patch --no-tree --no-signoff ${CHECK_IGNORE}


### PR DESCRIPTION
By default, the checkpatch script requires that commit references
included in commit messages follow a predefined format. Github
merge commits do not follow this convention, causing the code
style test to fail when a new pull request is created.

This patch adds the ignore GIT_COMMIT_ID option to the checkpatch
parameters. This flag indicates the tool to ignore the commit
message format.

Change-Id: I37133cc5cf803f664b8ff00f62d458b39f06918c