### PR TITLE
Remove the ARCH build configuration from the Makefile v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,6 @@ VERSION_MINOR		:= 1
 V			:= 0
 # Debug build
 DEBUG			:= 0
-# Build architecture
-ARCH 			:= aarch64
 # Build platform
 DEFAULT_PLAT		:= fvp
 PLAT			:= ${DEFAULT_PLAT}


### PR DESCRIPTION
The ARCH variable, which defaults to 'aarch64', gives the wrong
impression that the Trusted Firmware can be built for other
architectures. This patch removes it. This doesn't have any
consequence on the rest of the build system because the variable
was unused.

Change-Id: I97130f11f7733a3cbdfc89989587f2ebecaf3294