### PR TITLE
Tegra misc fixes v1

### DIFF
--- a/plat/nvidia/tegra/common/drivers/flowctrl/flowctrl.c
+++ b/plat/nvidia/tegra/common/drivers/flowctrl/flowctrl.c
@@ -215,7 +215,7 @@ void tegra_fc_lock_active_cluster(void)
  ******************************************************************************/
 void tegra_fc_reset_bpmp(void)
 {
-	uint32_t val;
+	uint32_t val, start, now;
 
 	/* halt BPMP */
 	tegra_fc_write_32(FLOWCTRL_HALT_BPMP_EVENTS, FLOWCTRL_WAITEVENT);
@@ -230,10 +230,10 @@ void tegra_fc_reset_bpmp(void)
 		; /* wait till value reaches EVP_BPMP_RESET_VECTOR */
 
 	/* Wait for 2us before de-asserting the reset signal. */
-	val = mmio_read_32(TEGRA_TMRUS_BASE);
-	val += 2;
-	while (val > mmio_read_32(TEGRA_TMRUS_BASE))
-		; /* wait for 2us */
+	start = mmio_read_32(TEGRA_TMRUS_BASE);
+	do {
+		now = mmio_read_32(TEGRA_TMRUS_BASE);
+	} while ((now - start) <= 2);
 
 	/* De-assert BPMP reset */
 	mmio_write_32(TEGRA_CAR_RESET_BASE + CLK_RST_DEV_L_CLR, CLK_BPMP_RST);

--- a/plat/nvidia/tegra/common/tegra_bl31_setup.c
+++ b/plat/nvidia/tegra/common/tegra_bl31_setup.c
@@ -196,13 +196,10 @@ void bl31_plat_arch_setup(void)
 	unsigned long total_size = TZDRAM_END - BL31_RO_BASE;
 	unsigned long ro_start = bl31_base_pa;
 	unsigned long ro_size = BL31_RO_LIMIT - BL31_RO_BASE;
+	const mmap_region_t *plat_mmio_map = NULL;
+#if USE_COHERENT_MEM
 	unsigned long coh_start = 0;
 	unsigned long coh_size = 0;
-	const mmap_region_t *plat_mmio_map = NULL;
-
-#if USE_COHERENT_MEM
-	coh_start = total_base + (BL31_COHERENT_RAM_BASE - BL31_RO_BASE);
-	coh_size = BL31_COHERENT_RAM_LIMIT - BL31_COHERENT_RAM_BASE;
 #endif
 
 	/* add memory regions */
@@ -212,7 +209,11 @@ void bl31_plat_arch_setup(void)
 	mmap_add_region(ro_start, ro_start,
 			ro_size,
 			MT_MEMORY | MT_RO | MT_SECURE);
+
 #if USE_COHERENT_MEM
+	coh_start = total_base + (BL31_COHERENT_RAM_BASE - BL31_RO_BASE);
+	coh_size = BL31_COHERENT_RAM_LIMIT - BL31_COHERENT_RAM_BASE;
+
 	mmap_add_region(coh_start, coh_start,
 			coh_size,
 			MT_DEVICE | MT_RW | MT_SECURE);

--- a/plat/nvidia/tegra/common/tegra_common.mk
+++ b/plat/nvidia/tegra/common/tegra_common.mk
@@ -34,6 +34,8 @@ $(eval $(call add_define,CRASH_REPORTING))
 ASM_ASSERTION		:=	1
 $(eval $(call add_define,ASM_ASSERTION))
 
+USE_COHERENT_MEM	:=	0
+
 PLAT_INCLUDES		:=	-Iplat/nvidia/tegra/include/drivers \
 				-Iplat/nvidia/tegra/include \
 				-Iplat/nvidia/tegra/include/${TARGET_SOC}

--- a/plat/nvidia/tegra/soc/t210/plat_psci_handlers.c
+++ b/plat/nvidia/tegra/soc/t210/plat_psci_handlers.c
@@ -40,6 +40,13 @@
 #include <tegra_def.h>
 #include <tegra_private.h>
 
+/*
+ * Register used to clear CPU reset signals. Each CPU has two reset
+ * signals: CPU reset (3:0) and Core reset (19:16).
+ */
+#define CPU_CMPLX_RESET_CLR		0x454
+#define CPU_CORE_RESET_MASK		0x10001
+
 /* Power down state IDs */
 #define PSTATE_ID_CORE_POWERDN		7
 #define PSTATE_ID_CLUSTER_IDLE		16
@@ -122,6 +129,10 @@ int tegra_prepare_cpu_on_finish(unsigned long mpidr)
 int tegra_prepare_cpu_on(unsigned long mpidr)
 {
 	int cpu = mpidr & MPIDR_CPU_MASK;
+	uint32_t mask = CPU_CORE_RESET_MASK << cpu;
+
+	/* Deassert CPU reset signals */
+	mmio_write_32(TEGRA_CAR_RESET_BASE + CPU_CMPLX_RESET_CLR, mask);
 
 	/* Turn on CPU using flow controller or PMC */
 	if (cpu_powergate_mask[cpu] == 0) {


### PR DESCRIPTION
- Deassert CPU reset signals during power ON
- Fix the delay loop during SC7 exit
- Exclude coherent memory from BL31 memory map