### PR TITLE
Implement get_sys_suspend_power_state() handler for Tegra

### DIFF
--- a/plat/nvidia/tegra/common/tegra_pm.c
+++ b/plat/nvidia/tegra/common/tegra_pm.c
@@ -114,6 +114,22 @@ void tegra_affinst_standby(unsigned int power_state)
 }
 
 /*******************************************************************************
+ * This handler is called by the PSCI implementation during the `SYSTEM_SUSPEND`
+ * call to get the `power_state` parameter. This allows the platform to encode
+ * the appropriate State-ID field within the `power_state` parameter which can
+ * be utilized in `affinst_suspend()` to suspend to system affinity level.
+******************************************************************************/
+unsigned int tegra_get_sys_suspend_power_state(void)
+{
+	unsigned int power_state;
+
+	power_state = psci_make_powerstate(PLAT_SYS_SUSPEND_STATE_ID,
+			PSTATE_TYPE_POWERDOWN, MPIDR_AFFLVL2);
+
+	return power_state;
+}
+
+/*******************************************************************************
  * Handler called to check the validity of the power state parameter.
  ******************************************************************************/
 int32_t tegra_validate_power_state(unsigned int power_state)
@@ -310,7 +326,8 @@ static const plat_pm_ops_t tegra_plat_pm_ops = {
 	.affinst_suspend_finish	= tegra_affinst_suspend_finish,
 	.system_off		= tegra_system_off,
 	.system_reset		= tegra_system_reset,
-	.validate_power_state	= tegra_validate_power_state
+	.validate_power_state	= tegra_validate_power_state,
+	.get_sys_suspend_power_state = tegra_get_sys_suspend_power_state
 };
 
 /*******************************************************************************

--- a/plat/nvidia/tegra/include/t210/tegra_def.h
+++ b/plat/nvidia/tegra/include/t210/tegra_def.h
@@ -34,6 +34,22 @@
 #include <platform_def.h>
 
 /*******************************************************************************
+ * Power down state IDs
+ ******************************************************************************/
+#define PSTATE_ID_CORE_POWERDN		7
+#define PSTATE_ID_CLUSTER_IDLE		16
+#define PSTATE_ID_CLUSTER_POWERDN	17
+#define PSTATE_ID_SOC_POWERDN		27
+
+/*******************************************************************************
+ * This value is used by the PSCI implementation during the `SYSTEM_SUSPEND`
+ * call as the `power_state` parameter. This allows the platform to encode
+ * the appropriate State-ID field within the `power_state` parameter which
+ * can be utilized in `affinst_suspend()` to suspend to system affinity level.
+ ******************************************************************************/
+#define PLAT_SYS_SUSPEND_STATE_ID	PSTATE_ID_SOC_POWERDN
+
+/*******************************************************************************
  * Implementation defined ACTLR_EL3 bit definitions
  ******************************************************************************/
 #define ACTLR_EL3_L2ACTLR_BIT		(1 << 6)

--- a/plat/nvidia/tegra/soc/t210/plat_psci_handlers.c
+++ b/plat/nvidia/tegra/soc/t210/plat_psci_handlers.c
@@ -40,12 +40,6 @@
 #include <tegra_def.h>
 #include <tegra_private.h>
 
-/* Power down state IDs */
-#define PSTATE_ID_CORE_POWERDN		7
-#define PSTATE_ID_CLUSTER_IDLE		16
-#define PSTATE_ID_CLUSTER_POWERDN	17
-#define PSTATE_ID_SOC_POWERDN		27
-
 static int cpu_powergate_mask[PLATFORM_MAX_CPUS_PER_CLUSTER];
 
 int tegra_prepare_cpu_suspend(unsigned int id, unsigned int afflvl)


### PR DESCRIPTION
This patch implements the get_sys_suspend_power_state() handler required by
the PSCI SYSTEM_SUSPEND API. The intent of this handler is to return the
appropriate State-ID field which can be utilized in `affinst_suspend()` to
suspend to system affinity level.

Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>