### PR TITLE
Reserve a Video Memory aperture in DRAM memory

### DIFF
--- a/plat/nvidia/tegra/common/drivers/memctrl/memctrl.c
+++ b/plat/nvidia/tegra/common/drivers/memctrl/memctrl.c
@@ -28,11 +28,23 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <arch_helpers.h>
 #include <assert.h>
 #include <debug.h>
 #include <mmio.h>
 #include <memctrl.h>
+#include <string.h>
 #include <tegra_def.h>
+#include <xlat_tables.h>
+
+extern void zeromem16(void *mem, unsigned int length);
+
+#define TEGRA_GPU_RESET_REG_OFFSET	0x28c
+#define  GPU_RESET_BIT			(1 << 24)
+
+/* Video Memory base and size (live values) */
+static uintptr_t video_mem_base;
+static uint64_t video_mem_size;
 
 /*
  * Init SMMU.
@@ -71,6 +83,10 @@ void tegra_memctrl_setup(void)
 	tegra_mc_write_32(MC_SMMU_CONFIG_0,
 			  MC_SMMU_CONFIG_0_SMMU_ENABLE_ENABLE);
 	(void)tegra_mc_read_32(MC_SMMU_CONFIG_0); /* read to flush writes */
+
+	/* video memory carveout */
+	tegra_mc_write_32(MC_VIDEO_PROTECT_BASE, video_mem_base);
+	tegra_mc_write_32(MC_VIDEO_PROTECT_SIZE_MB, video_mem_size);
 }
 
 /*
@@ -89,4 +105,67 @@ void tegra_memctrl_tzdram_setup(uint64_t phys_base, uint32_t size_in_bytes)
 
 	tegra_mc_write_32(MC_SECURITY_CFG0_0, phys_base);
 	tegra_mc_write_32(MC_SECURITY_CFG1_0, size_in_bytes >> 20);
+}
+
+/*
+ * Program the Video Memory carveout region
+ *
+ * phys_base = physical base of aperture
+ * size_in_bytes = size of aperture in bytes
+ */
+void tegra_memctrl_videomem_setup(uint64_t phys_base, uint32_t size_in_bytes)
+{
+	uintptr_t vmem_end_old = video_mem_base + (video_mem_size << 20);
+	uintptr_t vmem_end_new = phys_base + size_in_bytes;
+	uint32_t regval;
+
+	/*
+	 * The GPU is the user of the Video Memory region. In order to
+	 * transition to the new memory region smoothly, we program the
+	 * new base/size ONLY if the GPU is in reset mode.
+	 */
+	regval = mmio_read_32(TEGRA_CAR_RESET_BASE + TEGRA_GPU_RESET_REG_OFFSET);
+	if ((regval & GPU_RESET_BIT) == 0) {
+		ERROR("GPU not in reset! Video Memory setup failed\n");
+		return;
+	}
+
+	/*
+	 * Setup the Memory controller to restrict CPU accesses to the Video
+	 * Memory region
+	 */
+	INFO("Configuring Video Memory Carveout\n");
+
+	/*
+	 * Configure Memory Controller directly for the first time.
+	 */
+	if (video_mem_base == 0)
+		goto done;
+
+	/*
+	 * Clear the old regions now being exposed. The following cases
+	 * can occur -
+	 *
+	 * 1. clear whole old region (no overlap with new region)
+	 * 2. clear old sub-region below new base
+	 * 3. clear old sub-region above new end
+	 */
+	INFO("Cleaning previous Video Memory Carveout\n");
+
+	disable_mmu_el3();
+	if (phys_base > vmem_end_old || video_mem_base > vmem_end_new)
+		zeromem16((void *)video_mem_base, video_mem_size << 20);
+	else if (video_mem_base < phys_base)
+		zeromem16((void *)video_mem_base, phys_base - video_mem_base);
+	else if (vmem_end_old > vmem_end_new)
+		zeromem16((void *)vmem_end_new, vmem_end_old - vmem_end_new);
+	enable_mmu_el3(0);
+
+done:
+	tegra_mc_write_32(MC_VIDEO_PROTECT_BASE, phys_base);
+	tegra_mc_write_32(MC_VIDEO_PROTECT_SIZE_MB, size_in_bytes >> 20);
+
+	/* store new values */
+	video_mem_base = phys_base;
+	video_mem_size = size_in_bytes >> 20;
 }

--- a/plat/nvidia/tegra/common/tegra_bl31_setup.c
+++ b/plat/nvidia/tegra/common/tegra_bl31_setup.c
@@ -37,6 +37,7 @@
 #include <cortex_a57.h>
 #include <cortex_a53.h>
 #include <debug.h>
+#include <errno.h>
 #include <memctrl.h>
 #include <mmio.h>
 #include <platform.h>
@@ -225,4 +226,33 @@ void bl31_plat_arch_setup(void)
 
 	/* enable the MMU */
 	enable_mmu_el3(0);
+}
+
+/*******************************************************************************
+ * Check if the given NS DRAM range is valid
+ ******************************************************************************/
+int bl31_check_ns_address(uint64_t base, uint64_t size_in_bytes)
+{
+	uint64_t end = base + size_in_bytes - 1;
+
+	/*
+	 * Check if the NS DRAM address is valid
+	 */
+	if ((base < TEGRA_DRAM_BASE) || (end > TEGRA_DRAM_END) ||
+	    (base >= end)) {
+		ERROR("NS address is out-of-bounds!\n");
+		return -EFAULT;
+	}
+
+	/*
+	 * TZDRAM aperture contains the BL31 and BL32 images, so we need
+	 * to check if the NS DRAM range overlaps the TZDRAM aperture.
+	 */
+	if ((base < TZDRAM_END) && (end > tegra_bl31_phys_base)) {
+		ERROR("NS address overlaps TZDRAM!\n");
+		return -ENOTSUP;
+	}
+
+	/* valid NS address */
+	return 0;
 }

--- a/plat/nvidia/tegra/common/tegra_common.mk
+++ b/plat/nvidia/tegra/common/tegra_common.mk
@@ -59,4 +59,5 @@ BL31_SOURCES		+=	drivers/arm/gic/arm_gic.c			\
 				${COMMON_DIR}/tegra_bl31_setup.c		\
 				${COMMON_DIR}/tegra_gic.c			\
 				${COMMON_DIR}/tegra_pm.c			\
+				${COMMON_DIR}/tegra_sip_calls.c			\
 				${COMMON_DIR}/tegra_topology.c

--- a/plat/nvidia/tegra/include/drivers/memctrl.h
+++ b/plat/nvidia/tegra/include/drivers/memctrl.h
@@ -64,6 +64,10 @@
 #define MC_SECURITY_CFG0_0			0x70
 #define MC_SECURITY_CFG1_0			0x74
 
+/* Video Memory carveout configuration registers */
+#define MC_VIDEO_PROTECT_BASE			0x648
+#define MC_VIDEO_PROTECT_SIZE_MB		0x64c
+
 static inline uint32_t tegra_mc_read_32(uint32_t off)
 {
 	return mmio_read_32(TEGRA_MC_BASE + off);
@@ -76,5 +80,6 @@ static inline void tegra_mc_write_32(uint32_t off, uint32_t val)
 
 void tegra_memctrl_setup(void);
 void tegra_memctrl_tzdram_setup(uint64_t phys_base, uint32_t size_in_bytes);
+void tegra_memctrl_videomem_setup(uint64_t phys_base, uint32_t size_in_bytes);
 
 #endif /* __MEMCTRL_H__ */


### PR DESCRIPTION
This patch adds support to reserve a memory carveout region in the
DRAM on Tegra SoCs. The memory controller provides specific registers
to specify the aperture's base and size. This aperture can also be
changed dynamically in order to re-size the memory available for
DRM video playback. In case of the new aperture not overlapping
the previous one, the previous aperture has to be cleared before
setting up the new one. This means we do not "leak" any video data
to the NS world.

Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>