### PR TITLE
TBB: build 'cert_create' with ECDSA only if OpenSSL supports it

### DIFF
--- a/tools/cert_create/include/key.h
+++ b/tools/cert_create/include/key.h
@@ -47,7 +47,10 @@ enum {
 /* Supported key algorithms */
 enum {
 	KEY_ALG_RSA,
-	KEY_ALG_ECDSA
+#ifndef OPENSSL_NO_EC
+	KEY_ALG_ECDSA,
+#endif /* OPENSSL_NO_EC */
+	KEY_ALG_MAX_NUM
 };
 
 /*

--- a/tools/cert_create/src/main.c
+++ b/tools/cert_create/src/main.c
@@ -142,7 +142,9 @@ static char *strdup(const char *str)
 
 static const char *key_algs_str[] = {
 	[KEY_ALG_RSA] = "rsa",
+#ifndef OPENSSL_NO_EC
 	[KEY_ALG_ECDSA] = "ecdsa"
+#endif /* OPENSSL_NO_EC */
 };
 
 /* Command line options */


### PR DESCRIPTION
Some Linux distributions include an OpenSSL library which has been
built without ECDSA support. Trying to build the certificate
generation tool on those distributions will result in a build error.

This patch fixes that issue by including ECDSA support only if
OpenSSL has been built with ECDSA. In that case, the OpenSSL
configuration file does not define the OPENSSL_NO_EC macro. The tool
will build successfully, although the resulting binary will not
support ECDSA keys.

Change-Id: I4627d1abd19eef7ad3251997d8218599187eb902