### PR TITLE
Run a Trusted OS during boot on Tegra SoCs

### DIFF
--- a/docs/plat/nvidia-tegra.md
+++ b/docs/plat/nvidia-tegra.md
@@ -15,7 +15,13 @@ Directory structure
 * plat/nvidia/tegra/common - Common code for all Tegra SoCs
 * plat/nvidia/tegra/soc/txxx - Chip specific code
 
+Trusted OS dispatcher
+=====================
+Tegra support Trusted Little Kernel (TLK) as the default Trusted OS. But to
+support more Trusted OS' in the future, we pass the 'SPD' to be used, as an
+input parameter during compilation. Passing the 'SPD' parameter is optional.
+
 Preparing the BL31 image to run on Tegra SoCs
 ===================================================
 CROSS_COMPILE=<path-to-aarch64-gcc>/bin/aarch64-none-elf- make PLAT=tegra \
-TARGET_SOC=<target-soc e.g. t210> all
+TARGET_SOC=<target-soc e.g. t210> SPD=<dispatcher e.g. tlkd> all

--- a/plat/nvidia/tegra/common/tegra_bl31_setup.c
+++ b/plat/nvidia/tegra/common/tegra_bl31_setup.c
@@ -82,7 +82,7 @@ extern uint64_t tegra_bl31_phys_base;
 #define BL31_COHERENT_RAM_LIMIT (unsigned long)(&__COHERENT_RAM_END__)
 #endif
 
-static entry_point_info_t bl33_image_ep_info;
+static entry_point_info_t bl33_image_ep_info, bl32_image_ep_info;
 static plat_params_from_bl2_t plat_bl31_params_from_bl2 = {
 	(uint64_t)TZDRAM_SIZE, (uintptr_t)NULL
 };
@@ -101,6 +101,9 @@ entry_point_info_t *bl31_plat_get_next_image_ep_info(uint32_t type)
 {
 	if (type == NON_SECURE)
 		return &bl33_image_ep_info;
+
+	if (type == SECURE)
+		return &bl32_image_ep_info;
 
 	return NULL;
 }
@@ -134,10 +137,11 @@ void bl31_early_platform_setup(bl31_params_t *from_bl2,
 	plat_crash_console_init();
 
 	/*
-	 * Copy BL3-3 entry point information.
+	 * Copy BL3-3, BL3-2 entry point information.
 	 * They are stored in Secure RAM, in BL2's address space.
 	 */
 	bl33_image_ep_info = *from_bl2->bl33_ep_info;
+	bl32_image_ep_info = *from_bl2->bl32_ep_info;
 
 	/*
 	 * Parse platform specific parameters - TZDRAM aperture size and

--- a/plat/nvidia/tegra/include/platform_def.h
+++ b/plat/nvidia/tegra/include/platform_def.h
@@ -69,8 +69,11 @@
 /*******************************************************************************
  * BL31 specific defines.
  ******************************************************************************/
+#define BL31_SIZE			0x20000
 #define BL31_BASE			TZDRAM_BASE
-#define BL31_LIMIT			(TZDRAM_BASE + 0x11FFF)
+#define BL31_LIMIT			(TZDRAM_BASE + BL31_SIZE - 1)
+#define BL32_BASE			(TZDRAM_BASE + BL31_SIZE)
+#define BL32_LIMIT			TZDRAM_END
 
 /*******************************************************************************
  * Platform specific page table and MMU setup constants

--- a/plat/nvidia/tegra/platform.mk
+++ b/plat/nvidia/tegra/platform.mk
@@ -28,6 +28,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
+SPD		:=	${SPD}
+
 SOC_DIR		:=	plat/nvidia/tegra/soc/${TARGET_SOC}
 
 include plat/nvidia/tegra/common/tegra_common.mk


### PR DESCRIPTION
This patch adds support to run a Trusted OS during boot time. The
previous stage bootloader passes the entry point information in
the 'bl32_ep_info' structure.

The build system expects the dispatcher to be passed as an input
parameter using the 'SPD=<dispatcher>' option. This information
has also been added to the Tegra documentation's 'build' section.

Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>