### PR TITLE
FVP: Correct the PSYSR_WK bit width in platform_get_entrypoint

### DIFF
--- a/plat/arm/board/fvp/aarch64/fvp_helpers.S
+++ b/plat/arm/board/fvp/aarch64/fvp_helpers.S
@@ -123,7 +123,7 @@ func platform_get_entrypoint
 	ldr	x1, =PWRC_BASE
 	str	w2, [x1, #PSYSR_OFF]
 	ldr	w2, [x1, #PSYSR_OFF]
-	ubfx	w2, w2, #PSYSR_WK_SHIFT, #PSYSR_WK_MASK
+	ubfx	w2, w2, #PSYSR_WK_SHIFT, #PSYSR_WK_WIDTH
 	cmp	w2, #WKUP_PPONR
 	beq	warm_reset
 	cmp	w2, #WKUP_GICREQ

--- a/plat/arm/board/fvp/drivers/pwrc/fvp_pwrc.h
+++ b/plat/arm/board/fvp/drivers/pwrc/fvp_pwrc.h
@@ -48,7 +48,8 @@
 #define PSYSR_PP		(1 << 26)
 
 #define PSYSR_WK_SHIFT		24
-#define PSYSR_WK_MASK		0x3
+#define PSYSR_WK_WIDTH		0x2
+#define PSYSR_WK_MASK		((1 << PSYSR_WK_WIDTH) - 1)
 #define PSYSR_WK(x)		(x >> PSYSR_WK_SHIFT) & PSYSR_WK_MASK
 
 #define WKUP_COLD		0x0


### PR DESCRIPTION
This patch fixes the incorrect bit width used to extract the wakeup
reason from PSYSR in platform_get_entrypoint() function. This defect
did not have any observed regression.

Change-Id: I42652dbffc99f5bf50cc86a5878f28d730720d9a