### PR TITLE
Add functionality to handle all Secure Interrupts in EL3

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -7,5 +7,7 @@ Linaro Limited
 
 NVIDIA Corporation
 
+Virtual Open Systems
+
 Individuals
 -----------

--- a/bl32/tsp/aarch64/tsp_entrypoint.S
+++ b/bl32/tsp/aarch64/tsp_entrypoint.S
@@ -336,9 +336,9 @@ endfunc tsp_cpu_suspend_entry
 	 */
 func	tsp_fiq_entry
 #if DEBUG
-	mov	x2, #(TSP_HANDLE_FIQ_AND_RETURN & ~0xffff)
-	movk	x2, #(TSP_HANDLE_FIQ_AND_RETURN &  0xffff)
-	cmp	x0, x2
+	mov	x3, #(TSP_HANDLE_FIQ_AND_RETURN & ~0xffff)
+	movk	x3, #(TSP_HANDLE_FIQ_AND_RETURN &  0xffff)
+	cmp	x0, x3
 	b.ne	tsp_fiq_entry_panic
 #endif
 	/*---------------------------------------------
@@ -353,8 +353,10 @@ func	tsp_fiq_entry
 	 * fiq handler is an error.
 	 * ---------------------------------------------
 	 */
-	save_eret_context x2 x3
+	save_eret_context x3 x4
+	str x2, [sp, #-0x10]!
 	bl	tsp_update_sync_fiq_stats
+	ldr x0, [sp], #0x10
 	bl	tsp_fiq_handler
 	cbnz	x0, tsp_fiq_entry_panic
 	restore_eret_context x2 x3

--- a/docs/interrupt-framework-design.md
+++ b/docs/interrupt-framework-design.md
@@ -410,16 +410,16 @@ requirements mentioned earlier.
     purpose, SP_EL1/Secure-EL0, LR, VFP and system registers. It can use
     `x0-x18` to enable its C runtime.
 
-2.  The TSPD implements a handler function for Secure-EL1 interrupts. It
+2.  The TSPD implements a handler function for Secure interrupts. It
     registers it with the EL3 runtime firmware using the
     `register_interrupt_type_handler()` API as follows
 
         /* Forward declaration */
-        interrupt_type_handler tspd_secure_el1_interrupt_handler;
+        interrupt_type_handler tspd_secure_interrupt_handler;
         int32_t rc, flags = 0;
         set_interrupt_rm_flag(flags, NON_SECURE);
         rc = register_interrupt_type_handler(INTR_TYPE_S_EL1,
-                                         tspd_secure_el1_interrupt_handler,
+                                         tspd_secure_interrupt_handler,
                                          flags);
         assert(rc == 0);
 
@@ -687,8 +687,47 @@ originally taken.
 
 ##### 2.3.2.3 Test secure payload dispatcher behavior
 The example TSPD service registers a handler for Secure-EL1 interrupts taken
-from the non-secure state. Its handler `tspd_secure_el1_interrupt_handler()`
-takes the following actions upon being invoked.
+from the non-secure state when TSPD_ROUTE_FIQ_TO_EL3 is set to 1. Its handler
+`tspd_secure_interrupt_handler()` takes the following actions upon being
+invoked.
+
+1.  It uses the `id` parameter to query the interrupt controller to ensure
+    that the interrupt is a Secure-EL1 interrupt. It asserts if this is not
+    the case.
+
+2.  It uses the security state provided in the `flags` parameter to ensure
+    that the secure interrupt originated from the non-secure state. It asserts
+    if this is not the case.
+
+3.  It acknowledges the interrupt.
+
+4.  It uses the security state provided in the `flags` parameter to check
+    that the secure interrupt originated from the non-secure state. If it's
+    the case, it saves the system register context for the non-secure state
+    by calling `cm_el1_sysregs_context_save(NON_SECURE);`.
+
+5.  It sets the `ELR_EL3` system register to `tsp_fiq_entry` and sets the
+    `SPSR_EL3.DAIF` bits in the secure CPU context. It sets `x0` to
+    `TSP_HANDLE_FIQ_AND_RETURN`. If the TSP was in the middle of handling a
+    standard SMC, then the `ELR_EL3` and `SPSR_EL3` registers in the secure CPU
+    context are saved first.
+
+6.  It uses the security state provided in the `flags` parameter to check
+    that the secure interrupt originated from the non-secure state. If it's
+    the case, it restores the system register context for the secure state by
+    calling `cm_el1_sysregs_context_restore(SECURE);` then it ensures that
+    the secure CPU context is used to program the next exception return from
+    EL3 by calling `cm_set_next_eret_context(SECURE);`.
+
+7.  It returns the per-cpu `cpu_context` to indicate that the interrupt can
+    now be handled by the SP. `x1` is written with the value of `elr_el3`
+    register for the non-secure state. `x2` is written with the interrupt id.
+    This information is used by the SP for debugging purposes.
+
+The example TSPD service registers a handler for Secure-EL1 interrupts taken
+from the non-secure state when TSPD_ROUTE_FIQ_TO_EL3 is set to 0. Its handler
+`tspd_secure_interrupt_handler()` takes the following actions upon being
+invoked.
 
 1.  It uses the `id` parameter to query the interrupt controller to ensure
     that the interrupt is a Secure-EL1 interrupt. It asserts if this is not
@@ -812,10 +851,10 @@ state.
 
 ##### 2.3.3.1 Test secure payload behavior
 The TSPD hands control of a Secure-EL1 interrupt to the TSP at the
-`tsp_fiq_entry()`.  The TSP handles the interrupt while ensuring that the
-handover agreement described in Section 2.2.2.1 is maintained. It updates some
-statistics by calling `tsp_update_sync_fiq_stats()`. It then calls
-`tsp_fiq_handler()` which.
+`tsp_fiq_entry()`  when TSPD_ROUTE_FIQ_TO_EL3 is set to 0. The TSP handles
+the interrupt while ensuring that the handover agreement described in Section
+2.2.2.1 is maintained. It updates some statistics by calling
+`tsp_update_sync_fiq_stats()`. It then calls `tsp_fiq_handler()` which.
 
 1.  Checks whether the interrupt is the secure physical timer interrupt. It
     uses the platform API `plat_ic_get_pending_interrupt_id()` to get the
@@ -836,6 +875,44 @@ The TSP handles interrupts under the asynchronous model as follows.
     function. The function has been described above.
 
 2.  Non-secure interrupts are handled by issuing an SMC64 with `TSP_PREEMPTED`
+    as the function identifier. Execution resumes at the instruction that
+    follows this SMC instruction when the TSPD hands control to the TSP in
+    response to an SMC with `TSP_FID_RESUME` as the function identifier from
+    the non-secure state (see section 2.3.2.1).
+
+The TSPD hands control of a Secure-EL1 interrupt to the TSP at the
+`tsp_fiq_entry()`  when TSPD_ROUTE_FIQ_TO_EL3 is set to 1. The TSP handles
+the interrupt while ensuring that the handover agreement described in Section
+2.2.2.1 is maintained. It updates some statistics by calling
+
+1.  Checks whether the interrupt is the secure physical timer interrupt. The
+    interrupt number is passed as argument.
+
+2.  Handles the interrupt by calling `tsp_generic_timer_handler()` to
+    reprogram the secure physical generic timer and calling the
+    `plat_ic_end_of_interrupt()` platform API to signal end of interrupt
+    processing.
+
+The TSP passes control back to the TSPD by issuing an SMC64 with
+`TSP_HANDLED_S_EL1_FIQ` as the function identifier.
+
+The TSP handles interrupts under the asynchronous model as follows.
+
+1.  Secure-EL1 interrupts are handled by calling the `tsp_fiq_handler()`
+    function which:
+
+    1.  Checks whether the interrupt is the secure physical timer
+        interrupt. It uses the platform API
+        `plat_ic_get_pending_interrupt_id()` to get the interrupt
+        number.
+
+    2.  Handles the interrupt by acknowledging it using the
+        `plat_ic_acknowledge_interrupt()` platform API, calling
+        `tsp_generic_timer_handler()` to reprogram the secure physical
+        generic timer and calling the `plat_ic_end_of_interrupt()`
+        platform API to signal end of interrupt processing.
+
+4.  Non-secure interrupts are handled by issuing an SMC64 with `TSP_PREEMPTED`
     as the function identifier. Execution resumes at the instruction that
     follows this SMC instruction when the TSPD hands control to the TSP in
     response to an SMC with `TSP_FID_RESUME` as the function identifier from

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -287,6 +287,11 @@ performed.
     default model (when the value is 0) is to route non-secure interrupts
     to S-EL1 (TSP).
 
+*   `TSPD_ROUTE_FIQ_TO_EL3`: A non zero value enables the routing model
+    for secure interrupts in which they are routed to EL3 (TSPD). The
+    default model (when the value is 0) is to route non-secure interrupts
+    to S-EL1 (TSP).
+
 *   `TRUSTED_BOARD_BOOT`: Boolean flag to include support for the Trusted Board
     Boot feature. When set to '1', BL1 and BL2 images include support to load
     and verify the certificates and images in a FIP. The default value is '0'.

--- a/services/spd/tspd/tspd.mk
+++ b/services/spd/tspd/tspd.mk
@@ -57,5 +57,12 @@ NEED_BL32		:=	yes
 # generated while the code is executing in S-EL1/0.
 TSPD_ROUTE_IRQ_TO_EL3	:=	0
 
+# Flag used to enable routing of secure interrupts to EL3 when they are
+# generated while the code is executing in EL2/1/0 or S-EL1/0.
+TSPD_ROUTE_FIQ_TO_EL3	:=	0
+
 $(eval $(call assert_boolean,TSPD_ROUTE_IRQ_TO_EL3))
 $(eval $(call add_define,TSPD_ROUTE_IRQ_TO_EL3))
+
+$(eval $(call assert_boolean,TSPD_ROUTE_FIQ_TO_EL3))
+$(eval $(call add_define,TSPD_ROUTE_FIQ_TO_EL3))

--- a/services/spd/tspd/tspd_pm.c
+++ b/services/spd/tspd/tspd_pm.c
@@ -141,6 +141,14 @@ static void tspd_cpu_on_finish_handler(uint64_t unused)
 	disable_intr_rm_local(INTR_TYPE_NS, SECURE);
 #endif
 
+#if TSPD_ROUTE_FIQ_TO_EL3
+	/*
+	 * Disable the Secure interrupt locally since it will be enabled
+	 * globally within cm_init_context.
+	 */
+	disable_intr_rm_local(INTR_TYPE_S_EL1, SECURE);
+#endif
+
 	/* Enter the TSP */
 	rc = tspd_synchronous_sp_entry(tsp_ctx);
 

--- a/services/spd/tspd/tspd_private.h
+++ b/services/spd/tspd/tspd_private.h
@@ -210,6 +210,9 @@ typedef struct tsp_context {
 #if TSPD_ROUTE_IRQ_TO_EL3
 	sp_ctx_regs_t sp_ctx;
 #endif
+#if TSPD_ROUTE_FIQ_TO_EL3
+	sp_ctx_regs_t sp_ctx_2;
+#endif
 } tsp_context_t;
 
 /* Helper macros to store and retrieve tsp args from tsp_context */


### PR DESCRIPTION
The patch adds a new functionality to handle all secure interrupts in EL3. This functionality could be enabled at the compilation time by setting the FLAG TSPD_ROUTE_FIQ_TO_EL3 to 1. The goal of this change is to dedicate part of the secure interrupts to EL3 only. Such interrupt could be the system secure timer for example.

If TSPD_ROUTE_FIQ_TO_EL3 is set to 0, the patch has no impact and the FIQ handling process is directly done in the Secure payload application (S-EL1).

If TSPD_ROUTE_FIQ_TO_EL3 is set to 1:

- In EL3, the handler 'tspd_secure_interrupt_handler', implemented in the 'INTR_TYPE_S_EL1' type, is updated, to manage the case of the secure interrupt occurs during the Secure world execution, to propagate the FIQ ID to the Secure payload by passing the ID as third argument (register: X2).

- In TSP, the handler 'tsp_fiq_handler' is modified to avoid double acknowledge. Therefore the FIQ acknowledgement step is bypassed in S-EL1.

Signed-off-by: Kevin Chappuis <k.chappuis@virtualopensystems.com>
Signed-off-by: Petar Lalov <p.lalov@virtualopensystems.com>