### PR TITLE
Optimize the bakery lock implementation

### DIFF
--- a/include/lib/bakery_lock.h
+++ b/include/lib/bakery_lock.h
@@ -58,7 +58,6 @@
 #if USE_COHERENT_MEM
 
 typedef struct bakery_lock {
-	int owner;
 	/*
 	 * The lock_data is a bit-field of 2 members:
 	 * Bit[0]       : choosing. This field is set when the CPU is
@@ -67,8 +66,6 @@ typedef struct bakery_lock {
 	 */
 	volatile uint16_t lock_data[BAKERY_LOCK_MAX_CPUS];
 } bakery_lock_t;
-
-#define NO_OWNER (-1)
 
 void bakery_lock_init(bakery_lock_t *bakery);
 void bakery_lock_get(bakery_lock_t *bakery);


### PR DESCRIPTION
This patch-set applies several optimizations to bakery lock implementation that uses coherent memory. It also adds assertion checks to prevent recursive acquisition for the implementation that uses normal memory.