### PR TITLE
Add support to indicate size and end of assembly functions

### DIFF
--- a/bl1/aarch64/bl1_entrypoint.S
+++ b/bl1/aarch64/bl1_entrypoint.S
@@ -172,3 +172,4 @@ func bl1_entrypoint
 	bl	bl1_main
 panic:
 	b	panic
+endfunc bl1_entrypoint

--- a/bl2/aarch64/bl2_entrypoint.S
+++ b/bl2/aarch64/bl2_entrypoint.S
@@ -124,3 +124,4 @@ func bl2_entrypoint
 	bl	bl2_main
 _panic:
 	b	_panic
+endfunc bl2_entrypoint

--- a/bl31/aarch64/bl31_entrypoint.S
+++ b/bl31/aarch64/bl31_entrypoint.S
@@ -200,3 +200,4 @@ func bl31_entrypoint
 	bl	bl31_main
 
 	b	el3_exit
+endfunc bl31_entrypoint

--- a/bl31/aarch64/context.S
+++ b/bl31/aarch64/context.S
@@ -117,6 +117,7 @@ func el1_sysregs_context_save
 	str	x15, [x0, #CTX_FP_FPEXC32_EL2]
 
 	ret
+endfunc el1_sysregs_context_save
 
 /* -----------------------------------------------------
  * The following function strictly follows the AArch64
@@ -205,6 +206,7 @@ func el1_sysregs_context_restore
 	/* No explict ISB required here as ERET covers it */
 
 	ret
+endfunc el1_sysregs_context_restore
 
 /* -----------------------------------------------------
  * The following function follows the aapcs_64 strictly
@@ -249,6 +251,7 @@ func fpregs_context_save
 	str	x10, [x0, #CTX_FP_FPCR]
 
 	ret
+endfunc fpregs_context_save
 
 /* -----------------------------------------------------
  * The following function follows the aapcs_64 strictly
@@ -298,4 +301,5 @@ func fpregs_context_restore
 	 */
 
 	ret
+endfunc fpregs_context_restore
 #endif /* CTX_INCLUDE_FPREGS */

--- a/bl31/aarch64/cpu_data.S
+++ b/bl31/aarch64/cpu_data.S
@@ -51,6 +51,7 @@ func init_cpu_data_ptr
 	bl	_cpu_data_by_mpidr
 	msr	tpidr_el3, x0
 	ret	x10
+endfunc init_cpu_data_ptr
 
 
 /* -----------------------------------------------------------------
@@ -68,6 +69,7 @@ func _cpu_data_by_mpidr
 	bl	platform_get_core_pos
 	mov	x30, x9
 	b	_cpu_data_by_index
+endfunc _cpu_data_by_mpidr
 
 
 /* -----------------------------------------------------------------
@@ -83,3 +85,4 @@ func _cpu_data_by_index
 	adr	x1, percpu_data
 	add	x0, x1, x0, LSL #CPU_DATA_LOG2SIZE
 	ret
+endfunc _cpu_data_by_index

--- a/bl31/aarch64/crash_reporting.S
+++ b/bl31/aarch64/crash_reporting.S
@@ -85,6 +85,7 @@ intr_excpt_msg:
 func print_newline
 	mov	x0, '\n'
 	b	plat_crash_console_putc
+endfunc print_newline
 
 	/*
 	 * Helper function to print from crash buf.
@@ -122,6 +123,7 @@ test_size_list:
 exit_size_print:
 	mov	x30, sp
 	ret
+endfunc size_controlled_print
 
 	/*
 	 * Helper function to store x8 - x15 registers to
@@ -140,6 +142,7 @@ func str_in_crash_buf_print
 	stp	x12, x13, [x0, #REG_SIZE * 4]
 	stp	x14, x15, [x0, #REG_SIZE * 6]
 	b	size_controlled_print
+endfunc str_in_crash_buf_print
 
 	/* ------------------------------------------------------
 	 * This macro calculates the offset to crash buf from
@@ -176,6 +179,7 @@ func report_unhandled_exception
 	mov	sp, x0
 	/* This call will not return */
 	b	do_crash_reporting
+endfunc report_unhandled_exception
 
 
 	/* -----------------------------------------------------
@@ -192,6 +196,7 @@ func report_unhandled_interrupt
 	mov	sp, x0
 	/* This call will not return */
 	b	do_crash_reporting
+endfunc report_unhandled_interrupt
 
 	/* -----------------------------------------------------
 	 * This function allows to report a crash (if crash
@@ -208,6 +213,7 @@ func el3_panic
 	mov	sp, x0
 	/* This call will not return */
 	b	do_crash_reporting
+endfunc el3_panic
 
 	/* ------------------------------------------------------------
 	 * The common crash reporting functionality. It requires x0
@@ -346,13 +352,16 @@ func do_crash_reporting
 
 	/* Done reporting */
 	b	crash_panic
+endfunc do_crash_reporting
 
 #else	/* CRASH_REPORTING */
 func report_unhandled_exception
 report_unhandled_interrupt:
 	b	crash_panic
+endfunc report_unhandled_exception
 #endif	/* CRASH_REPORING */
 
 
 func crash_panic
 	b	crash_panic
+endfunc crash_panic

--- a/bl31/aarch64/runtime_exceptions.S
+++ b/bl31/aarch64/runtime_exceptions.S
@@ -479,6 +479,7 @@ smc_prohibited:
 rt_svc_fw_critical_error:
 	msr	spsel, #1 /* Switch to SP_ELx */
 	bl	report_unhandled_exception
+endfunc smc_handler
 
 	/* -----------------------------------------------------
 	 * The following functions are used to saved and restore
@@ -503,6 +504,7 @@ func save_gp_registers
 	stp	x16, x17, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_X16]
 	save_x18_to_x29_sp_el0
 	ret
+endfunc save_gp_registers
 
 func restore_gp_registers_eret
 	ldp	x0, x1, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_X0]
@@ -525,3 +527,4 @@ restore_gp_registers_callee_eret:
 	msr	sp_el0, x17
 	ldp	x16, x17, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_X16]
 	eret
+endfunc restore_gp_registers_eret

--- a/bl32/tsp/aarch64/tsp_entrypoint.S
+++ b/bl32/tsp/aarch64/tsp_entrypoint.S
@@ -149,6 +149,7 @@ func tsp_entrypoint
 
 tsp_entrypoint_panic:
 	b	tsp_entrypoint_panic
+endfunc tsp_entrypoint
 
 
 	/* -------------------------------------------
@@ -166,6 +167,7 @@ func tsp_vector_table
 	b	tsp_fiq_entry
 	b	tsp_system_off_entry
 	b	tsp_system_reset_entry
+endfunc tsp_vector_table
 
 	/*---------------------------------------------
 	 * This entrypoint is used by the TSPD when this
@@ -180,6 +182,7 @@ func tsp_vector_table
 func tsp_cpu_off_entry
 	bl	tsp_cpu_off_main
 	restore_args_call_smc
+endfunc tsp_cpu_off_entry
 
 	/*---------------------------------------------
 	 * This entrypoint is used by the TSPD when the
@@ -191,6 +194,7 @@ func tsp_cpu_off_entry
 func tsp_system_off_entry
 	bl	tsp_system_off_main
 	restore_args_call_smc
+endfunc tsp_system_off_entry
 
 	/*---------------------------------------------
 	 * This entrypoint is used by the TSPD when the
@@ -202,6 +206,7 @@ func tsp_system_off_entry
 func tsp_system_reset_entry
 	bl	tsp_system_reset_main
 	restore_args_call_smc
+endfunc tsp_system_reset_entry
 
 	/*---------------------------------------------
 	 * This entrypoint is used by the TSPD when this
@@ -292,6 +297,7 @@ func tsp_cpu_on_entry
 	/* Should never reach here */
 tsp_cpu_on_entry_panic:
 	b	tsp_cpu_on_entry_panic
+endfunc tsp_cpu_on_entry
 
 	/*---------------------------------------------
 	 * This entrypoint is used by the TSPD when this
@@ -305,6 +311,7 @@ tsp_cpu_on_entry_panic:
 func tsp_cpu_suspend_entry
 	bl	tsp_cpu_suspend_main
 	restore_args_call_smc
+endfunc tsp_cpu_suspend_entry
 
 	/*---------------------------------------------
 	 * This entrypoint is used by the TSPD to pass
@@ -357,6 +364,7 @@ func	tsp_fiq_entry
 
 tsp_fiq_entry_panic:
 	b	tsp_fiq_entry_panic
+endfunc tsp_fiq_entry
 
 	/*---------------------------------------------
 	 * This entrypoint is used by the TSPD when this
@@ -373,6 +381,7 @@ func tsp_cpu_resume_entry
 	restore_args_call_smc
 tsp_cpu_resume_panic:
 	b	tsp_cpu_resume_panic
+endfunc tsp_cpu_resume_entry
 
 	/*---------------------------------------------
 	 * This entrypoint is used by the TSPD to ask
@@ -384,6 +393,7 @@ func tsp_fast_smc_entry
 	restore_args_call_smc
 tsp_fast_smc_entry_panic:
 	b	tsp_fast_smc_entry_panic
+endfunc tsp_fast_smc_entry
 
 	/*---------------------------------------------
 	 * This entrypoint is used by the TSPD to ask
@@ -399,3 +409,4 @@ func tsp_std_smc_entry
 	restore_args_call_smc
 tsp_std_smc_entry_panic:
 	b	tsp_std_smc_entry_panic
+endfunc tsp_std_smc_entry

--- a/bl32/tsp/aarch64/tsp_request.S
+++ b/bl32/tsp/aarch64/tsp_request.S
@@ -56,6 +56,7 @@ func tsp_get_magic
 	stp	x0, x1, [x4, #0]
 
 	ret
+endfunc tsp_get_magic
 
 	.align 2
 _tsp_fid_get_magic:

--- a/common/aarch64/debug.S
+++ b/common/aarch64/debug.S
@@ -98,6 +98,7 @@ func asm_assert
 	asm_print_line_dec
 _assert_loop:
 	b	_assert_loop
+endfunc asm_assert
 #endif
 
 /*
@@ -114,6 +115,7 @@ func asm_print_str
 	b	1b
 2:
 	ret	x3
+endfunc asm_print_str
 
 /*
  * This function prints a hexadecimal number in x4.
@@ -138,6 +140,7 @@ func asm_print_hex
 	bl	plat_crash_console_putc
 	cbnz	x5, 1b
 	ret	x3
+endfunc asm_print_hex
 
 	/***********************************************************
 	 * The common implementation of do_panic for all BL stages
@@ -185,4 +188,5 @@ el3_panic:
 	bl	asm_print_hex
 _panic_loop:
 	b	_panic_loop
+endfunc do_panic
 

--- a/drivers/arm/pl011/pl011_console.S
+++ b/drivers/arm/pl011/pl011_console.S
@@ -64,6 +64,7 @@ func console_init
 	adrp	x3, console_base
 	str	x0, [x3, :lo12:console_base]
 	b	console_core_init
+endfunc console_init
 
 	/* -----------------------------------------------
 	 * int console_core_init(unsigned long base_addr,
@@ -107,6 +108,7 @@ func console_core_init
 	mov	w0, #1
 init_fail:
 	ret
+endfunc console_core_init
 
 	/* ---------------------------------------------
 	 * int console_putc(int c)
@@ -122,6 +124,7 @@ func console_putc
 	adrp	x2, console_base
 	ldr	x1, [x2, :lo12:console_base]
 	b	console_core_putc
+endfunc console_putc
 
 	/* --------------------------------------------------------
 	 * int console_core_putc(int c, unsigned int base_addr)
@@ -154,6 +157,7 @@ func console_core_putc
 putc_error:
 	mov	w0, #-1
 	ret
+endfunc console_core_putc
 
 	/* ---------------------------------------------
 	 * int console_getc(void)
@@ -176,3 +180,4 @@ func console_getc
 getc_error:
 	mov	w0, #-1
 	ret
+endfunc console_getc

--- a/include/common/asm_macros.S
+++ b/include/common/asm_macros.S
@@ -85,7 +85,16 @@
 	.macro func _name
 	.section .text.\_name, "ax"
 	.type \_name, %function
+	.func \_name
 	\_name:
+	.endm
+
+	/*
+	 * This macro is used to mark the end of a function.
+	 */
+	.macro endfunc _name
+	.endfunc
+	.size \_name, . - \_name
 	.endm
 
 	/* ---------------------------------------------

--- a/lib/aarch64/cache_helpers.S
+++ b/lib/aarch64/cache_helpers.S
@@ -56,6 +56,7 @@ flush_loop:
 	b.lo    flush_loop
 	dsb	sy
 	ret
+endfunc flush_dcache_range
 
 
 	/* ------------------------------------------
@@ -75,6 +76,7 @@ inv_loop:
 	b.lo    inv_loop
 	dsb	sy
 	ret
+endfunc inv_dcache_range
 
 
 	/* ---------------------------------------------------------------
@@ -154,6 +156,7 @@ level_done:
 	isb
 exit:
 	ret
+endfunc do_dcsw_op
 
 dcsw_loop_table:
 	dcsw_loop isw
@@ -163,10 +166,12 @@ dcsw_loop_table:
 
 func dcsw_op_louis
 	dcsw_op #LOUIS_SHIFT, #CLIDR_FIELD_WIDTH, #LEVEL_SHIFT
+endfunc dcsw_op_louis
 
 
 func dcsw_op_all
 	dcsw_op #LOC_SHIFT, #CLIDR_FIELD_WIDTH, #LEVEL_SHIFT
+endfunc dcsw_op_all
 
 	/* ---------------------------------------------------------------
 	 *  Helper macro for data cache operations by set/way for the
@@ -189,6 +194,7 @@ func dcsw_op_all
 	 */
 func dcsw_op_level1
 	dcsw_op_level #(1 << LEVEL_SHIFT)
+endfunc dcsw_op_level1
 
 	/* ---------------------------------------------------------------
 	 * Data cache operations by set/way for level 2 cache
@@ -199,6 +205,7 @@ func dcsw_op_level1
 	 */
 func dcsw_op_level2
 	dcsw_op_level #(2 << LEVEL_SHIFT)
+endfunc dcsw_op_level2
 
 	/* ---------------------------------------------------------------
 	 * Data cache operations by set/way for level 3 cache
@@ -209,3 +216,4 @@ func dcsw_op_level2
 	 */
 func dcsw_op_level3
 	dcsw_op_level #(3 << LEVEL_SHIFT)
+endfunc dcsw_op_level3

--- a/lib/aarch64/misc_helpers.S
+++ b/lib/aarch64/misc_helpers.S
@@ -53,6 +53,7 @@ func get_afflvl_shift
 	mov	x1, #MPIDR_AFFLVL_SHIFT
 	lsl	x0, x0, x1
 	ret
+endfunc get_afflvl_shift
 
 func mpidr_mask_lower_afflvls
 	cmp	x1, #3
@@ -62,14 +63,17 @@ func mpidr_mask_lower_afflvls
 	lsr	x0, x0, x2
 	lsl	x0, x0, x2
 	ret
+endfunc mpidr_mask_lower_afflvls
 
 
 func eret
 	eret
+endfunc eret
 
 
 func smc
 	smc	#0
+endfunc smc
 
 /* -----------------------------------------------------------------------
  * void zeromem16(void *mem, unsigned int length);
@@ -97,7 +101,9 @@ z_loop1:
 	b.eq	z_end
 	strb	wzr, [x0], #1
 	b	z_loop1
-z_end:	ret
+z_end:
+	ret
+endfunc zeromem16
 
 
 /* --------------------------------------------------------------------------
@@ -129,7 +135,9 @@ m_loop1:
 	strb	w3, [x0], #1
 	subs	x2, x2, #1
 	b.ne	m_loop1
-m_end:	ret
+m_end:
+	ret
+endfunc memcpy16
 
 /* ---------------------------------------------------------------------------
  * Disable the MMU at EL3
@@ -148,11 +156,13 @@ do_disable_mmu:
 	isb				// ensure MMU is off
 	mov	x0, #DCCISW		// DCache clean and invalidate
 	b	dcsw_op_all
+endfunc disable_mmu_el3
 
 
 func disable_mmu_icache_el3
 	mov	x1, #(SCTLR_M_BIT | SCTLR_C_BIT | SCTLR_I_BIT)
 	b	do_disable_mmu
+endfunc disable_mmu_icache_el3
 
 /* ---------------------------------------------------------------------------
  * Enable the use of VFP at EL3
@@ -169,4 +179,5 @@ func enable_vfp
 	msr	cptr_el3, x0
 	isb
 	ret
+endfunc enable_vfp
 #endif

--- a/lib/cpus/aarch64/aem_generic.S
+++ b/lib/cpus/aarch64/aem_generic.S
@@ -49,6 +49,7 @@ func aem_generic_core_pwr_dwn
 	 * ---------------------------------------------
 	 */
 	b	dcsw_op_louis
+endfunc aem_generic_core_pwr_dwn
 
 
 func aem_generic_cluster_pwr_dwn
@@ -67,6 +68,7 @@ func aem_generic_cluster_pwr_dwn
 	 */
 	mov	x0, #DCCISW
 	b	dcsw_op_all
+endfunc aem_generic_cluster_pwr_dwn
 
 	/* ---------------------------------------------
 	 * This function provides cpu specific
@@ -80,6 +82,7 @@ func aem_generic_cluster_pwr_dwn
 func aem_generic_cpu_reg_dump
 	mov	x6, #0 /* no registers to report */
 	ret
+endfunc aem_generic_cpu_reg_dump
 
 
 /* cpu_ops for Base AEM FVP */

--- a/lib/cpus/aarch64/cortex_a53.S
+++ b/lib/cpus/aarch64/cortex_a53.S
@@ -44,6 +44,7 @@ func cortex_a53_disable_dcache
 	msr	sctlr_el3, x1
 	isb
 	ret
+endfunc cortex_a53_disable_dcache
 
 	/* ---------------------------------------------
 	 * Disable intra-cluster coherency
@@ -56,6 +57,7 @@ func cortex_a53_disable_smp
 	isb
 	dsb	sy
 	ret
+endfunc cortex_a53_disable_smp
 
 func cortex_a53_reset_func
 	/* ---------------------------------------------
@@ -72,6 +74,7 @@ func cortex_a53_reset_func
 	isb
 skip_smp_setup:
 	ret
+endfunc cortex_a53_reset_func
 
 func cortex_a53_core_pwr_dwn
 	mov	x18, x30
@@ -95,6 +98,7 @@ func cortex_a53_core_pwr_dwn
 	 */
 	mov	x30, x18
 	b	cortex_a53_disable_smp
+endfunc cortex_a53_core_pwr_dwn
 
 func cortex_a53_cluster_pwr_dwn
 	mov	x18, x30
@@ -131,6 +135,7 @@ func cortex_a53_cluster_pwr_dwn
 	 */
 	mov	x30, x18
 	b	cortex_a53_disable_smp
+endfunc cortex_a53_cluster_pwr_dwn
 
 	/* ---------------------------------------------
 	 * This function provides cortex_a53 specific
@@ -149,5 +154,6 @@ func cortex_a53_cpu_reg_dump
 	adr	x6, cortex_a53_regs
 	mrs	x8, CPUECTLR_EL1
 	ret
+endfunc cortex_a53_cpu_reg_dump
 
 declare_cpu_ops cortex_a53, CORTEX_A53_MIDR

--- a/lib/cpus/aarch64/cortex_a57.S
+++ b/lib/cpus/aarch64/cortex_a57.S
@@ -45,6 +45,7 @@ func cortex_a57_disable_dcache
 	msr	sctlr_el3, x1
 	isb
 	ret
+endfunc cortex_a57_disable_dcache
 
 	/* ---------------------------------------------
 	 * Disable all types of L2 prefetches.
@@ -60,6 +61,7 @@ func cortex_a57_disable_l2_prefetch
 	isb
 	dsb	ish
 	ret
+endfunc cortex_a57_disable_l2_prefetch
 
 	/* ---------------------------------------------
 	 * Disable intra-cluster coherency
@@ -70,6 +72,7 @@ func cortex_a57_disable_smp
 	bic	x0, x0, #CPUECTLR_SMP_BIT
 	msr	CPUECTLR_EL1, x0
 	ret
+endfunc cortex_a57_disable_smp
 
 	/* ---------------------------------------------
 	 * Disable debug interfaces
@@ -81,6 +84,7 @@ func cortex_a57_disable_ext_debug
 	isb
 	dsb	sy
 	ret
+endfunc cortex_a57_disable_ext_debug
 
 	/* --------------------------------------------------
 	 * Errata Workaround for Cortex A57 Errata #806969.
@@ -113,6 +117,7 @@ apply_806969:
 	msr	CPUACTLR_EL1, x1
 skip_806969:
 	ret
+endfunc errata_a57_806969_wa
 
 
 	/* ---------------------------------------------------
@@ -146,6 +151,7 @@ apply_813420:
 	msr	CPUACTLR_EL1, x1
 skip_813420:
 	ret
+endfunc errata_a57_813420_wa
 
 	/* -------------------------------------------------
 	 * The CPU Ops reset function for Cortex-A57.
@@ -188,6 +194,7 @@ func cortex_a57_reset_func
 skip_smp_setup:
 	isb
 	ret	x19
+endfunc cortex_a57_reset_func
 
 	/* ----------------------------------------------------
 	 * The CPU Ops core power down function for Cortex-A57.
@@ -227,6 +234,7 @@ func cortex_a57_core_pwr_dwn
 	 */
 	mov	x30, x18
 	b	cortex_a57_disable_ext_debug
+endfunc cortex_a57_core_pwr_dwn
 
 	/* -------------------------------------------------------
 	 * The CPU Ops cluster power down function for Cortex-A57.
@@ -280,6 +288,7 @@ func cortex_a57_cluster_pwr_dwn
 	 */
 	mov	x30, x18
 	b	cortex_a57_disable_ext_debug
+endfunc cortex_a57_cluster_pwr_dwn
 
 	/* ---------------------------------------------
 	 * This function provides cortex_a57 specific
@@ -298,6 +307,7 @@ func cortex_a57_cpu_reg_dump
 	adr	x6, cortex_a57_regs
 	mrs	x8, CPUECTLR_EL1
 	ret
+endfunc cortex_a57_cpu_reg_dump
 
 
 declare_cpu_ops cortex_a57, CORTEX_A57_MIDR

--- a/lib/cpus/aarch64/cortex_a72.S
+++ b/lib/cpus/aarch64/cortex_a72.S
@@ -44,6 +44,7 @@ func cortex_a72_disable_dcache
 	msr	sctlr_el3, x1
 	isb
 	ret
+endfunc cortex_a72_disable_dcache
 
 	/* ---------------------------------------------
 	 * Disable all types of L2 prefetches.
@@ -58,6 +59,7 @@ func cortex_a72_disable_l2_prefetch
 	msr	CPUECTLR_EL1, x0
 	isb
 	ret
+endfunc cortex_a72_disable_l2_prefetch
 
 	/* ---------------------------------------------
 	 * Disable the load-store hardware prefetcher.
@@ -70,6 +72,7 @@ func cortex_a72_disable_hw_prefetcher
 	isb
 	dsb	ish
 	ret
+endfunc cortex_a72_disable_hw_prefetcher
 
 	/* ---------------------------------------------
 	 * Disable intra-cluster coherency
@@ -80,6 +83,7 @@ func cortex_a72_disable_smp
 	bic	x0, x0, #CPUECTLR_SMP_BIT
 	msr	CPUECTLR_EL1, x0
 	ret
+endfunc cortex_a72_disable_smp
 
 	/* ---------------------------------------------
 	 * Disable debug interfaces
@@ -91,6 +95,7 @@ func cortex_a72_disable_ext_debug
 	isb
 	dsb	sy
 	ret
+endfunc cortex_a72_disable_ext_debug
 
 	/* -------------------------------------------------
 	 * The CPU Ops reset function for Cortex-A72.
@@ -106,6 +111,7 @@ func cortex_a72_reset_func
 	msr	CPUECTLR_EL1, x0
 	isb
 	ret
+endfunc cortex_a72_reset_func
 
 	/* ----------------------------------------------------
 	 * The CPU Ops core power down function for Cortex-A72.
@@ -151,6 +157,7 @@ func cortex_a72_core_pwr_dwn
 	 */
 	mov	x30, x18
 	b	cortex_a72_disable_ext_debug
+endfunc cortex_a72_core_pwr_dwn
 
 	/* -------------------------------------------------------
 	 * The CPU Ops cluster power down function for Cortex-A72.
@@ -211,6 +218,7 @@ func cortex_a72_cluster_pwr_dwn
 	 */
 	mov	x30, x18
 	b	cortex_a72_disable_ext_debug
+endfunc cortex_a72_cluster_pwr_dwn
 
 	/* ---------------------------------------------
 	 * This function provides cortex_a72 specific
@@ -229,6 +237,7 @@ func cortex_a72_cpu_reg_dump
 	adr	x6, cortex_a72_regs
 	mrs	x8, CPUECTLR_EL1
 	ret
+endfunc cortex_a72_cpu_reg_dump
 
 
 declare_cpu_ops cortex_a72, CORTEX_A72_MIDR

--- a/lib/cpus/aarch64/cpu_helpers.S
+++ b/lib/cpus/aarch64/cpu_helpers.S
@@ -67,6 +67,7 @@ func reset_handler
 	br	x2
 1:
 	ret
+endfunc reset_handler
 
 #endif /* IMAGE_BL1 || IMAGE_BL31 */
 
@@ -88,6 +89,7 @@ func prepare_core_pwr_dwn
 	/* Get the cpu_ops core_pwr_dwn handler */
 	ldr	x1, [x0, #CPU_PWR_DWN_CORE]
 	br	x1
+endfunc prepare_core_pwr_dwn
 
 	/*
 	 * The prepare cluster power down function for all platforms.  After
@@ -106,6 +108,7 @@ func prepare_cluster_pwr_dwn
 	/* Get the cpu_ops cluster_pwr_dwn handler */
 	ldr	x1, [x0, #CPU_PWR_DWN_CLUSTER]
 	br	x1
+endfunc prepare_cluster_pwr_dwn
 
 
 	/*
@@ -129,6 +132,7 @@ func init_cpu_ops
 	mov x30, x10
 1:
 	ret
+endfunc init_cpu_ops
 #endif /* IMAGE_BL31 */
 
 #if IMAGE_BL31 && CRASH_REPORTING
@@ -153,6 +157,7 @@ func do_cpu_reg_dump
 1:
 	mov	x30, x16
 	ret
+endfunc do_cpu_reg_dump
 #endif
 
 	/*
@@ -197,6 +202,7 @@ func get_cpu_ops_ptr
 	sub	x0, x4, #(CPU_OPS_SIZE + CPU_MIDR)
 error_exit:
 	ret
+endfunc get_cpu_ops_ptr
 
 #if DEBUG
 	/*
@@ -221,5 +227,6 @@ func print_revision_warning
 	bl	asm_print_str
 1:
 	ret	x5
+endfunc print_revision_warning
 #endif
 

--- a/lib/locks/exclusive/spinlock.S
+++ b/lib/locks/exclusive/spinlock.S
@@ -43,8 +43,10 @@ l2:	ldaxr	w1, [x0]
 	stxr	w1, w2, [x0]
 	cbnz	w1, l2
 	ret
+endfunc spin_lock
 
 
 func spin_unlock
 	stlr	wzr, [x0]
 	ret
+endfunc spin_unlock

--- a/lib/semihosting/aarch64/semihosting_call.S
+++ b/lib/semihosting/aarch64/semihosting_call.S
@@ -35,3 +35,4 @@
 func semihosting_call
 	hlt	#0xf000
 	ret
+endfunc semihosting_call

--- a/plat/common/aarch64/platform_helpers.S
+++ b/plat/common/aarch64/platform_helpers.S
@@ -52,6 +52,7 @@ func platform_get_core_pos
 	and	x0, x0, #MPIDR_CLUSTER_MASK
 	add	x0, x1, x0, LSR #6
 	ret
+endfunc platform_get_core_pos
 
 	/* -----------------------------------------------------
 	 * Placeholder function which should be redefined by
@@ -61,6 +62,7 @@ func platform_get_core_pos
 func platform_check_mpidr
 	mov	x0, xzr
 	ret
+endfunc platform_check_mpidr
 
 	/* -----------------------------------------------------
 	 * Placeholder function which should be redefined by
@@ -69,6 +71,7 @@ func platform_check_mpidr
 	 */
 func plat_report_exception
 	ret
+endfunc plat_report_exception
 
 	/* -----------------------------------------------------
 	 * Placeholder function which should be redefined by
@@ -78,6 +81,7 @@ func plat_report_exception
 func plat_crash_console_init
 	mov	x0, #0
 	ret
+endfunc plat_crash_console_init
 
 	/* -----------------------------------------------------
 	 * Placeholder function which should be redefined by
@@ -86,6 +90,7 @@ func plat_crash_console_init
 	 */
 func plat_crash_console_putc
 	ret
+endfunc plat_crash_console_putc
 
 	/* -----------------------------------------------------
 	 * Placeholder function which should be redefined by
@@ -94,6 +99,7 @@ func plat_crash_console_putc
 	 */
 func plat_reset_handler
 	ret
+endfunc plat_reset_handler
 
 	/* -----------------------------------------------------
 	 * Placeholder function which should be redefined by
@@ -103,3 +109,4 @@ func plat_reset_handler
 	 */
 func plat_disable_acp
 	ret
+endfunc plat_disable_acp

--- a/plat/common/aarch64/platform_mp_stack.S
+++ b/plat/common/aarch64/platform_mp_stack.S
@@ -49,6 +49,7 @@ func platform_get_stack
 	mov x10, x30 // lr
 	get_mp_stack platform_normal_stacks, PLATFORM_STACK_SIZE
 	ret x10
+endfunc platform_get_stack
 
 	/* -----------------------------------------------------
 	 * void platform_set_stack (unsigned long mpidr)
@@ -62,6 +63,7 @@ func platform_set_stack
 	bl  platform_get_stack
 	mov sp, x0
 	ret x9
+endfunc platform_set_stack
 
 	/* -----------------------------------------------------
 	 * Per-cpu stacks in normal memory. Each cpu gets a

--- a/plat/common/aarch64/platform_up_stack.S
+++ b/plat/common/aarch64/platform_up_stack.S
@@ -48,6 +48,7 @@
 func platform_get_stack
 	get_up_stack platform_normal_stacks, PLATFORM_STACK_SIZE
 	ret
+endfunc platform_get_stack
 
 	/* -----------------------------------------------------
 	 * void platform_set_stack (unsigned long)
@@ -61,6 +62,7 @@ func platform_set_stack
 	get_up_stack platform_normal_stacks, PLATFORM_STACK_SIZE
 	mov sp, x0
 	ret
+endfunc platform_set_stack
 
 	/* -----------------------------------------------------
 	 * Single cpu stack in normal memory.

--- a/plat/fvp/aarch64/fvp_helpers.S
+++ b/plat/fvp/aarch64/fvp_helpers.S
@@ -97,6 +97,7 @@ func plat_secondary_cold_boot_setup
 	wfi
 cb_panic:
 	b	cb_panic
+endfunc plat_secondary_cold_boot_setup
 
 
 	/* -----------------------------------------------------
@@ -148,6 +149,7 @@ warm_reset:
 exit:
 	ret	x9
 _panic:	b	_panic
+endfunc platform_get_entrypoint
 
 
 	/* -----------------------------------------------------
@@ -170,6 +172,7 @@ loop:
 	subs	w1, w1, #1
 	b.gt	loop
 	ret
+endfunc platform_mem_init
 
 	/* ---------------------------------------------
 	 * void plat_report_exception(unsigned int type)
@@ -191,12 +194,14 @@ func plat_report_exception
 	add	x1, x1, #V2M_SYS_LED
 	str	w0, [x1]
 	ret
+endfunc plat_report_exception
 
 func platform_is_primary_cpu
 	and	x0, x0, #(MPIDR_CLUSTER_MASK | MPIDR_CPU_MASK)
 	cmp	x0, #FVP_PRIMARY_CPU
 	cset	x0, eq
 	ret
+endfunc platform_is_primary_cpu
 
 	/* Define a crash console for the plaform */
 #define FVP_CRASH_CONSOLE_BASE		PL011_UART1_BASE
@@ -213,6 +218,7 @@ func plat_crash_console_init
 	mov_imm	x1, PL011_UART1_CLK_IN_HZ
 	mov_imm	x2, PL011_BAUDRATE
 	b	console_core_init
+endfunc plat_crash_console_init
 
 	/* ---------------------------------------------
 	 * int plat_crash_console_putc(int c)
@@ -224,3 +230,4 @@ func plat_crash_console_init
 func plat_crash_console_putc
 	mov_imm	x1, FVP_CRASH_CONSOLE_BASE
 	b	console_core_putc
+endfunc plat_crash_console_putc

--- a/plat/juno/aarch64/bl1_plat_helpers.S
+++ b/plat/juno/aarch64/bl1_plat_helpers.S
@@ -53,6 +53,7 @@ func platform_is_primary_cpu
 	cmp	x0, x1
 	cset	x0, eq
 	ret	x9
+endfunc platform_is_primary_cpu
 
 	/* -----------------------------------------------------
 	 * void plat_secondary_cold_boot_setup (void);
@@ -67,6 +68,7 @@ func plat_secondary_cold_boot_setup
 	/* Juno todo: Implement secondary CPU cold boot setup on Juno */
 cb_panic:
 	b	cb_panic
+endfunc plat_secondary_cold_boot_setup
 
 
 	/* -----------------------------------------------------
@@ -91,6 +93,7 @@ func platform_get_entrypoint
 	lsl	x0, x0, #TRUSTED_MAILBOX_SHIFT
 	ldr	x0, [x1, x0]
 	ret	x9
+endfunc platform_get_entrypoint
 
 
 	/* -----------------------------------------------------
@@ -140,3 +143,4 @@ func platform_cold_boot_init
 
 cb_init_panic:
 	b	cb_init_panic
+endfunc platform_cold_boot_init

--- a/plat/juno/aarch64/plat_helpers.S
+++ b/plat/juno/aarch64/plat_helpers.S
@@ -58,6 +58,7 @@ func plat_crash_console_init
 	mov_imm	x1, PL011_UART3_CLK_IN_HZ
 	mov_imm	x2, PL011_BAUDRATE
 	b	console_core_init
+endfunc plat_crash_console_init
 
 	/* ---------------------------------------------
 	 * int plat_crash_console_putc(int c)
@@ -69,6 +70,7 @@ func plat_crash_console_init
 func plat_crash_console_putc
 	mov_imm	x1, JUNO_CRASH_CONSOLE_BASE
 	b	console_core_putc
+endfunc plat_crash_console_putc
 
 	/* ---------------------------------------------
 	 * void plat_report_exception(unsigned int type)
@@ -90,6 +92,7 @@ func plat_report_exception
 	add	x1, x1, #V2M_SYS_LED
 	str	w0, [x1]
 	ret
+endfunc plat_report_exception
 
 	/*
 	 * Return 0 to 3 for the A53s and 4 or 5 for the A57s
@@ -100,6 +103,7 @@ func platform_get_core_pos
 	eor	x0, x0, #(1 << MPIDR_AFFINITY_BITS)  // swap A53/A57 order
 	add	x0, x1, x0, LSR #6
 	ret
+endfunc platform_get_core_pos
 
 
 	/* -----------------------------------------------------
@@ -111,6 +115,7 @@ func platform_get_core_pos
 	 */
 func platform_mem_init
 	ret
+endfunc platform_mem_init
 
 	/* --------------------------------------------------------------------
 	 * void plat_reset_handler(void);
@@ -197,3 +202,4 @@ ret:
 	isb
 #endif /* FIRST_RESET_HANDLER_CALL */
 	ret
+endfunc plat_reset_handler

--- a/services/spd/opteed/opteed_helpers.S
+++ b/services/spd/opteed/opteed_helpers.S
@@ -64,6 +64,7 @@ func opteed_enter_sp
 	 * ---------------------------------------------
 	 */
 	b	el3_exit
+endfunc opteed_enter_sp
 
 	/* ---------------------------------------------
 	 * This function is called 'x0' pointing to a C
@@ -99,3 +100,4 @@ func opteed_exit_sp
 	 */
 	mov	x0, x1
 	ret
+endfunc opteed_exit_sp

--- a/services/spd/tlkd/tlkd_helpers.S
+++ b/services/spd/tlkd/tlkd_helpers.S
@@ -66,6 +66,7 @@ func tlkd_enter_sp
 	 * ----------------------------------------------
 	 */
 	b	el3_exit
+endfunc tlkd_enter_sp
 
 	/* ----------------------------------------------
 	 * This function is called with 'x0' pointing to
@@ -100,3 +101,4 @@ func tlkd_exit_sp
 	 */
 	mov	x0, x1
 	ret
+endfunc tlkd_exit_sp

--- a/services/spd/tspd/tspd_helpers.S
+++ b/services/spd/tspd/tspd_helpers.S
@@ -64,6 +64,7 @@ func tspd_enter_sp
 	 * ---------------------------------------------
 	 */
 	b	el3_exit
+endfunc tspd_enter_sp
 
 	/* ---------------------------------------------
 	 * This function is called 'x0' pointing to a C
@@ -99,3 +100,4 @@ func tspd_exit_sp
 	 */
 	mov	x0, x1
 	ret
+endfunc tspd_exit_sp

--- a/services/std_svc/psci/psci_entry.S
+++ b/services/std_svc/psci/psci_entry.S
@@ -148,6 +148,7 @@ psci_aff_common_finish_entry:
 	bl	psci_afflvl_power_on_finish
 
 	b	el3_exit
+endfunc psci_aff_on_finish_entry
 
 	/* --------------------------------------------
 	 * This function is called to indicate to the
@@ -163,4 +164,5 @@ func psci_power_down_wfi
 	wfi
 wfi_spill:
 	b	wfi_spill
+endfunc psci_power_down_wfi
 

--- a/services/std_svc/psci/psci_helpers.S
+++ b/services/std_svc/psci/psci_helpers.S
@@ -120,6 +120,7 @@ do_stack_maintenance:
 	ldp	x19, x20, [sp], #16
 	ldp	x29, x30, [sp], #16
 	ret
+endfunc psci_do_pwrdown_cache_maintenance
 
 
 /* -----------------------------------------------------------------------
@@ -164,3 +165,4 @@ func psci_do_pwrup_cache_maintenance
 
 	ldp	x29, x30, [sp], #16
 	ret
+endfunc psci_do_pwrup_cache_maintenance


### PR DESCRIPTION
In order for the symbol table in the ELF file to contain the size of
functions written in assembly, it is necessary to report it to the
assembler using the .size directive.

To fulfil the above requirements, this patch introduces an 'endfunc'
macro which contains the .endfunc and .size directives. It also adds
a .func directive to the 'func' assembler macro.

The .func/.endfunc have been used so the assembler can fail if
endfunc is omitted.

Fixes ARM-Software/tf-issues#295

Change-Id: If8cb331b03d7f38fe7e3694d4de26f1075b278fc
Signed-off-by: Kévin Petit <kevin.petit@arm.com>