### PR TITLE
Pass arguments/results between EL3/S-EL1 via CPU registers (x0-x7)

### DIFF
--- a/include/bl32/payloads/tlk.h
+++ b/include/bl32/payloads/tlk.h
@@ -52,7 +52,6 @@
 #define TLK_PREEMPTED		(0x32000002 | (1 << 31))
 #define TLK_ENTRY_DONE		(0x32000003 | (1 << 31))
 #define TLK_VA_TRANSLATE	(0x32000004 | (1 << 31))
-#define TLK_FID_SHARED_MEMBUF	(0x32000005 | (1 << 31))
 
 /*
  * Trusted Application specific function IDs


### PR DESCRIPTION
This patch removes the need for a shared buffer between the EL3 and S-EL1
levels. We now use the CPU registers, x0-x7, while passing data between
the two levels. Since TLK is a 32-bit Trusted OS, tlkd has to unpack the
arguments in the x0-x7 registers. TLK in turn gets these values via r0-r7.

Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>