### PR TITLE
Fix bug in semihosting write function

### DIFF
--- a/drivers/io/io_semihosting.c
+++ b/drivers/io/io_semihosting.c
@@ -183,7 +183,6 @@ static int sh_file_read(io_entity_t *entity, uintptr_t buffer, size_t length,
 static int sh_file_write(io_entity_t *entity, const uintptr_t buffer,
 		size_t length, size_t *length_written)
 {
-	int result = IO_FAIL;
 	long sh_result = -1;
 	long file_handle;
 	size_t bytes = length;
@@ -196,13 +195,9 @@ static int sh_file_write(io_entity_t *entity, const uintptr_t buffer,
 
 	sh_result = semihosting_file_write(file_handle, &bytes, buffer);
 
-	if (sh_result >= 0) {
-		*length_written = sh_result;
-		result = IO_SUCCESS;
-	} else
-		result = IO_FAIL;
+	*length_written = length - bytes;
 
-	return result;
+	return (sh_result == 0) ? IO_SUCCESS : IO_FAIL;
 }
 
 

--- a/lib/semihosting/semihosting.c
+++ b/lib/semihosting/semihosting.c
@@ -125,6 +125,7 @@ long semihosting_file_write(long file_handle,
 			    const uintptr_t buffer)
 {
 	smh_file_read_write_block_t write_block;
+	long result = -EINVAL;
 
 	if ((length == NULL) || (buffer == (uintptr_t)NULL))
 		return -EINVAL;
@@ -133,10 +134,12 @@ long semihosting_file_write(long file_handle,
 	write_block.buffer = (uintptr_t)buffer; /* cast away const */
 	write_block.length = *length;
 
-	*length = semihosting_call(SEMIHOSTING_SYS_WRITE,
+	result = semihosting_call(SEMIHOSTING_SYS_WRITE,
 				   (void *) &write_block);
 
-	return *length;
+	*length = result;
+
+	return (result == 0) ? 0 : -EINVAL;
 }
 
 long semihosting_file_close(long file_handle)


### PR DESCRIPTION
The return value from the SYS_WRITE semihosting operation is 0 if
the call is successful or the number of bytes not written, if there
is an error. The implementation of the write function in the
semihosting driver treats the return value as the number of bytes
written, which is wrong. This patch fixes it.

Change-Id: Id39dac3d17b5eac557408b8995abe90924c85b85