### PR TITLE
Juno: Disable workaround for Cortex-A57 erratum #806969

### DIFF
--- a/plat/juno/platform.mk
+++ b/plat/juno/platform.mk
@@ -103,7 +103,7 @@ endif
 NEED_BL30		:=	yes
 
 # Enable workarounds for selected Cortex-A57 erratas.
-ERRATA_A57_806969	:=	1
+ERRATA_A57_806969	:=	0
 ERRATA_A57_813420	:=	1
 
 # Enable option to skip L1 data cache flush during the Cortex-A57 cluster


### PR DESCRIPTION
Cortex-A57 erratum #806969 applies to revision r0p0 of the CPU
but does not manifest itself on Juno r0. It is not applicable
to Juno r1 in any case.

This patch modifies the Juno platform Makefile to no longer
compile this erratum workaround in.
