### PR TITLE
Juno: Move to the new ARM SCP Messaging Interfaces

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -336,6 +336,12 @@ the [Firmware Design].
     -   `tsram` : Trusted SRAM (default option)
     -   `dram`  : Secure region in DRAM (set by the TrustZone controller)
 
+*   `DETECT_PRE_1_7_0_SCP`: Boolean flag to detect SCP version incompatibility.
+    Version 1.7.0 of the Juno SCP firmware made a non-backwards compatible
+    change to the MTL protocol, used for AP/SCP communication. Trusted Firmware
+    no longer supports earlier SCP versions. If this option is set to 1 then
+    Trusted Firmware will detect if an earlier version is in use. Default is 1.
+
 ### Creating a Firmware Image Package
 
 FIPs are automatically created as part of the build instructions described in

--- a/plat/juno/bl2_plat_setup.c
+++ b/plat/juno/bl2_plat_setup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2015, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -222,13 +222,15 @@ int bl2_plat_handle_bl30(image_info_t *bl30_image_info)
 {
 	int ret;
 
+	INFO("BL2: Initiating BL3-0 transfer to SCP\n");
+
 	ret = scp_bootloader_transfer((void *)bl30_image_info->image_base,
 		bl30_image_info->image_size);
 
 	if (ret == 0)
-		INFO("BL2: BL3-0 transferred to SCP\n\r");
+		INFO("BL2: BL3-0 transferred to SCP\n");
 	else
-		ERROR("BL2: BL3-0 transfer failure\n\r");
+		ERROR("BL2: BL3-0 transfer failure\n");
 
 	return ret;
 }

--- a/plat/juno/mhu.c
+++ b/plat/juno/mhu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2015, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -29,6 +29,7 @@
  */
 
 #include <arch_helpers.h>
+#include <assert.h>
 #include <bakery_lock.h>
 #include <mmio.h>
 #include "juno_def.h"
@@ -56,21 +57,31 @@ static bakery_lock_t mhu_secure_lock __attribute__ ((section("tzfw_coherent_mem"
 #define LOCK_ARG	/* Locks required only for BL3-1 images */
 #endif /* __IMAGE_BL31__ */
 
-void mhu_secure_message_start(void)
+/*
+ * Slot 31 is reserved because the MHU hardware uses this register bit to
+ * indicate a non-secure access attempt. The total number of available slots is
+ * therefore 31 [30:0].
+ */
+#define MHU_MAX_SLOT_ID		30
+
+void mhu_secure_message_start(unsigned int slot_id)
 {
+	assert(slot_id <= MHU_MAX_SLOT_ID);
+
 	juno_lock_get(LOCK_ARG);
 
 	/* Make sure any previous command has finished */
-	while (mmio_read_32(MHU_BASE + CPU_INTR_S_STAT) != 0)
+	while (mmio_read_32(MHU_BASE + CPU_INTR_S_STAT) & (1 << slot_id))
 		;
 }
 
-void mhu_secure_message_send(uint32_t command)
+void mhu_secure_message_send(unsigned int slot_id)
 {
-	/* Send command to SCP and wait for it to pick it up */
-	mmio_write_32(MHU_BASE + CPU_INTR_S_SET, command);
-	while (mmio_read_32(MHU_BASE + CPU_INTR_S_STAT) != 0)
-		;
+	assert(slot_id <= MHU_MAX_SLOT_ID);
+	assert(!(mmio_read_32(MHU_BASE + CPU_INTR_S_STAT) & (1 << slot_id)));
+
+	/* Send command to SCP */
+	mmio_write_32(MHU_BASE + CPU_INTR_S_SET, 1 << slot_id);
 }
 
 uint32_t mhu_secure_message_wait(void)
@@ -83,10 +94,15 @@ uint32_t mhu_secure_message_wait(void)
 	return response;
 }
 
-void mhu_secure_message_end(void)
+void mhu_secure_message_end(unsigned int slot_id)
 {
-	/* Clear any response we got by writing all ones to the CLEAR register */
-	mmio_write_32(MHU_BASE + SCP_INTR_S_CLEAR, 0xffffffffu);
+	assert(slot_id <= MHU_MAX_SLOT_ID);
+
+	/*
+	 * Clear any response we got by writing one in the relevant slot bit to
+	 * the CLEAR register
+	 */
+	mmio_write_32(MHU_BASE + SCP_INTR_S_CLEAR, 1 << slot_id);
 
 	juno_lock_release(LOCK_ARG);
 }
@@ -96,8 +112,9 @@ void mhu_secure_init(void)
 	juno_lock_init(LOCK_ARG);
 
 	/*
-	 * Clear the CPU's INTR register to make sure we don't see a stale
-	 * or garbage value and think it's a message we've already sent.
+	 * The STAT register resets to zero. Ensure it is in the expected state,
+	 * as a stale or garbage value would make us think it's a message we've
+	 * already sent.
 	 */
-	mmio_write_32(MHU_BASE + CPU_INTR_S_CLEAR, 0xffffffffu);
+	assert(mmio_read_32(MHU_BASE + CPU_INTR_S_STAT) == 0);
 }

--- a/plat/juno/mhu.h
+++ b/plat/juno/mhu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2015, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -33,11 +33,11 @@
 
 #include <stdint.h>
 
-extern void mhu_secure_message_start(void);
-extern void mhu_secure_message_send(uint32_t command);
-extern uint32_t mhu_secure_message_wait(void);
-extern void mhu_secure_message_end(void);
+void mhu_secure_message_start(unsigned int slot_id);
+void mhu_secure_message_send(unsigned int slot_id);
+uint32_t mhu_secure_message_wait(void);
+void mhu_secure_message_end(unsigned int slot_id);
 
-extern void mhu_secure_init(void);
+void mhu_secure_init(void);
 
 #endif	/* __MHU_H__ */

--- a/plat/juno/platform.mk
+++ b/plat/juno/platform.mk
@@ -109,3 +109,11 @@ ERRATA_A57_813420	:=	1
 # Enable option to skip L1 data cache flush during the Cortex-A57 cluster
 # power down sequence
 SKIP_A57_L1_FLUSH_PWR_DWN	:=	 1
+
+# Enable option to detect whether the SCP ROM firmware in use predates version
+# 1.7.0 and therefore, is incompatible.
+DETECT_PRE_1_7_0_SCP	:=	1
+
+# Process DETECT_PRE_1_7_0_SCP flag
+$(eval $(call assert_boolean,DETECT_PRE_1_7_0_SCP))
+$(eval $(call add_define,DETECT_PRE_1_7_0_SCP))

--- a/plat/juno/scp_bootloader.c
+++ b/plat/juno/scp_bootloader.c
@@ -149,6 +149,24 @@ int scp_bootloader_transfer(void *image, unsigned int image_size)
 	cmd_info_payload->checksum = checksum;
 
 	scp_boot_message_send(sizeof(*cmd_info_payload));
+#if DETECT_PRE_1_7_0_SCP
+	{
+		const uint32_t deprecated_scp_nack_cmd = 0x404;
+		uint32_t mhu_status;
+
+		VERBOSE("Detecting SCP version incompatibility\n");
+
+		mhu_status = mhu_secure_message_wait();
+		if (mhu_status == deprecated_scp_nack_cmd) {
+			ERROR("Detected an incompatible version of the SCP firmware.\n");
+			ERROR("Only versions from v1.7.0 onwards are supported.\n");
+			ERROR("Please update the SCP firmware.\n");
+			return -1;
+		}
+
+		VERBOSE("SCP version looks OK\n");
+	}
+#endif /* DETECT_PRE_1_7_0_SCP */
 	response = scp_boot_message_wait(sizeof(response));
 	scp_boot_message_end();
 

--- a/plat/juno/scp_bootloader.c
+++ b/plat/juno/scp_bootloader.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2015, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -29,124 +29,154 @@
  */
 
 #include <arch_helpers.h>
+#include <assert.h>
+#include <debug.h>
 #include <platform.h>
+#include <platform_def.h>
+#include <stdint.h>
 #include "juno_def.h"
 #include "mhu.h"
 #include "scp_bootloader.h"
 #include "scpi.h"
 
+/* ID of the MHU slot used for the BOM protocol */
+#define BOM_MHU_SLOT_ID		0
+
 /* Boot commands sent from AP -> SCP */
-#define BOOT_CMD_START	0x01
-#define BOOT_CMD_DATA	0x02
+#define BOOT_CMD_INFO	0x00
+#define BOOT_CMD_DATA	0x01
+
+/* BOM command header */
+typedef struct {
+	uint32_t id : 8;
+	uint32_t reserved : 24;
+} bom_cmd_t;
 
 typedef struct {
 	uint32_t image_size;
-} cmd_start_payload;
-
-typedef struct {
-	uint32_t sequence_num;
-	uint32_t offset;
-	uint32_t size;
-} cmd_data_payload;
-
-#define BOOT_DATA_MAX_SIZE  0x1000
-
-/* Boot commands sent from SCP -> AP */
-#define BOOT_CMD_ACK	0x03
-#define BOOT_CMD_NACK	0x04
-
-typedef struct {
-	uint32_t sequence_num;
-} cmd_ack_payload;
+	uint32_t checksum;
+} cmd_info_payload_t;
 
 /*
- * Unlike the runtime protocol, the boot protocol uses the same memory region
+ * Unlike the SCPI protocol, the boot protocol uses the same memory region
  * for both AP -> SCP and SCP -> AP transfers; define the address of this...
  */
-static void * const cmd_payload = (void *)(MHU_SECURE_BASE + 0x0080);
+#define BOM_SHARED_MEM		(MHU_SECURE_BASE + 0x0080)
+#define BOM_CMD_HEADER		((bom_cmd_t *) BOM_SHARED_MEM)
+#define BOM_CMD_PAYLOAD		((void *) (BOM_SHARED_MEM + sizeof(bom_cmd_t)))
 
-static void *scp_boot_message_start(void)
+typedef struct {
+	/* Offset from the base address of the Trusted RAM */
+	uint32_t offset;
+	uint32_t block_size;
+} cmd_data_payload_t;
+
+static void scp_boot_message_start(void)
 {
-	mhu_secure_message_start();
-
-	return cmd_payload;
+	mhu_secure_message_start(BOM_MHU_SLOT_ID);
 }
 
-static void scp_boot_message_send(unsigned command, size_t size)
+static void scp_boot_message_send(size_t payload_size)
 {
 	/* Make sure payload can be seen by SCP */
 	if (MHU_PAYLOAD_CACHED)
-		flush_dcache_range((unsigned long)cmd_payload, size);
+		flush_dcache_range(BOM_SHARED_MEM,
+				   sizeof(bom_cmd_t) + payload_size);
 
 	/* Send command to SCP */
-	mhu_secure_message_send(command | (size << 8));
+	mhu_secure_message_send(BOM_MHU_SLOT_ID);
 }
 
 static uint32_t scp_boot_message_wait(size_t size)
 {
-	uint32_t response =  mhu_secure_message_wait();
+	uint32_t mhu_status;
+
+	mhu_status = mhu_secure_message_wait();
+
+	/* Expect an SCP Boot Protocol message, reject any other protocol */
+	if (mhu_status != (1 << BOM_MHU_SLOT_ID)) {
+		ERROR("MHU: Unexpected protocol (MHU status: 0x%x)\n",
+			mhu_status);
+		panic();
+	}
 
 	/* Make sure we see the reply from the SCP and not any stale data */
 	if (MHU_PAYLOAD_CACHED)
-		inv_dcache_range((unsigned long)cmd_payload, size);
+		inv_dcache_range(BOM_SHARED_MEM, size);
 
-	return response & 0xff;
+	return *(uint32_t *) BOM_SHARED_MEM;
 }
 
 static void scp_boot_message_end(void)
 {
-	mhu_secure_message_end();
-}
-
-static int transfer_block(uint32_t sequence_num, uint32_t offset, uint32_t size)
-{
-	cmd_data_payload *cmd_data = scp_boot_message_start();
-	cmd_data->sequence_num = sequence_num;
-	cmd_data->offset = offset;
-	cmd_data->size = size;
-
-	scp_boot_message_send(BOOT_CMD_DATA, sizeof(*cmd_data));
-
-	cmd_ack_payload *cmd_ack = cmd_payload;
-	int ok = scp_boot_message_wait(sizeof(*cmd_ack)) == BOOT_CMD_ACK
-		 && cmd_ack->sequence_num == sequence_num;
-
-	scp_boot_message_end();
-
-	return ok;
+	mhu_secure_message_end(BOM_MHU_SLOT_ID);
 }
 
 int scp_bootloader_transfer(void *image, unsigned int image_size)
 {
-	uintptr_t offset = (uintptr_t)image - MHU_SECURE_BASE;
-	uintptr_t end = offset + image_size;
 	uint32_t response;
+	uint32_t checksum;
+	cmd_info_payload_t *cmd_info_payload;
+	cmd_data_payload_t *cmd_data_payload;
+
+	assert((uintptr_t) image == BL30_BASE);
+
+	if ((image_size == 0) || (image_size % 4 != 0)) {
+		ERROR("Invalid size for the BL3-0 image. Must be a multiple of "
+			"4 bytes and not zero (current size = 0x%x)\n",
+			image_size);
+		return -1;
+	}
+
+	/* Extract the checksum from the image */
+	checksum = *(uint32_t *) image;
+	image = (char *) image + sizeof(checksum);
+	image_size -= sizeof(checksum);
 
 	mhu_secure_init();
 
-	/* Initiate communications with SCP */
-	do {
-		cmd_start_payload *cmd_start = scp_boot_message_start();
-		cmd_start->image_size = image_size;
+	VERBOSE("Send info about the BL3-0 image to be transferred to SCP\n");
 
-		scp_boot_message_send(BOOT_CMD_START, sizeof(*cmd_start));
+	/*
+	 * Send information about the SCP firmware image about to be transferred
+	 * to SCP
+	 */
+	scp_boot_message_start();
 
-		response = scp_boot_message_wait(0);
+	BOM_CMD_HEADER->id = BOOT_CMD_INFO;
+	cmd_info_payload = BOM_CMD_PAYLOAD;
+	cmd_info_payload->image_size = image_size;
+	cmd_info_payload->checksum = checksum;
 
-		scp_boot_message_end();
-	} while (response != BOOT_CMD_ACK);
+	scp_boot_message_send(sizeof(*cmd_info_payload));
+	response = scp_boot_message_wait(sizeof(response));
+	scp_boot_message_end();
 
-	/* Transfer image to SCP a block at a time */
-	uint32_t sequence_num = 1;
-	size_t size;
-	while ((size = end - offset) != 0) {
-		if (size > BOOT_DATA_MAX_SIZE)
-			size = BOOT_DATA_MAX_SIZE;
-		while (!transfer_block(sequence_num, offset, size))
-			; /* Retry forever */
-		offset += size;
-		sequence_num++;
+	if (response != 0) {
+		ERROR("SCP BOOT_CMD_INFO returned error %u\n", response);
+		return -1;
 	}
+
+	VERBOSE("Transferring BL3-0 image to SCP\n");
+
+	/* Transfer BL3-0 image to SCP */
+	scp_boot_message_start();
+
+	BOM_CMD_HEADER->id = BOOT_CMD_DATA;
+	cmd_data_payload = BOM_CMD_PAYLOAD;
+	cmd_data_payload->offset = (uintptr_t) image - MHU_SECURE_BASE;
+	cmd_data_payload->block_size = image_size;
+
+	scp_boot_message_send(sizeof(*cmd_data_payload));
+	response = scp_boot_message_wait(sizeof(response));
+	scp_boot_message_end();
+
+	if (response != 0) {
+		ERROR("SCP BOOT_CMD_DATA returned error %u\n", response);
+		return -1;
+	}
+
+	VERBOSE("Waiting for SCP to signal it is ready to go on\n");
 
 	/* Wait for SCP to signal it's ready */
 	return scpi_wait_ready();


### PR DESCRIPTION
The communication protocol used between the AP cores and the SCP
has undergone a number of changes.

The first patch makes the required modifications to the SCP Boot Protocol,
SCPI Protocol and MHU driver code in the Juno platform code so that the
AP cores are still able to communicate with the SCP.

The second patch detects any SCP version incompatibility in case the user
forgot to update the SCP ROM firmware.
