### PR TITLE
Bug fix: Build time condition to relocate RW data

### DIFF
--- a/include/common/el3_common_macros.S
+++ b/include/common/el3_common_macros.S
@@ -226,7 +226,7 @@
 		bl	zeromem16
 #endif
 
-#ifdef __DATA_ROM_START__
+#if IMAGE_BL1
 		ldr	x0, =__DATA_RAM_START__
 		ldr	x1, =__DATA_ROM_START__
 		ldr	x2, =__DATA_SIZE__


### PR DESCRIPTION
This patch fixes the build time condition deciding whether the
read-write data should be relocated from ROM to RAM. It was incorrectly
using __DATA_ROM_START__, which is a linker symbol and not a compiler
build flag. As a result, the relocation code was always compiled out.

This bug has been introduced by the following patch:
"Rationalize reset handling code"