### PR TITLE
CSS: Extract primary cpu id using the correct bit width

### DIFF
--- a/include/plat/arm/css/common/css_def.h
+++ b/include/plat/arm/css/common/css_def.h
@@ -69,7 +69,7 @@
 /* SCP <=> AP boot configuration */
 #define SCP_BOOT_CFG_ADDR		0x04000080
 #define PRIMARY_CPU_SHIFT		8
-#define PRIMARY_CPU_MASK		0xf
+#define PRIMARY_CPU_BIT_WIDTH		4
 
 
 #define CSS_MAP_DEVICE			MAP_REGION_FLAT(		\

--- a/plat/arm/css/common/aarch64/css_helpers.S
+++ b/plat/arm/css/common/aarch64/css_helpers.S
@@ -115,7 +115,7 @@ func platform_is_primary_cpu
 	bl	platform_get_core_pos
 	ldr	x1, =SCP_BOOT_CFG_ADDR
 	ldr	x1, [x1]
-	ubfx	x1, x1, #PRIMARY_CPU_SHIFT, #PRIMARY_CPU_MASK
+	ubfx	x1, x1, #PRIMARY_CPU_SHIFT, #PRIMARY_CPU_BIT_WIDTH
 	cmp	x0, x1
 	cset	x0, eq
 	ret	x9


### PR DESCRIPTION
This patch fixes the incorrect bit width used to extract the primary
cpu id from `ap_data` exported by scp at SCP_BOOT_CFG_ADDR in
platform_is_primary_cpu().

Change-Id: I14abb361685f31164ecce0755fc1a145903b27aa