### PR TITLE
Fix recursive crash prints on FVP AEM model

### DIFF
--- a/lib/cpus/aarch64/aem_generic.S
+++ b/lib/cpus/aarch64/aem_generic.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2015, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -79,8 +79,12 @@ endfunc aem_generic_cluster_pwr_dwn
 	 * reported.
 	 * ---------------------------------------------
 	 */
+.section .rodata.aem_generic_regs, "aS"
+aem_generic_regs:  /* The ascii list of register names to be reported */
+	.asciz	"" /* no registers to report */
+
 func aem_generic_cpu_reg_dump
-	mov	x6, #0 /* no registers to report */
+	adr	x6, aem_generic_regs
 	ret
 endfunc aem_generic_cpu_reg_dump
 


### PR DESCRIPTION
This patch fixes an issue in the cpu specific register reporting
of FVP AEM model whereby crash reporting itself triggers an exception
thus resulting in recursive crash prints. The input to the
'size_controlled_print' in the crash reporting framework should
be a NULL terminated string. As there were no cpu specific register
to be reported on FVP AEM model, the issue was caused by passing 0
instead of NULL terminated string to the above mentioned function.

Change-Id: I664427b22b89977b389175dfde84c815f02c705a