### PR TITLE
Handling FIQ in EL3

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -7,5 +7,7 @@ Linaro Limited
 
 NVIDIA Corporation
 
+Virtual Open Systems
+
 Individuals
 -----------

--- a/bl31/interrupt_mgmt.c
+++ b/bl31/interrupt_mgmt.c
@@ -72,10 +72,8 @@ static intr_type_desc_t intr_type_descs[MAX_INTR_TYPES];
  ******************************************************************************/
 static int32_t validate_interrupt_type(uint32_t type)
 {
-	if (type == INTR_TYPE_EL3)
-		return -ENOTSUP;
-
-	if (type != INTR_TYPE_S_EL1 && type != INTR_TYPE_NS)
+	if (type != INTR_TYPE_EL3 && type != INTR_TYPE_S_EL1
+		&& type != INTR_TYPE_NS)
 		return -EINVAL;
 
 	return 0;
@@ -88,6 +86,9 @@ static int32_t validate_routing_model(uint32_t type, uint32_t flags)
 {
 	flags >>= INTR_RM_FLAGS_SHIFT;
 	flags &= INTR_RM_FLAGS_MASK;
+
+	if (type == INTR_TYPE_EL3)
+		return validate_el3_interrupt_rm(flags);
 
 	if (type == INTR_TYPE_S_EL1)
 		return validate_sel1_interrupt_rm(flags);

--- a/bl32/tsp/aarch64/tsp_entrypoint.S
+++ b/bl32/tsp/aarch64/tsp_entrypoint.S
@@ -353,7 +353,7 @@ func	tsp_fiq_entry
 	 * fiq handler is an error.
 	 * ---------------------------------------------
 	 */
-	save_eret_context x2 x3
+	save_eret_context x3 x4
 	bl	tsp_update_sync_fiq_stats
 	bl	tsp_fiq_handler
 	cbnz	x0, tsp_fiq_entry_panic

--- a/bl32/tsp/aarch64/tsp_exceptions.S
+++ b/bl32/tsp/aarch64/tsp_exceptions.S
@@ -32,7 +32,7 @@
 #include <arch.h>
 #include <tsp.h>
 #include <asm_macros.S>
-
+#include "../tsp_private.h"
 
 	/* ----------------------------------------------------
 	 * The caller-saved registers x0-x18 and LR are saved
@@ -139,6 +139,8 @@ fiq_sp_elx:
 	msr	daifclr, #DAIF_ABT_BIT
 
 	save_caller_regs_and_lr
+	/* Tell 'tsp_fiq_handler' that FIQ is caught in S-EL3 */
+	mov x0, #TSP_SEL1_EXCEPTION
 	bl	tsp_fiq_handler
 	cbz	x0, fiq_sp_elx_done
 

--- a/bl32/tsp/tsp_private.h
+++ b/bl32/tsp/tsp_private.h
@@ -43,6 +43,8 @@
 #define TSP_ARG7		0x38
 #define TSP_ARGS_END		0x40
 
+/* Definition to help FIQ handler to identify the interrupts caught in S-EL1 */
+#define TSP_SEL1_EXCEPTION	0xFFFF0000
 
 #ifndef __ASSEMBLY__
 
@@ -116,7 +118,9 @@ void tsp_generic_timer_save(void);
 void tsp_generic_timer_restore(void);
 
 /* FIQ management functions */
-void tsp_update_sync_fiq_stats(uint32_t type, uint64_t elr_el3);
+const uint32_t tsp_update_sync_fiq_stats(uint32_t type,
+		uint64_t elr_el3,
+		const uint32_t id);
 
 
 /* Data structure to keep track of TSP statistics */

--- a/docs/interrupt-framework-design.md
+++ b/docs/interrupt-framework-design.md
@@ -331,7 +331,7 @@ the type of interrupt.
 
 
 The `type` parameter can be one of the three interrupt types listed above i.e.
-`INTR_TYPE_S_EL1`, `INTR_TYPE_NS` & `INTR_TYPE_EL3` (currently unimplemented).
+`INTR_TYPE_S_EL1`, `INTR_TYPE_NS` & `INTR_TYPE_EL3`.
 The `flags` parameter is as described in Section 2.
 
 The function will return `0` upon a successful registration. It will return
@@ -410,16 +410,16 @@ requirements mentioned earlier.
     purpose, SP_EL1/Secure-EL0, LR, VFP and system registers. It can use
     `x0-x18` to enable its C runtime.
 
-2.  The TSPD implements a handler function for Secure-EL1 interrupts. It
+2.  The TSPD implements a handler function for Secure interrupts. It
     registers it with the EL3 runtime firmware using the
     `register_interrupt_type_handler()` API as follows
 
         /* Forward declaration */
-        interrupt_type_handler tspd_secure_el1_interrupt_handler;
+        interrupt_type_handler tspd_secure_interrupt_handler;
         int32_t rc, flags = 0;
         set_interrupt_rm_flag(flags, NON_SECURE);
-        rc = register_interrupt_type_handler(INTR_TYPE_S_EL1,
-                                         tspd_secure_el1_interrupt_handler,
+        rc = register_interrupt_type_handler(INTR_TYPE_EL3,
+                                         tspd_secure_interrupt_handler,
                                          flags);
         assert(rc == 0);
 
@@ -687,7 +687,7 @@ originally taken.
 
 ##### 2.3.2.3 Test secure payload dispatcher behavior
 The example TSPD service registers a handler for Secure-EL1 interrupts taken
-from the non-secure state. Its handler `tspd_secure_el1_interrupt_handler()`
+from the non-secure state. Its handler `tspd_secure_interrupt_handler()`
 takes the following actions upon being invoked.
 
 1.  It uses the `id` parameter to query the interrupt controller to ensure

--- a/docs/interrupt-framework-design.md
+++ b/docs/interrupt-framework-design.md
@@ -698,25 +698,27 @@ takes the following actions upon being invoked.
     that the secure interrupt originated from the non-secure state. It asserts
     if this is not the case.
 
-3.  It saves the system register context for the non-secure state by calling
+3.  It acknowledges the interrupt.
+
+4.  It saves the system register context for the non-secure state by calling
     `cm_el1_sysregs_context_save(NON_SECURE);`.
 
-4.  It sets the `ELR_EL3` system register to `tsp_fiq_entry` and sets the
+5.  It sets the `ELR_EL3` system register to `tsp_fiq_entry` and sets the
     `SPSR_EL3.DAIF` bits in the secure CPU context. It sets `x0` to
     `TSP_HANDLE_FIQ_AND_RETURN`. If the TSP was in the middle of handling a
     standard SMC, then the `ELR_EL3` and `SPSR_EL3` registers in the secure CPU
     context are saved first.
 
-5.  It restores the system register context for the secure state by calling
+6.  It restores the system register context for the secure state by calling
     `cm_el1_sysregs_context_restore(SECURE);`.
 
-6.  It ensures that the secure CPU context is used to program the next
+7.  It ensures that the secure CPU context is used to program the next
     exception return from EL3 by calling `cm_set_next_eret_context(SECURE);`.
 
-7.  It returns the per-cpu `cpu_context` to indicate that the interrupt can
+8.  It returns the per-cpu `cpu_context` to indicate that the interrupt can
     now be handled by the SP. `x1` is written with the value of `elr_el3`
-    register for the non-secure state. This information is used by the SP for
-    debugging purposes.
+    register for the non-secure state. `x2` is written with the interrupt id.
+    This information is used by the SP for debugging purposes.
 
 The figure below describes how the interrupt handling is implemented by the TSPD
 when a Secure-EL1 interrupt is generated when execution is in the non-secure
@@ -817,15 +819,13 @@ handover agreement described in Section 2.2.2.1 is maintained. It updates some
 statistics by calling `tsp_update_sync_fiq_stats()`. It then calls
 `tsp_fiq_handler()` which.
 
-1.  Checks whether the interrupt is the secure physical timer interrupt. It
-    uses the platform API `plat_ic_get_pending_interrupt_id()` to get the
-    interrupt number.
+1.  Checks whether the interrupt is the secure physical timer interrupt. The
+    interrupt number is passed as argument.
 
-2.   Handles the interrupt by acknowledging it using the
-    `plat_ic_acknowledge_interrupt()` platform API, calling
-    `tsp_generic_timer_handler()` to reprogram the secure physical generic
-    timer and calling the `plat_ic_end_of_interrupt()` platform API to signal
-    end of interrupt processing.
+2.  Handles the interrupt by calling `tsp_generic_timer_handler()` to
+    reprogram the secure physical generic timer and calling the
+    `plat_ic_end_of_interrupt()` platform API to signal end of interrupt
+    processing.
 
 The TSP passes control back to the TSPD by issuing an SMC64 with
 `TSP_HANDLED_S_EL1_FIQ` as the function identifier.
@@ -833,9 +833,20 @@ The TSP passes control back to the TSPD by issuing an SMC64 with
 The TSP handles interrupts under the asynchronous model as follows.
 
 1.  Secure-EL1 interrupts are handled by calling the `tsp_fiq_handler()`
-    function. The function has been described above.
+    function which:
 
-2.  Non-secure interrupts are handled by issuing an SMC64 with `TSP_PREEMPTED`
+    1.  Checks whether the interrupt is the secure physical timer
+        interrupt. It uses the platform API
+        `plat_ic_get_pending_interrupt_id()` to get the interrupt
+        number.
+
+    2.  Handles the interrupt by acknowledging it using the
+        `plat_ic_acknowledge_interrupt()` platform API, calling
+        `tsp_generic_timer_handler()` to reprogram the secure physical
+        generic timer and calling the `plat_ic_end_of_interrupt()`
+        platform API to signal end of interrupt processing.
+
+4.  Non-secure interrupts are handled by issuing an SMC64 with `TSP_PREEMPTED`
     as the function identifier. Execution resumes at the instruction that
     follows this SMC instruction when the TSPD hands control to the TSP in
     response to an SMC with `TSP_FID_RESUME` as the function identifier from

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -262,6 +262,11 @@ performed.
     default model (when the value is 0) is to route non-secure interrupts
     to S-EL1 (TSP).
 
+*   `TSPD_ROUTE_FIQ_TO_EL3`: A non zero value enables the routing model
+    for secure interrupts in which they are routed to EL3 (TSPD). The
+    default model (when the value is 0) is to route non-secure interrupts
+    to S-EL1 (TSP).
+
 *   `TRUSTED_BOARD_BOOT`: Boolean flag to include support for the Trusted Board
     Boot feature. When set to '1', BL1 and BL2 images include support to load
     and verify the certificates and images in a FIP. The default value is '0'.

--- a/drivers/arm/gic/arm_gic.c
+++ b/drivers/arm/gic/arm_gic.c
@@ -403,9 +403,14 @@ uint32_t arm_gic_get_pending_interrupt_type(void)
 	assert(g_gicc_base);
 	id = gicc_read_hppir(g_gicc_base) & INT_ID_MASK;
 
-	/* Assume that all secure interrupts are S-EL1 interrupts */
 	if (id < 1022)
+#if TSPD_ROUTE_FIQ_TO_EL3
+		/* Assume that all secure interrupts are EL3 interrupts */
+		return INTR_TYPE_EL3;
+#else
+		/* Assume that all secure interrupts are S-EL1 interrupts */
 		return INTR_TYPE_S_EL1;
+#endif
 
 	if (id == GIC_SPURIOUS_INTERRUPT)
 		return INTR_TYPE_INVAL;
@@ -472,7 +477,13 @@ uint32_t arm_gic_get_interrupt_type(uint32_t id)
 
 	/* Assume that all secure interrupts are S-EL1 interrupts */
 	if (group == GRP0)
+#if TSPD_ROUTE_FIQ_TO_EL3
+		/* Assume that all secure interrupts are EL3 interrupts */
+		return INTR_TYPE_EL3;
+#else
+		/* Assume that all secure interrupts are S-EL1 interrupts */
 		return INTR_TYPE_S_EL1;
+#endif
 	else
 		return INTR_TYPE_NS;
 }

--- a/include/bl31/interrupt_mgmt.h
+++ b/include/bl31/interrupt_mgmt.h
@@ -95,6 +95,8 @@
 					 (x == INTR_NS_VALID_RM1 ? 0 :\
 					  -EINVAL))
 
+#define validate_el3_interrupt_rm(x)	(x == INTR_SEL1_VALID_RM1 ? 0 : -EINVAL)
+
 /*******************************************************************************
  * Macros to set the 'flags' parameter passed to an interrupt type handler. Only
  * the flag to indicate the security state when the exception was generated is

--- a/services/spd/tspd/tspd.mk
+++ b/services/spd/tspd/tspd.mk
@@ -57,5 +57,12 @@ NEED_BL32		:=	yes
 # generated while the code is executing in S-EL1/0.
 TSPD_ROUTE_IRQ_TO_EL3	:=	0
 
+# Flag used to enable routing of secure interrupts to EL3 when they are
+# generated while the code is executing in EL2/1/0 or S-EL1/0.
+TSPD_ROUTE_FIQ_TO_EL3	:=	0
+
 $(eval $(call assert_boolean,TSPD_ROUTE_IRQ_TO_EL3))
 $(eval $(call add_define,TSPD_ROUTE_IRQ_TO_EL3))
+
+$(eval $(call assert_boolean,TSPD_ROUTE_FIQ_TO_EL3))
+$(eval $(call add_define,TSPD_ROUTE_FIQ_TO_EL3))

--- a/services/spd/tspd/tspd_main.c
+++ b/services/spd/tspd/tspd_main.c
@@ -116,6 +116,8 @@ static uint64_t tspd_sel1_interrupt_handler(uint32_t id,
 	mpidr = read_mpidr();
 	assert(handle == cm_get_context(NON_SECURE));
 
+	id = plat_ic_acknowledge_interrupt();
+
 	/* Save the non-secure context before entering the TSP */
 	cm_el1_sysregs_context_save(NON_SECURE);
 
@@ -158,7 +160,8 @@ static uint64_t tspd_sel1_interrupt_handler(uint32_t id,
 	 * from ELR_EL3 as the secure context will not take effect until
 	 * el3_exit().
 	 */
-	SMC_RET2(&tsp_ctx->cpu_ctx, TSP_HANDLE_FIQ_AND_RETURN, read_elr_el3());
+	SMC_RET3(&tsp_ctx->cpu_ctx, TSP_HANDLE_FIQ_AND_RETURN,
+			read_elr_el3(), id);
 }
 
 #if TSPD_ROUTE_IRQ_TO_EL3

--- a/services/spd/tspd/tspd_pm.c
+++ b/services/spd/tspd/tspd_pm.c
@@ -141,6 +141,14 @@ static void tspd_cpu_on_finish_handler(uint64_t unused)
 	disable_intr_rm_local(INTR_TYPE_NS, SECURE);
 #endif
 
+#if TSPD_ROUTE_FIQ_TO_EL3
+	/*
+	 * Disable the Secure interrupt locally since it will be enabled
+	 * globally within cm_init_context.
+	 */
+	disable_intr_rm_local(INTR_TYPE_EL3, SECURE);
+#endif
+
 	/* Enter the TSP */
 	rc = tspd_synchronous_sp_entry(tsp_ctx);
 

--- a/services/spd/tspd/tspd_private.h
+++ b/services/spd/tspd/tspd_private.h
@@ -210,6 +210,9 @@ typedef struct tsp_context {
 #if TSPD_ROUTE_IRQ_TO_EL3
 	sp_ctx_regs_t sp_ctx;
 #endif
+#if TSPD_ROUTE_FIQ_TO_EL3
+	sp_ctx_regs_t sp_ctx_2;
+#endif
 } tsp_context_t;
 
 /* Helper macros to store and retrieve tsp args from tsp_context */


### PR DESCRIPTION
The following series implements secure interrupt handling to catch
all FIQs in EL3 regardless the current exception layer which is executing.
The handling in EL3 helps to target some of the interrupts to EL3,
while the rest are routed in S-EL1.
The routing to S-EL1 is feasible, since the EL3 is responsible to acknowledge
secure interrupts and to pass the interrupt ID to S-EL1. Then S-EL1 is
responsible to process the end of interrupt.