### PR TITLE
Tegra210: enable WRAP to INCR burst type conversions

### DIFF
--- a/plat/nvidia/tegra/include/t210/tegra_def.h
+++ b/plat/nvidia/tegra/include/t210/tegra_def.h
@@ -68,6 +68,23 @@
 #define TEGRA_GICC_BASE			0x50042000
 
 /*******************************************************************************
+ * Tegra Memory Select Switch Controller constants
+ ******************************************************************************/
+#define TEGRA_MSELECT_BASE		0x50060000
+
+#define MSELECT_CONFIG			0x0
+#define ENABLE_WRAP_INCR_MASTER2_BIT	(1 << 29)
+#define ENABLE_WRAP_INCR_MASTER1_BIT	(1 << 28)
+#define ENABLE_WRAP_INCR_MASTER0_BIT	(1 << 27)
+#define UNSUPPORTED_TX_ERR_MASTER2_BIT	(1 << 25)
+#define UNSUPPORTED_TX_ERR_MASTER1_BIT	(1 << 24)
+#define ENABLE_UNSUP_TX_ERRORS		(UNSUPPORTED_TX_ERR_MASTER2_BIT | \
+					 UNSUPPORTED_TX_ERR_MASTER1_BIT)
+#define ENABLE_WRAP_TO_INCR_BURSTS	(ENABLE_WRAP_INCR_MASTER2_BIT | \
+					 ENABLE_WRAP_INCR_MASTER1_BIT | \
+					 ENABLE_WRAP_INCR_MASTER0_BIT)
+
+/*******************************************************************************
  * Tegra micro-seconds timer constants
  ******************************************************************************/
 #define TEGRA_TMRUS_BASE		0x60005010

--- a/plat/nvidia/tegra/soc/t210/plat_psci_handlers.c
+++ b/plat/nvidia/tegra/soc/t210/plat_psci_handlers.c
@@ -120,10 +120,21 @@ int tegra_soc_prepare_cpu_suspend(unsigned int id, unsigned int afflvl)
 
 int tegra_soc_prepare_cpu_on_finish(unsigned long mpidr)
 {
+	uint32_t val;
+
 	/*
 	 * Check if we are exiting from SOC_POWERDN.
 	 */
 	if (tegra_system_suspended()) {
+
+		/*
+		 * Enable WRAP to INCR burst type conversions for
+		 * incoming requests on the AXI slave ports.
+		 */
+		val = mmio_read_32(TEGRA_MSELECT_BASE + MSELECT_CONFIG);
+		val &= ~ENABLE_UNSUP_TX_ERRORS;
+		val |= ENABLE_WRAP_TO_INCR_BURSTS;
+		mmio_write_32(TEGRA_MSELECT_BASE + MSELECT_CONFIG, val);
 
 		/*
 		 * Restore Boot and Power Management Processor (BPMP) reset


### PR DESCRIPTION
The Memory Select Switch Controller routes any CPU transactions to
the appropriate slave depending on the transaction address. During
system suspend, it loses all config settings and hence the CPU has
to restore them during resume.

This patch restores the controller's settings for enabling WRAP to
INCR burst type conversions on the master ports, for any incoming
requests from the AXI slave ports.

Tested by performing multiple system suspend cycles.

Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>