### PR TITLE
Fix integer extension in mpidr_set_aff_inst()

### DIFF
--- a/services/std_svc/psci/psci_common.c
+++ b/services/std_svc/psci/psci_common.c
@@ -185,8 +185,8 @@ unsigned long mpidr_set_aff_inst(unsigned long mpidr,
 	aff_shift = get_afflvl_shift(aff_lvl);
 
 	/* Clear the existing affinity instance & set the new one*/
-	mpidr &= ~(MPIDR_AFFLVL_MASK << aff_shift);
-	mpidr |= aff_inst << aff_shift;
+	mpidr &= ~(((unsigned long)MPIDR_AFFLVL_MASK) << aff_shift);
+	mpidr |= ((unsigned long)aff_inst) << aff_shift;
 
 	return mpidr;
 }


### PR DESCRIPTION
`mpidr_set_aff_inst()` is left shifting an int constant and an
unsigned char value to construct an `MPIDR`. For affinity level 3 a
shift of 32 would result in shifting out of the 32-bit type and
have no effect on the `MPIDR`.

These values need to be extended to unsigned long before shifting
to ensure correct results for affinity level 3.