### PR TITLE
tlkd: delete 'NEED_BL32' build variable

### DIFF
--- a/docs/plat/nvidia-tegra.md
+++ b/docs/plat/nvidia-tegra.md
@@ -57,8 +57,7 @@ without changing any makefiles.
 Preparing the BL31 image to run on Tegra SoCs
 ===================================================
 'CROSS_COMPILE=<path-to-aarch64-gcc>/bin/aarch64-none-elf- make PLAT=tegra \
-TARGET_SOC=<target-soc e.g. t210|t132> BL32=<path-to-trusted-os-binary> \
-SPD=<dispatcher e.g. tlkd> all'
+TARGET_SOC=<target-soc e.g. t210|t132> SPD=<dispatcher e.g. tlkd> all'
 
 Power Management
 ================

--- a/services/spd/tlkd/tlkd.mk
+++ b/services/spd/tlkd/tlkd.mk
@@ -34,5 +34,3 @@ SPD_SOURCES		:=	services/spd/tlkd/tlkd_common.c		\
 				services/spd/tlkd/tlkd_helpers.S	\
 				services/spd/tlkd/tlkd_main.c		\
 				services/spd/tlkd/tlkd_pm.c
-
-NEED_BL32		:=	yes


### PR DESCRIPTION
Remove the 'NEED_BL32' flag from the makefile. TLK compiles using a
completely different build system and is present on the device as a
binary blob. The NEED_BL32 flag does not influence the TLK load/boot
sequence at all. Moreover, it expects that TLK binary be present on
the host before we can compile BL31 support for Tegra.

This patch removes the flag from the makefile and thus decouples both
the build systems.

Tested by booting TLK without the NEED_BL32 flag on Tegra.

Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>