### PR TITLE
Fix build option 'ARM_TSP_RAM_LOCATION' in user guide

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -322,7 +322,7 @@ performed.
 
 #### ARM development platform specific build options
 
-*   `ARM_TSP_RAM_LOCATION_ID`: location of the TSP binary. Options:
+*   `ARM_TSP_RAM_LOCATION`: location of the TSP binary. Options:
     -   `tsram` : Trusted SRAM (default option)
     -   `tdram` : Trusted DRAM (if available)
     -   `dram`  : Secure region in DRAM (configured by the TrustZone controller)


### PR DESCRIPTION
The 'ARM_TSP_RAM_LOCATION_ID' option specified in the user guide
corresponds to the internal definition not visible to the final
user. The proper build option is 'ARM_TSP_RAM_LOCATION'. This
patch fixes it.

Fixes ARM-software/tf-issues#308

Change-Id: Ica8cb72c0c5e8b3503f60b5357d16698e869b1bd