### PR TITLE
Bootargs tzdram base v2

### DIFF
--- a/docs/plat/nvidia-tegra.md
+++ b/docs/plat/nvidia-tegra.md
@@ -57,7 +57,7 @@ without changing any makefiles.
 Preparing the BL31 image to run on Tegra SoCs
 ===================================================
 'CROSS_COMPILE=<path-to-aarch64-gcc>/bin/aarch64-none-elf- make PLAT=tegra \
-TARGET_SOC=<target-soc e.g. t210|t132> SPD=<dispatcher e.g. tlkd> all'
+TARGET_SOC=<target-soc e.g. t210|t132> SPD=<dispatcher e.g. tlkd> bl31'
 
 Platforms wanting to use different TZDRAM_BASE, can add 'TZDRAM_BASE=<value>'
 to the build command line.

--- a/docs/plat/nvidia-tegra.md
+++ b/docs/plat/nvidia-tegra.md
@@ -59,6 +59,9 @@ Preparing the BL31 image to run on Tegra SoCs
 'CROSS_COMPILE=<path-to-aarch64-gcc>/bin/aarch64-none-elf- make PLAT=tegra \
 TARGET_SOC=<target-soc e.g. t210|t132> SPD=<dispatcher e.g. tlkd> all'
 
+Platforms wanting to use different TZDRAM_BASE, can add 'TZDRAM_BASE=<value>'
+to the build command line.
+
 Power Management
 ================
 The PSCI implementation expects each platform to expose the 'power state'

--- a/docs/spd/tlk-dispatcher.md
+++ b/docs/spd/tlk-dispatcher.md
@@ -10,12 +10,9 @@ In order to compile TLK-D, we need a BL32 image to be present. Since, TLKD
 just needs to compile, any BL32 image would do. To use TLK as the BL32, please
 refer to the "Build TLK" section.
 
-Once a BL32 is ready, TLKD can be included in the image using the following
-command:
+Once a BL32 is ready, TLKD can be included in the image by adding "SPD=tlkd"
+to the build command.
 
-CROSS_COMPILE=<path_to_linaro_chain>/bin/aarch64-none-elf- make NEED_BL1=0
-NEED_BL2=0 BL32=<path_to_BL32_image> PLAT=<platform> SPD=tlkd all
-_
 Trusted Little Kernel (TLK)
 ===========================
 TLK is a Trusted OS running as Secure EL1. It is a Free Open Source Software
@@ -58,3 +55,16 @@ Build TLK
 =========
 To build and execute TLK, follow the instructions from "Building a TLK Device"
 section from Tegra_BSP_for_Android_TLK_FOSS_Reference.pdf manual.
+
+Input parameters to TLK
+=======================
+TLK expects the TZDRAM size and a structure containing the boot arguments. BL2
+passes this information to the EL3 software as members of the bl32_ep_info
+struct, where bl32_ep_info is part of bl31_params_t (passed by BL2 in X0)
+
+Example:
+--------
+    bl32_ep_info->args.arg0 = TZDRAM size available for BL32
+    bl32_ep_info->args.arg1 = unused (used only on ARMv7)
+    bl32_ep_info->args.arg2 = pointer to boot args
+

--- a/plat/nvidia/tegra/common/tegra_bl31_setup.c
+++ b/plat/nvidia/tegra/common/tegra_bl31_setup.c
@@ -85,7 +85,7 @@ extern uint64_t tegra_bl31_phys_base;
 
 static entry_point_info_t bl33_image_ep_info, bl32_image_ep_info;
 static plat_params_from_bl2_t plat_bl31_params_from_bl2 = {
-	(uint64_t)TZDRAM_SIZE, (uintptr_t)NULL
+	.tzdram_size = (uint64_t)TZDRAM_SIZE
 };
 
 /*******************************************************************************
@@ -145,13 +145,10 @@ void bl31_early_platform_setup(bl31_params_t *from_bl2,
 	bl32_image_ep_info = *from_bl2->bl32_ep_info;
 
 	/*
-	 * Parse platform specific parameters - TZDRAM aperture size and
-	 * pointer to BL32 params.
+	 * Parse platform specific parameters - TZDRAM aperture size
 	 */
-	if (plat_params) {
+	if (plat_params)
 		plat_bl31_params_from_bl2.tzdram_size = plat_params->tzdram_size;
-		plat_bl31_params_from_bl2.bl32_params = plat_params->bl32_params;
-	}
 }
 
 /*******************************************************************************

--- a/plat/nvidia/tegra/include/tegra_private.h
+++ b/plat/nvidia/tegra/include/tegra_private.h
@@ -42,7 +42,6 @@
 
 typedef struct plat_params_from_bl2 {
 	uint64_t tzdram_size;
-	uintptr_t bl32_params;
 } plat_params_from_bl2_t;
 
 /* Declarations for plat_psci_handlers.c */

--- a/plat/nvidia/tegra/soc/t132/platform_t132.mk
+++ b/plat/nvidia/tegra/soc/t132/platform_t132.mk
@@ -31,7 +31,7 @@
 TEGRA_BOOT_UART_BASE		:= 0x70006300
 $(eval $(call add_define,TEGRA_BOOT_UART_BASE))
 
-TZDRAM_BASE			:= 0xF1C00000
+TZDRAM_BASE			:= 0xF5C00000
 $(eval $(call add_define,TZDRAM_BASE))
 
 PLATFORM_CLUSTER_COUNT		:= 1


### PR DESCRIPTION
* Tegra: retrieve BL32's bootargs from bl32_ep_info
* Tegra132: set TZDRAM_BASE to 0xF5C00000
* docs: fix the command to compile BL31 on Tegra