### PR TITLE
Use uintptr_t as base address type in ARM driver APIs

### DIFF
--- a/drivers/arm/cci/cci.c
+++ b/drivers/arm/cci/cci.c
@@ -33,8 +33,9 @@
 #include <cci.h>
 #include <debug.h>
 #include <mmio.h>
+#include <stdint.h>
 
-static unsigned long g_cci_base;
+static uintptr_t g_cci_base;
 static unsigned int g_max_master_id;
 static const int *g_cci_slave_if_map;
 
@@ -74,7 +75,7 @@ static int validate_cci_map(const int *map)
 }
 #endif /* DEBUG */
 
-void cci_init(unsigned long cci_base,
+void cci_init(uintptr_t cci_base,
 		const int *map,
 		unsigned int num_cci_masters)
 {

--- a/drivers/arm/cci400/cci400.c
+++ b/drivers/arm/cci400/cci400.c
@@ -33,14 +33,15 @@
 #include <cci400.h>
 #include <debug.h>
 #include <mmio.h>
+#include <stdint.h>
 
 #define MAX_CLUSTERS		2
 
-static unsigned long cci_base_addr;
+static uintptr_t cci_base_addr;
 static unsigned int cci_cluster_ix_to_iface[MAX_CLUSTERS];
 
 
-void cci_init(unsigned long cci_base,
+void cci_init(uintptr_t cci_base,
 		int slave_iface3_cluster_ix,
 		int slave_iface4_cluster_ix)
 {

--- a/drivers/arm/gic/arm_gic.c
+++ b/drivers/arm/gic/arm_gic.c
@@ -47,9 +47,9 @@
 	(GIC_HIGHEST_NS_PRIORITY << 16) | \
 	(GIC_HIGHEST_NS_PRIORITY << 24))
 
-static unsigned int g_gicc_base;
-static unsigned int g_gicd_base;
-static unsigned long g_gicr_base;
+static uintptr_t g_gicc_base;
+static uintptr_t g_gicd_base;
+static uintptr_t g_gicr_base;
 static const unsigned int *g_irq_sec_ptr;
 static unsigned int g_num_irqs;
 
@@ -323,12 +323,11 @@ static void arm_gic_distif_setup(void)
 /*******************************************************************************
  * Initialize the ARM GIC driver with the provided platform inputs
 ******************************************************************************/
-void arm_gic_init(unsigned int gicc_base,
-		unsigned int gicd_base,
-		unsigned long gicr_base,
-		const unsigned int *irq_sec_ptr,
-		unsigned int num_irqs
-		)
+void arm_gic_init(uintptr_t gicc_base,
+		  uintptr_t gicd_base,
+		  uintptr_t gicr_base,
+		  const unsigned int *irq_sec_ptr,
+		  unsigned int num_irqs)
 {
 	unsigned int val;
 

--- a/drivers/arm/gic/gic_v2.c
+++ b/drivers/arm/gic/gic_v2.c
@@ -38,73 +38,73 @@
  * GIC Distributor interface accessors for reading entire registers
  ******************************************************************************/
 
-unsigned int gicd_read_igroupr(unsigned int base, unsigned int id)
+unsigned int gicd_read_igroupr(uintptr_t base, unsigned int id)
 {
 	unsigned n = id >> IGROUPR_SHIFT;
 	return mmio_read_32(base + GICD_IGROUPR + (n << 2));
 }
 
-unsigned int gicd_read_isenabler(unsigned int base, unsigned int id)
+unsigned int gicd_read_isenabler(uintptr_t base, unsigned int id)
 {
 	unsigned n = id >> ISENABLER_SHIFT;
 	return mmio_read_32(base + GICD_ISENABLER + (n << 2));
 }
 
-unsigned int gicd_read_icenabler(unsigned int base, unsigned int id)
+unsigned int gicd_read_icenabler(uintptr_t base, unsigned int id)
 {
 	unsigned n = id >> ICENABLER_SHIFT;
 	return mmio_read_32(base + GICD_ICENABLER + (n << 2));
 }
 
-unsigned int gicd_read_ispendr(unsigned int base, unsigned int id)
+unsigned int gicd_read_ispendr(uintptr_t base, unsigned int id)
 {
 	unsigned n = id >> ISPENDR_SHIFT;
 	return mmio_read_32(base + GICD_ISPENDR + (n << 2));
 }
 
-unsigned int gicd_read_icpendr(unsigned int base, unsigned int id)
+unsigned int gicd_read_icpendr(uintptr_t base, unsigned int id)
 {
 	unsigned n = id >> ICPENDR_SHIFT;
 	return mmio_read_32(base + GICD_ICPENDR + (n << 2));
 }
 
-unsigned int gicd_read_isactiver(unsigned int base, unsigned int id)
+unsigned int gicd_read_isactiver(uintptr_t base, unsigned int id)
 {
 	unsigned n = id >> ISACTIVER_SHIFT;
 	return mmio_read_32(base + GICD_ISACTIVER + (n << 2));
 }
 
-unsigned int gicd_read_icactiver(unsigned int base, unsigned int id)
+unsigned int gicd_read_icactiver(uintptr_t base, unsigned int id)
 {
 	unsigned n = id >> ICACTIVER_SHIFT;
 	return mmio_read_32(base + GICD_ICACTIVER + (n << 2));
 }
 
-unsigned int gicd_read_ipriorityr(unsigned int base, unsigned int id)
+unsigned int gicd_read_ipriorityr(uintptr_t base, unsigned int id)
 {
 	unsigned n = id >> IPRIORITYR_SHIFT;
 	return mmio_read_32(base + GICD_IPRIORITYR + (n << 2));
 }
 
-unsigned int gicd_read_itargetsr(unsigned int base, unsigned int id)
+unsigned int gicd_read_itargetsr(uintptr_t base, unsigned int id)
 {
 	unsigned n = id >> ITARGETSR_SHIFT;
 	return mmio_read_32(base + GICD_ITARGETSR + (n << 2));
 }
 
-unsigned int gicd_read_icfgr(unsigned int base, unsigned int id)
+unsigned int gicd_read_icfgr(uintptr_t base, unsigned int id)
 {
 	unsigned n = id >> ICFGR_SHIFT;
 	return mmio_read_32(base + GICD_ICFGR + (n << 2));
 }
 
-unsigned int gicd_read_cpendsgir(unsigned int base, unsigned int id)
+unsigned int gicd_read_cpendsgir(uintptr_t base, unsigned int id)
 {
 	unsigned n = id >> CPENDSGIR_SHIFT;
 	return mmio_read_32(base + GICD_CPENDSGIR + (n << 2));
 }
 
-unsigned int gicd_read_spendsgir(unsigned int base, unsigned int id)
+unsigned int gicd_read_spendsgir(uintptr_t base, unsigned int id)
 {
 	unsigned n = id >> SPENDSGIR_SHIFT;
 	return mmio_read_32(base + GICD_SPENDSGIR + (n << 2));
@@ -114,73 +114,73 @@ unsigned int gicd_read_spendsgir(unsigned int base, unsigned int id)
  * GIC Distributor interface accessors for writing entire registers
  ******************************************************************************/
 
-void gicd_write_igroupr(unsigned int base, unsigned int id, unsigned int val)
+void gicd_write_igroupr(uintptr_t base, unsigned int id, unsigned int val)
 {
 	unsigned n = id >> IGROUPR_SHIFT;
 	mmio_write_32(base + GICD_IGROUPR + (n << 2), val);
 }
 
-void gicd_write_isenabler(unsigned int base, unsigned int id, unsigned int val)
+void gicd_write_isenabler(uintptr_t base, unsigned int id, unsigned int val)
 {
 	unsigned n = id >> ISENABLER_SHIFT;
 	mmio_write_32(base + GICD_ISENABLER + (n << 2), val);
 }
 
-void gicd_write_icenabler(unsigned int base, unsigned int id, unsigned int val)
+void gicd_write_icenabler(uintptr_t base, unsigned int id, unsigned int val)
 {
 	unsigned n = id >> ICENABLER_SHIFT;
 	mmio_write_32(base + GICD_ICENABLER + (n << 2), val);
 }
 
-void gicd_write_ispendr(unsigned int base, unsigned int id, unsigned int val)
+void gicd_write_ispendr(uintptr_t base, unsigned int id, unsigned int val)
 {
 	unsigned n = id >> ISPENDR_SHIFT;
 	mmio_write_32(base + GICD_ISPENDR + (n << 2), val);
 }
 
-void gicd_write_icpendr(unsigned int base, unsigned int id, unsigned int val)
+void gicd_write_icpendr(uintptr_t base, unsigned int id, unsigned int val)
 {
 	unsigned n = id >> ICPENDR_SHIFT;
 	mmio_write_32(base + GICD_ICPENDR + (n << 2), val);
 }
 
-void gicd_write_isactiver(unsigned int base, unsigned int id, unsigned int val)
+void gicd_write_isactiver(uintptr_t base, unsigned int id, unsigned int val)
 {
 	unsigned n = id >> ISACTIVER_SHIFT;
 	mmio_write_32(base + GICD_ISACTIVER + (n << 2), val);
 }
 
-void gicd_write_icactiver(unsigned int base, unsigned int id, unsigned int val)
+void gicd_write_icactiver(uintptr_t base, unsigned int id, unsigned int val)
 {
 	unsigned n = id >> ICACTIVER_SHIFT;
 	mmio_write_32(base + GICD_ICACTIVER + (n << 2), val);
 }
 
-void gicd_write_ipriorityr(unsigned int base, unsigned int id, unsigned int val)
+void gicd_write_ipriorityr(uintptr_t base, unsigned int id, unsigned int val)
 {
 	unsigned n = id >> IPRIORITYR_SHIFT;
 	mmio_write_32(base + GICD_IPRIORITYR + (n << 2), val);
 }
 
-void gicd_write_itargetsr(unsigned int base, unsigned int id, unsigned int val)
+void gicd_write_itargetsr(uintptr_t base, unsigned int id, unsigned int val)
 {
 	unsigned n = id >> ITARGETSR_SHIFT;
 	mmio_write_32(base + GICD_ITARGETSR + (n << 2), val);
 }
 
-void gicd_write_icfgr(unsigned int base, unsigned int id, unsigned int val)
+void gicd_write_icfgr(uintptr_t base, unsigned int id, unsigned int val)
 {
 	unsigned n = id >> ICFGR_SHIFT;
 	mmio_write_32(base + GICD_ICFGR + (n << 2), val);
 }
 
-void gicd_write_cpendsgir(unsigned int base, unsigned int id, unsigned int val)
+void gicd_write_cpendsgir(uintptr_t base, unsigned int id, unsigned int val)
 {
 	unsigned n = id >> CPENDSGIR_SHIFT;
 	mmio_write_32(base + GICD_CPENDSGIR + (n << 2), val);
 }
 
-void gicd_write_spendsgir(unsigned int base, unsigned int id, unsigned int val)
+void gicd_write_spendsgir(uintptr_t base, unsigned int id, unsigned int val)
 {
 	unsigned n = id >> SPENDSGIR_SHIFT;
 	mmio_write_32(base + GICD_SPENDSGIR + (n << 2), val);
@@ -189,7 +189,7 @@ void gicd_write_spendsgir(unsigned int base, unsigned int id, unsigned int val)
 /*******************************************************************************
  * GIC Distributor interface accessors for individual interrupt manipulation
  ******************************************************************************/
-unsigned int gicd_get_igroupr(unsigned int base, unsigned int id)
+unsigned int gicd_get_igroupr(uintptr_t base, unsigned int id)
 {
 	unsigned bit_num = id & ((1 << IGROUPR_SHIFT) - 1);
 	unsigned int reg_val = gicd_read_igroupr(base, id);
@@ -197,7 +197,7 @@ unsigned int gicd_get_igroupr(unsigned int base, unsigned int id)
 	return (reg_val >> bit_num) & 0x1;
 }
 
-void gicd_set_igroupr(unsigned int base, unsigned int id)
+void gicd_set_igroupr(uintptr_t base, unsigned int id)
 {
 	unsigned bit_num = id & ((1 << IGROUPR_SHIFT) - 1);
 	unsigned int reg_val = gicd_read_igroupr(base, id);
@@ -205,7 +205,7 @@ void gicd_set_igroupr(unsigned int base, unsigned int id)
 	gicd_write_igroupr(base, id, reg_val | (1 << bit_num));
 }
 
-void gicd_clr_igroupr(unsigned int base, unsigned int id)
+void gicd_clr_igroupr(uintptr_t base, unsigned int id)
 {
 	unsigned bit_num = id & ((1 << IGROUPR_SHIFT) - 1);
 	unsigned int reg_val = gicd_read_igroupr(base, id);
@@ -213,42 +213,42 @@ void gicd_clr_igroupr(unsigned int base, unsigned int id)
 	gicd_write_igroupr(base, id, reg_val & ~(1 << bit_num));
 }
 
-void gicd_set_isenabler(unsigned int base, unsigned int id)
+void gicd_set_isenabler(uintptr_t base, unsigned int id)
 {
 	unsigned bit_num = id & ((1 << ISENABLER_SHIFT) - 1);
 
 	gicd_write_isenabler(base, id, (1 << bit_num));
 }
 
-void gicd_set_icenabler(unsigned int base, unsigned int id)
+void gicd_set_icenabler(uintptr_t base, unsigned int id)
 {
 	unsigned bit_num = id & ((1 << ICENABLER_SHIFT) - 1);
 
 	gicd_write_icenabler(base, id, (1 << bit_num));
 }
 
-void gicd_set_ispendr(unsigned int base, unsigned int id)
+void gicd_set_ispendr(uintptr_t base, unsigned int id)
 {
 	unsigned bit_num = id & ((1 << ISPENDR_SHIFT) - 1);
 
 	gicd_write_ispendr(base, id, (1 << bit_num));
 }
 
-void gicd_set_icpendr(unsigned int base, unsigned int id)
+void gicd_set_icpendr(uintptr_t base, unsigned int id)
 {
 	unsigned bit_num = id & ((1 << ICPENDR_SHIFT) - 1);
 
 	gicd_write_icpendr(base, id, (1 << bit_num));
 }
 
-void gicd_set_isactiver(unsigned int base, unsigned int id)
+void gicd_set_isactiver(uintptr_t base, unsigned int id)
 {
 	unsigned bit_num = id & ((1 << ISACTIVER_SHIFT) - 1);
 
 	gicd_write_isactiver(base, id, (1 << bit_num));
 }
 
-void gicd_set_icactiver(unsigned int base, unsigned int id)
+void gicd_set_icactiver(uintptr_t base, unsigned int id)
 {
 	unsigned bit_num = id & ((1 << ICACTIVER_SHIFT) - 1);
 
@@ -259,7 +259,7 @@ void gicd_set_icactiver(unsigned int base, unsigned int id)
  * Make sure that the interrupt's group is set before expecting
  * this function to do its job correctly.
  */
-void gicd_set_ipriorityr(unsigned int base, unsigned int id, unsigned int pri)
+void gicd_set_ipriorityr(uintptr_t base, unsigned int id, unsigned int pri)
 {
 	unsigned int reg = base + GICD_IPRIORITYR + (id & ~3);
 	unsigned int shift = (id & 3) << 3;
@@ -283,7 +283,7 @@ void gicd_set_ipriorityr(unsigned int base, unsigned int id, unsigned int pri)
 	mmio_write_32(reg, reg_val);
 }
 
-void gicd_set_itargetsr(unsigned int base, unsigned int id, unsigned int target)
+void gicd_set_itargetsr(uintptr_t base, unsigned int id, unsigned int target)
 {
 	unsigned byte_off = id & ((1 << ITARGETSR_SHIFT) - 1);
 	unsigned int reg_val = gicd_read_itargetsr(base, id);

--- a/drivers/arm/pl011/pl011_console.S
+++ b/drivers/arm/pl011/pl011_console.S
@@ -44,7 +44,7 @@
 
 
 	/* -----------------------------------------------
-	 * int console_core_init(unsigned long base_addr,
+	 * int console_core_init(uintptr_t base_addr,
 	 * unsigned int uart_clk, unsigned int baud_rate)
 	 * Function to initialize the console without a
 	 * C Runtime to print debug information. This
@@ -90,7 +90,7 @@ core_init_fail:
 endfunc console_core_init
 
 	/* --------------------------------------------------------
-	 * int console_core_putc(int c, unsigned long base_addr)
+	 * int console_core_putc(int c, uintptr_t base_addr)
 	 * Function to output a character over the console. It
 	 * returns the character printed on success or -1 on error.
 	 * In : w0 - character to be printed
@@ -123,7 +123,7 @@ putc_error:
 endfunc console_core_putc
 
 	/* ---------------------------------------------
-	 * int console_core_getc(unsigned long base_addr)
+	 * int console_core_getc(uintptr_t base_addr)
 	 * Function to get a character from the console.
 	 * It returns the character grabbed on success
 	 * or -1 on error.

--- a/drivers/arm/tzc400/tzc400.c
+++ b/drivers/arm/tzc400/tzc400.c
@@ -41,7 +41,7 @@
  * Address width : Values between 32 to 64
  */
 typedef struct tzc_instance {
-	uint64_t base;
+	uintptr_t base;
 	uint8_t addr_width;
 	uint8_t num_filters;
 	uint8_t num_regions;
@@ -50,27 +50,27 @@ typedef struct tzc_instance {
 tzc_instance_t tzc;
 
 
-static inline uint32_t tzc_read_build_config(uint64_t base)
+static inline uint32_t tzc_read_build_config(uintptr_t base)
 {
 	return mmio_read_32(base + BUILD_CONFIG_OFF);
 }
 
-static inline uint32_t tzc_read_gate_keeper(uint64_t base)
+static inline uint32_t tzc_read_gate_keeper(uintptr_t base)
 {
 	return mmio_read_32(base + GATE_KEEPER_OFF);
 }
 
-static inline void tzc_write_gate_keeper(uint64_t base, uint32_t val)
+static inline void tzc_write_gate_keeper(uintptr_t base, uint32_t val)
 {
 	mmio_write_32(base + GATE_KEEPER_OFF, val);
 }
 
-static inline void tzc_write_action(uint64_t base, tzc_action_t action)
+static inline void tzc_write_action(uintptr_t base, tzc_action_t action)
 {
 	mmio_write_32(base + ACTION_OFF, action);
 }
 
-static inline void tzc_write_region_base_low(uint64_t base,
+static inline void tzc_write_region_base_low(uintptr_t base,
 					uint32_t region,
 					uint32_t val)
 {
@@ -78,7 +78,7 @@ static inline void tzc_write_region_base_low(uint64_t base,
 		REGION_NUM_OFF(region), val);
 }
 
-static inline void tzc_write_region_base_high(uint64_t base,
+static inline void tzc_write_region_base_high(uintptr_t base,
 					uint32_t region,
 					uint32_t val)
 {
@@ -86,7 +86,7 @@ static inline void tzc_write_region_base_high(uint64_t base,
 		REGION_NUM_OFF(region), val);
 }
 
-static inline void tzc_write_region_top_low(uint64_t base,
+static inline void tzc_write_region_top_low(uintptr_t base,
 					uint32_t region,
 					uint32_t val)
 {
@@ -94,7 +94,7 @@ static inline void tzc_write_region_top_low(uint64_t base,
 		REGION_NUM_OFF(region), val);
 }
 
-static inline void tzc_write_region_top_high(uint64_t base,
+static inline void tzc_write_region_top_high(uintptr_t base,
 					uint32_t region,
 					uint32_t val)
 {
@@ -102,7 +102,7 @@ static inline void tzc_write_region_top_high(uint64_t base,
 		REGION_NUM_OFF(region), val);
 }
 
-static inline void tzc_write_region_attributes(uint64_t base,
+static inline void tzc_write_region_attributes(uintptr_t base,
 					uint32_t region,
 					uint32_t val)
 {
@@ -110,7 +110,7 @@ static inline void tzc_write_region_attributes(uint64_t base,
 		REGION_NUM_OFF(region), val);
 }
 
-static inline void tzc_write_region_id_access(uint64_t base,
+static inline void tzc_write_region_id_access(uintptr_t base,
 					uint32_t region,
 					uint32_t val)
 {
@@ -118,7 +118,7 @@ static inline void tzc_write_region_id_access(uint64_t base,
 		REGION_NUM_OFF(region), val);
 }
 
-static uint32_t tzc_read_component_id(uint64_t base)
+static uint32_t tzc_read_component_id(uintptr_t base)
 {
 	uint32_t id;
 
@@ -130,7 +130,7 @@ static uint32_t tzc_read_component_id(uint64_t base)
 	return id;
 }
 
-static uint32_t tzc_get_gate_keeper(uint64_t base, uint8_t filter)
+static uint32_t tzc_get_gate_keeper(uintptr_t base, uint8_t filter)
 {
 	uint32_t tmp;
 
@@ -141,7 +141,7 @@ static uint32_t tzc_get_gate_keeper(uint64_t base, uint8_t filter)
 }
 
 /* This function is not MP safe. */
-static void tzc_set_gate_keeper(uint64_t base, uint8_t filter, uint32_t val)
+static void tzc_set_gate_keeper(uintptr_t base, uint8_t filter, uint32_t val)
 {
 	uint32_t tmp;
 
@@ -164,7 +164,7 @@ static void tzc_set_gate_keeper(uint64_t base, uint8_t filter, uint32_t val)
 }
 
 
-void tzc_init(uint64_t base)
+void tzc_init(uintptr_t base)
 {
 	uint32_t tzc_id, tzc_build;
 

--- a/drivers/console/console.S
+++ b/drivers/console/console.S
@@ -44,7 +44,7 @@
 	console_base: .quad 0x0
 
 	/* -----------------------------------------------
-	 * int console_init(unsigned long base_addr,
+	 * int console_init(uintptr_t base_addr,
 	 * unsigned int uart_clk, unsigned int baud_rate)
 	 * Function to initialize the console without a
 	 * C Runtime to print debug information. It saves

--- a/drivers/console/skeleton_console.S
+++ b/drivers/console/skeleton_console.S
@@ -40,7 +40,7 @@
 	.globl	console_core_getc
 
 	/* -----------------------------------------------
-	 * int console_core_init(unsigned long base_addr,
+	 * int console_core_init(uintptr_t base_addr,
 	 * unsigned int uart_clk, unsigned int baud_rate)
 	 * Function to initialize the console without a
 	 * C Runtime to print debug information. This
@@ -68,7 +68,7 @@ core_init_fail:
 endfunc console_core_init
 
 	/* --------------------------------------------------------
-	 * int console_core_putc(int c, unsigned long base_addr)
+	 * int console_core_putc(int c, uintptr_t base_addr)
 	 * Function to output a character over the console. It
 	 * returns the character printed on success or -1 on error.
 	 * In : w0 - character to be printed
@@ -88,7 +88,7 @@ putc_error:
 endfunc console_core_putc
 
 	/* ---------------------------------------------
-	 * int console_core_getc(unsigned long base_addr)
+	 * int console_core_getc(uintptr_t base_addr)
 	 * Function to get a character from the console.
 	 * It returns the character grabbed on success
 	 * or -1 on error.

--- a/include/drivers/arm/arm_gic.h
+++ b/include/drivers/arm/arm_gic.h
@@ -36,11 +36,11 @@
 /*******************************************************************************
  * Function declarations
  ******************************************************************************/
-void arm_gic_init(unsigned int gicc_base,
-		unsigned int gicd_base,
-		unsigned long gicr_base,
-		const unsigned int *irq_sec_ptr,
-		unsigned int num_irqs);
+void arm_gic_init(uintptr_t gicc_base,
+		  uintptr_t gicd_base,
+		  uintptr_t gicr_base,
+		  const unsigned int *irq_sec_ptr,
+		  unsigned int num_irqs);
 void arm_gic_setup(void);
 void arm_gic_cpuif_deactivate(void);
 void arm_gic_cpuif_setup(void);

--- a/include/drivers/arm/cci.h
+++ b/include/drivers/arm/cci.h
@@ -146,7 +146,7 @@
  * SLAVE_IF_UNUSED should be used in the map to represent no AMBA 4 master exists
  * for that interface.
  */
-void cci_init(unsigned long cci_base,
+void cci_init(uintptr_t cci_base,
 	const int *map,
 	unsigned int num_cci_masters);
 

--- a/include/drivers/arm/cci400.h
+++ b/include/drivers/arm/cci400.h
@@ -68,6 +68,8 @@
 
 #ifndef __ASSEMBLY__
 
+#include <stdint.h>
+
 /* Function declarations */
 
 /*
@@ -79,7 +81,7 @@
  * affinity instance of the mpidr representing the cluster. A negative cluster
  * index indicates that no cluster is present on that slave interface.
  */
-void cci_init(unsigned long cci_base,
+void cci_init(uintptr_t cci_base,
 		int slave_iface3_cluster_ix,
 		int slave_iface4_cluster_ix);
 

--- a/include/drivers/arm/gic_v2.h
+++ b/include/drivers/arm/gic_v2.h
@@ -145,64 +145,64 @@
 #ifndef __ASSEMBLY__
 
 #include <mmio.h>
-
+#include <stdint.h>
 
 /*******************************************************************************
  * GIC Distributor function prototypes
  ******************************************************************************/
 
-unsigned int gicd_read_igroupr(unsigned int, unsigned int);
-unsigned int gicd_read_isenabler(unsigned int, unsigned int);
-unsigned int gicd_read_icenabler(unsigned int, unsigned int);
-unsigned int gicd_read_ispendr(unsigned int, unsigned int);
-unsigned int gicd_read_icpendr(unsigned int, unsigned int);
-unsigned int gicd_read_isactiver(unsigned int, unsigned int);
-unsigned int gicd_read_icactiver(unsigned int, unsigned int);
-unsigned int gicd_read_ipriorityr(unsigned int, unsigned int);
-unsigned int gicd_read_itargetsr(unsigned int, unsigned int);
-unsigned int gicd_read_icfgr(unsigned int, unsigned int);
-unsigned int gicd_read_cpendsgir(unsigned int, unsigned int);
-unsigned int gicd_read_spendsgir(unsigned int, unsigned int);
-void gicd_write_igroupr(unsigned int, unsigned int, unsigned int);
-void gicd_write_isenabler(unsigned int, unsigned int, unsigned int);
-void gicd_write_icenabler(unsigned int, unsigned int, unsigned int);
-void gicd_write_ispendr(unsigned int, unsigned int, unsigned int);
-void gicd_write_icpendr(unsigned int, unsigned int, unsigned int);
-void gicd_write_isactiver(unsigned int, unsigned int, unsigned int);
-void gicd_write_icactiver(unsigned int, unsigned int, unsigned int);
-void gicd_write_ipriorityr(unsigned int, unsigned int, unsigned int);
-void gicd_write_itargetsr(unsigned int, unsigned int, unsigned int);
-void gicd_write_icfgr(unsigned int, unsigned int, unsigned int);
-void gicd_write_cpendsgir(unsigned int, unsigned int, unsigned int);
-void gicd_write_spendsgir(unsigned int, unsigned int, unsigned int);
-unsigned int gicd_get_igroupr(unsigned int, unsigned int);
-void gicd_set_igroupr(unsigned int, unsigned int);
-void gicd_clr_igroupr(unsigned int, unsigned int);
-void gicd_set_isenabler(unsigned int, unsigned int);
-void gicd_set_icenabler(unsigned int, unsigned int);
-void gicd_set_ispendr(unsigned int, unsigned int);
-void gicd_set_icpendr(unsigned int, unsigned int);
-void gicd_set_isactiver(unsigned int, unsigned int);
-void gicd_set_icactiver(unsigned int, unsigned int);
-void gicd_set_ipriorityr(unsigned int, unsigned int, unsigned int);
-void gicd_set_itargetsr(unsigned int, unsigned int, unsigned int);
+unsigned int gicd_read_igroupr(uintptr_t, unsigned int);
+unsigned int gicd_read_isenabler(uintptr_t, unsigned int);
+unsigned int gicd_read_icenabler(uintptr_t, unsigned int);
+unsigned int gicd_read_ispendr(uintptr_t, unsigned int);
+unsigned int gicd_read_icpendr(uintptr_t, unsigned int);
+unsigned int gicd_read_isactiver(uintptr_t, unsigned int);
+unsigned int gicd_read_icactiver(uintptr_t, unsigned int);
+unsigned int gicd_read_ipriorityr(uintptr_t, unsigned int);
+unsigned int gicd_read_itargetsr(uintptr_t, unsigned int);
+unsigned int gicd_read_icfgr(uintptr_t, unsigned int);
+unsigned int gicd_read_cpendsgir(uintptr_t, unsigned int);
+unsigned int gicd_read_spendsgir(uintptr_t, unsigned int);
+void gicd_write_igroupr(uintptr_t, unsigned int, unsigned int);
+void gicd_write_isenabler(uintptr_t, unsigned int, unsigned int);
+void gicd_write_icenabler(uintptr_t, unsigned int, unsigned int);
+void gicd_write_ispendr(uintptr_t, unsigned int, unsigned int);
+void gicd_write_icpendr(uintptr_t, unsigned int, unsigned int);
+void gicd_write_isactiver(uintptr_t, unsigned int, unsigned int);
+void gicd_write_icactiver(uintptr_t, unsigned int, unsigned int);
+void gicd_write_ipriorityr(uintptr_t, unsigned int, unsigned int);
+void gicd_write_itargetsr(uintptr_t, unsigned int, unsigned int);
+void gicd_write_icfgr(uintptr_t, unsigned int, unsigned int);
+void gicd_write_cpendsgir(uintptr_t, unsigned int, unsigned int);
+void gicd_write_spendsgir(uintptr_t, unsigned int, unsigned int);
+unsigned int gicd_get_igroupr(uintptr_t, unsigned int);
+void gicd_set_igroupr(uintptr_t, unsigned int);
+void gicd_clr_igroupr(uintptr_t, unsigned int);
+void gicd_set_isenabler(uintptr_t, unsigned int);
+void gicd_set_icenabler(uintptr_t, unsigned int);
+void gicd_set_ispendr(uintptr_t, unsigned int);
+void gicd_set_icpendr(uintptr_t, unsigned int);
+void gicd_set_isactiver(uintptr_t, unsigned int);
+void gicd_set_icactiver(uintptr_t, unsigned int);
+void gicd_set_ipriorityr(uintptr_t, unsigned int, unsigned int);
+void gicd_set_itargetsr(uintptr_t, unsigned int, unsigned int);
 
 
 /*******************************************************************************
  * GIC Distributor interface accessors for reading entire registers
  ******************************************************************************/
 
-static inline unsigned int gicd_read_ctlr(unsigned int base)
+static inline unsigned int gicd_read_ctlr(uintptr_t base)
 {
 	return mmio_read_32(base + GICD_CTLR);
 }
 
-static inline unsigned int gicd_read_typer(unsigned int base)
+static inline unsigned int gicd_read_typer(uintptr_t base)
 {
 	return mmio_read_32(base + GICD_TYPER);
 }
 
-static inline unsigned int gicd_read_sgir(unsigned int base)
+static inline unsigned int gicd_read_sgir(uintptr_t base)
 {
 	return mmio_read_32(base + GICD_SGIR);
 }
@@ -212,12 +212,12 @@ static inline unsigned int gicd_read_sgir(unsigned int base)
  * GIC Distributor interface accessors for writing entire registers
  ******************************************************************************/
 
-static inline void gicd_write_ctlr(unsigned int base, unsigned int val)
+static inline void gicd_write_ctlr(uintptr_t base, unsigned int val)
 {
 	mmio_write_32(base + GICD_CTLR, val);
 }
 
-static inline void gicd_write_sgir(unsigned int base, unsigned int val)
+static inline void gicd_write_sgir(uintptr_t base, unsigned int val)
 {
 	mmio_write_32(base + GICD_SGIR, val);
 }
@@ -227,47 +227,47 @@ static inline void gicd_write_sgir(unsigned int base, unsigned int val)
  * GIC CPU interface accessors for reading entire registers
  ******************************************************************************/
 
-static inline unsigned int gicc_read_ctlr(unsigned int base)
+static inline unsigned int gicc_read_ctlr(uintptr_t base)
 {
 	return mmio_read_32(base + GICC_CTLR);
 }
 
-static inline unsigned int gicc_read_pmr(unsigned int base)
+static inline unsigned int gicc_read_pmr(uintptr_t base)
 {
 	return mmio_read_32(base + GICC_PMR);
 }
 
-static inline unsigned int gicc_read_BPR(unsigned int base)
+static inline unsigned int gicc_read_BPR(uintptr_t base)
 {
 	return mmio_read_32(base + GICC_BPR);
 }
 
-static inline unsigned int gicc_read_IAR(unsigned int base)
+static inline unsigned int gicc_read_IAR(uintptr_t base)
 {
 	return mmio_read_32(base + GICC_IAR);
 }
 
-static inline unsigned int gicc_read_EOIR(unsigned int base)
+static inline unsigned int gicc_read_EOIR(uintptr_t base)
 {
 	return mmio_read_32(base + GICC_EOIR);
 }
 
-static inline unsigned int gicc_read_hppir(unsigned int base)
+static inline unsigned int gicc_read_hppir(uintptr_t base)
 {
 	return mmio_read_32(base + GICC_HPPIR);
 }
 
-static inline unsigned int gicc_read_ahppir(unsigned int base)
+static inline unsigned int gicc_read_ahppir(uintptr_t base)
 {
 	return mmio_read_32(base + GICC_AHPPIR);
 }
 
-static inline unsigned int gicc_read_dir(unsigned int base)
+static inline unsigned int gicc_read_dir(uintptr_t base)
 {
 	return mmio_read_32(base + GICC_DIR);
 }
 
-static inline unsigned int gicc_read_iidr(unsigned int base)
+static inline unsigned int gicc_read_iidr(uintptr_t base)
 {
 	return mmio_read_32(base + GICC_IIDR);
 }
@@ -277,38 +277,38 @@ static inline unsigned int gicc_read_iidr(unsigned int base)
  * GIC CPU interface accessors for writing entire registers
  ******************************************************************************/
 
-static inline void gicc_write_ctlr(unsigned int base, unsigned int val)
+static inline void gicc_write_ctlr(uintptr_t base, unsigned int val)
 {
 	mmio_write_32(base + GICC_CTLR, val);
 }
 
-static inline void gicc_write_pmr(unsigned int base, unsigned int val)
+static inline void gicc_write_pmr(uintptr_t base, unsigned int val)
 {
 	mmio_write_32(base + GICC_PMR, val);
 }
 
-static inline void gicc_write_BPR(unsigned int base, unsigned int val)
+static inline void gicc_write_BPR(uintptr_t base, unsigned int val)
 {
 	mmio_write_32(base + GICC_BPR, val);
 }
 
 
-static inline void gicc_write_IAR(unsigned int base, unsigned int val)
+static inline void gicc_write_IAR(uintptr_t base, unsigned int val)
 {
 	mmio_write_32(base + GICC_IAR, val);
 }
 
-static inline void gicc_write_EOIR(unsigned int base, unsigned int val)
+static inline void gicc_write_EOIR(uintptr_t base, unsigned int val)
 {
 	mmio_write_32(base + GICC_EOIR, val);
 }
 
-static inline void gicc_write_hppir(unsigned int base, unsigned int val)
+static inline void gicc_write_hppir(uintptr_t base, unsigned int val)
 {
 	mmio_write_32(base + GICC_HPPIR, val);
 }
 
-static inline void gicc_write_dir(unsigned int base, unsigned int val)
+static inline void gicc_write_dir(uintptr_t base, unsigned int val)
 {
 	mmio_write_32(base + GICC_DIR, val);
 }

--- a/include/drivers/arm/tzc400.h
+++ b/include/drivers/arm/tzc400.h
@@ -189,7 +189,7 @@ typedef enum {
 } tzc_region_attributes_t;
 
 
-void tzc_init(uint64_t base);
+void tzc_init(uintptr_t base);
 void tzc_configure_region0(tzc_region_attributes_t sec_attr,
 			uint32_t ns_device_access);
 void tzc_configure_region(uint32_t filters,

--- a/include/drivers/console.h
+++ b/include/drivers/console.h
@@ -31,7 +31,9 @@
 #ifndef __CONSOLE_H__
 #define __CONSOLE_H__
 
-int console_init(unsigned long base_addr,
+#include <stdint.h>
+
+int console_init(uintptr_t base_addr,
 		unsigned int uart_clk, unsigned int baud_rate);
 int console_putc(int c);
 int console_getc(void);

--- a/include/plat/arm/common/arm_config.h
+++ b/include/plat/arm/common/arm_config.h
@@ -30,6 +30,7 @@
 #ifndef __ARM_CONFIG_H__
 #define __ARM_CONFIG_H__
 
+#include <stdint.h>
 
 enum arm_config_flags {
 	/* Whether Base memory map is in use */
@@ -41,10 +42,10 @@ enum arm_config_flags {
 };
 
 typedef struct arm_config {
-	unsigned int gicd_base;
-	unsigned int gicc_base;
-	unsigned int gich_base;
-	unsigned int gicv_base;
+	uintptr_t gicd_base;
+	uintptr_t gicc_base;
+	uintptr_t gich_base;
+	uintptr_t gicv_base;
 	unsigned int max_aff0;
 	unsigned int max_aff1;
 	unsigned long flags;


### PR DESCRIPTION
This patch changes the type of the base address parameter in the
ARM device driver APIs to uintptr_t (GIC, CCI, TZC400, PL011). The
uintptr_t type allows coverage of the whole memory space and to
perform arithmetic operations on the addresses. ARM platform code
has also been updated to use uintptr_t as GIC base address in the
configuration.

Fixes ARM-software/tf-issues#214

Change-Id: I1b87daedadcc8b63e8f113477979675e07d788f1