### PR TITLE
TBB: rework cert_create tool to follow a data driven approach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ build/
 tools/**/*.o
 tools/fip_create/fip_create
 tools/cert_create/src/*.o
+tools/cert_create/src/**/*.o
 tools/cert_create/cert_create

--- a/tools/cert_create/Makefile
+++ b/tools/cert_create/Makefile
@@ -39,10 +39,10 @@ OBJECTS := src/cert.o \
            src/ext.o \
            src/key.o \
            src/main.o \
-           src/tbb_cert.o \
-           src/tbb_ext.o \
-           src/tbb_key.o \
-           src/sha.o
+           src/sha.o \
+           src/tbbr/tbb_cert.o \
+           src/tbbr/tbb_ext.o \
+           src/tbbr/tbb_key.o
 
 CFLAGS := -Wall -std=c99
 

--- a/tools/cert_create/include/cert.h
+++ b/tools/cert_create/include/cert.h
@@ -33,7 +33,10 @@
 
 #include <openssl/ossl_typ.h>
 #include <openssl/x509.h>
+#include "ext.h"
 #include "key.h"
+
+#define CERT_MAX_EXT			4
 
 /*
  * This structure contains information related to the generation of the
@@ -52,18 +55,28 @@ struct cert_s {
 	int id;			/* Unique identifier */
 
 	const char *fn;		/* Filename to save the certificate */
-	const char *bin;	/* Image associated to this certificate */
-
 	const char *cn;		/* Subject CN (Company Name) */
 
-	X509 *x;		/* X509 certificate container */
-	key_t *key;		/* Key to be signed */
+	/* These fields must be defined statically */
+	int key;		/* Key to be signed */
+	int issuer;		/* Issuer certificate */
+	int ext[CERT_MAX_EXT];	/* Certificate extensions */
+	int num_ext;		/* Number of extensions in the certificate */
 
-	cert_t *issuer;		/* Issuer certificate */
+	X509 *x;		/* X509 certificate container */
 };
 
+/* Exported API */
 int cert_add_ext(X509 *issuer, X509 *subject, int nid, char *value);
-
 int cert_new(cert_t *cert, int days, int ca, STACK_OF(X509_EXTENSION) * sk);
+
+/* Macro to register the certificates used in the CoT */
+#define REGISTER_COT(_certs) \
+	cert_t *certs = &_certs[0]; \
+	const unsigned int num_certs = sizeof(_certs)/sizeof(_certs[0]);
+
+/* Exported variables */
+extern cert_t *certs;
+extern const unsigned int num_certs;
 
 #endif /* CERT_H_ */

--- a/tools/cert_create/include/key.h
+++ b/tools/cert_create/include/key.h
@@ -68,8 +68,18 @@ typedef struct key_s {
 	EVP_PKEY *key;		/* Key container */
 } key_t;
 
+/* Exported API */
 int key_create(key_t *key, int type);
 int key_load(key_t *key, unsigned int *err_code);
 int key_store(key_t *key);
+
+/* Macro to register the keys used in the CoT */
+#define REGISTER_KEYS(_keys) \
+	key_t *keys = &_keys[0]; \
+	const unsigned int num_keys = sizeof(_keys)/sizeof(_keys[0]);
+
+/* Exported variables */
+extern key_t *keys;
+extern const unsigned int num_keys;
 
 #endif /* KEY_H_ */

--- a/tools/cert_create/include/tbbr/tbb_cert.h
+++ b/tools/cert_create/include/tbbr/tbb_cert.h
@@ -46,13 +46,7 @@ enum {
 	BL32_KEY_CERT,
 	BL32_CERT,
 	BL33_KEY_CERT,
-	BL33_CERT,
-	NUM_CERTIFICATES,
+	BL33_CERT
 };
-
-/*
- * Array containing the certificate instances
- */
-extern cert_t certs[NUM_CERTIFICATES];
 
 #endif /* TBB_CERT_H_ */

--- a/tools/cert_create/include/tbbr/tbb_ext.h
+++ b/tools/cert_create/include/tbbr/tbb_ext.h
@@ -27,41 +27,26 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+#ifndef TBB_EXT_H_
+#define TBB_EXT_H_
 
-#include "tbb_key.h"
+#include "ext.h"
 
-/*
- * Keys used to establish the chain of trust
- *
- * The order of the keys must follow the enumeration specified in tbb_key.h
- */
-key_t keys[NUM_KEYS] = {
-	{
-		.id = ROT_KEY,
-		.desc = "Root Of Trust key"
-	},
-	{
-		.id = TRUSTED_WORLD_KEY,
-		.desc = "Trusted World key"
-	},
-	{
-		.id = NON_TRUSTED_WORLD_KEY,
-		.desc = "Non Trusted World key"
-	},
-	{
-		.id = BL30_KEY,
-		.desc = "BL30 key"
-	},
-	{
-		.id = BL31_KEY,
-		.desc = "BL31 key"
-	},
-	{
-		.id = BL32_KEY,
-		.desc = "BL32 key"
-	},
-	{
-		.id = BL33_KEY,
-		.desc = "BL33 key"
-	}
+/* TBBR extensions */
+enum {
+	TZ_FW_NVCOUNTER_EXT,
+	NTZ_FW_NVCOUNTER_EXT,
+	BL2_HASH_EXT,
+	TZ_WORLD_PK_EXT,
+	NTZ_WORLD_PK_EXT,
+	BL31_CONTENT_CERT_PK_EXT,
+	BL31_HASH_EXT,
+	BL30_CONTENT_CERT_PK_EXT,
+	BL30_HASH_EXT,
+	BL32_CONTENT_CERT_PK_EXT,
+	BL32_HASH_EXT,
+	BL33_CONTENT_CERT_PK_EXT,
+	BL33_HASH_EXT
 };
+
+#endif /* TBB_EXT_H_ */

--- a/tools/cert_create/include/tbbr/tbb_key.h
+++ b/tools/cert_create/include/tbbr/tbb_key.h
@@ -27,12 +27,23 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
-#ifndef TBB_EXT_H_
-#define TBB_EXT_H_
 
-#include "ext.h"
+#ifndef TBB_KEY_H_
+#define TBB_KEY_H_
 
-/* Array containing the extensions used in the chain of trust */
-extern ext_t tbb_ext[];
+#include "key.h"
 
-#endif /* TBB_EXT_H_ */
+/*
+ * Enumerate the keys that are used to establish the chain of trust
+ */
+enum {
+	ROT_KEY,
+	TRUSTED_WORLD_KEY,
+	NON_TRUSTED_WORLD_KEY,
+	BL30_KEY,
+	BL31_KEY,
+	BL32_KEY,
+	BL33_KEY
+};
+
+#endif /* TBB_KEY_H_ */

--- a/tools/cert_create/src/cert.c
+++ b/tools/cert_create/src/cert.c
@@ -98,9 +98,10 @@ int cert_add_ext(X509 *issuer, X509 *subject, int nid, char *value)
 
 int cert_new(cert_t *cert, int days, int ca, STACK_OF(X509_EXTENSION) * sk)
 {
-	EVP_PKEY *pkey = cert->key->key;
-	EVP_PKEY *ikey = cert->issuer->key->key;
-	X509 *issuer = cert->issuer->x;
+	EVP_PKEY *pkey = keys[cert->key].key;
+	cert_t *issuer_cert = &certs[cert->issuer];
+	EVP_PKEY *ikey = keys[issuer_cert->key].key;
+	X509 *issuer = issuer_cert->x;
 	X509 *x = NULL;
 	X509_EXTENSION *ex = NULL;
 	X509_NAME *name = NULL;
@@ -147,7 +148,7 @@ int cert_new(cert_t *cert, int days, int ca, STACK_OF(X509_EXTENSION) * sk)
 	/* Issuer name */
 	name = X509_get_issuer_name(x);
 	X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC,
-			(const unsigned char *)cert->issuer->cn, -1, -1, 0);
+			(const unsigned char *)issuer_cert->cn, -1, -1, 0);
 	X509_set_issuer_name(x, name);
 
 	/* Add various extensions: standard extensions */

--- a/tools/cert_create/src/ext.c
+++ b/tools/cert_create/src/ext.c
@@ -65,20 +65,20 @@ IMPLEMENT_ASN1_FUNCTIONS(HASH)
  *
  * Return: 0 = success, Otherwise: error
  */
-int ext_init(ext_t *tbb_ext)
+int ext_register(ext_t *exts)
 {
 	ext_t *ext;
 	X509V3_EXT_METHOD *m;
 	int i = 0, nid, ret;
 
-	while ((ext = &tbb_ext[i++]) && ext->oid) {
+	while ((ext = &exts[i++]) && ext->oid) {
 		nid = OBJ_create(ext->oid, ext->sn, ext->ln);
 		if (ext->alias) {
 			X509V3_EXT_add_alias(nid, ext->alias);
 		} else {
 			m = &ext->method;
 			memset(m, 0x0, sizeof(X509V3_EXT_METHOD));
-			switch (ext->type) {
+			switch (ext->asn1_type) {
 			case V_ASN1_INTEGER:
 				m->it = ASN1_ITEM_ref(ASN1_INTEGER);
 				m->i2s = (X509V3_EXT_I2S)i2s_ASN1_INTEGER;

--- a/tools/cert_create/src/main.c
+++ b/tools/cert_create/src/main.c
@@ -46,9 +46,9 @@
 #include "key.h"
 #include "platform_oid.h"
 #include "sha.h"
-#include "tbb_ext.h"
-#include "tbb_cert.h"
-#include "tbb_key.h"
+#include "tbbr/tbb_ext.h"
+#include "tbbr/tbb_cert.h"
+#include "tbbr/tbb_key.h"
 
 /*
  * Helper macros to simplify the code. This macro assigns the return value of
@@ -79,7 +79,6 @@
 #define MAX_FILENAME_LEN		1024
 #define VAL_DAYS			7300
 #define ID_TO_BIT_MASK(id)		(1 << id)
-#define NVCOUNTER_VALUE			0
 #define NUM_ELEM(x)			((sizeof(x)) / (sizeof(x[0])))
 
 /* Files */
@@ -119,11 +118,6 @@ static int save_keys;
 static int print_cert;
 static int bl30_present;
 static int bl32_present;
-
-/* We are not checking nvcounters in TF. Include them in the certificates but
- * the value will be set to 0 */
-static int tf_nvcounter;
-static int non_tf_nvcounter;
 
 /* Info messages created in the Makefile */
 extern const char build_msg[];
@@ -231,27 +225,27 @@ static void check_cmd_params(void)
 	}
 
 	/* BL2, BL31 and BL33 are mandatory */
-	if (certs[BL2_CERT].bin == NULL) {
+	if (extensions[BL2_HASH_EXT].data.fn == NULL) {
 		ERROR("BL2 image not specified\n");
 		exit(1);
 	}
 
-	if (certs[BL31_CERT].bin == NULL) {
+	if (extensions[BL31_HASH_EXT].data.fn == NULL) {
 		ERROR("BL31 image not specified\n");
 		exit(1);
 	}
 
-	if (certs[BL33_CERT].bin == NULL) {
+	if (extensions[BL33_HASH_EXT].data.fn == NULL) {
 		ERROR("BL33 image not specified\n");
 		exit(1);
 	}
 
 	/* BL30 and BL32 are optional */
-	if (certs[BL30_CERT].bin != NULL) {
+	if (extensions[BL30_HASH_EXT].data.fn != NULL) {
 		bl30_present = 1;
 	}
 
-	if (certs[BL32_CERT].bin != NULL) {
+	if (extensions[BL32_HASH_EXT].data.fn != NULL) {
 		bl32_present = 1;
 	}
 
@@ -299,12 +293,11 @@ static void check_cmd_params(void)
 int main(int argc, char *argv[])
 {
 	STACK_OF(X509_EXTENSION) * sk = NULL;
-	X509_EXTENSION *hash_ext = NULL;
-	X509_EXTENSION *nvctr_ext = NULL;
-	X509_EXTENSION *trusted_key_ext = NULL;
-	X509_EXTENSION *non_trusted_key_ext = NULL;
+	X509_EXTENSION *cert_ext = NULL;
+	ext_t *ext = NULL;
+	cert_t *cert;
 	FILE *file = NULL;
-	int i, tz_nvctr_nid, ntz_nvctr_nid, hash_nid, pk_nid;
+	int i, j, ext_nid;
 	int c, opt_idx = 0;
 	unsigned int err_code;
 	unsigned char md[SHA256_DIGEST_LENGTH];
@@ -346,19 +339,19 @@ int main(int argc, char *argv[])
 			print_cert = 1;
 			break;
 		case BL2_ID:
-			certs[BL2_CERT].bin = strdup(optarg);
+			extensions[BL2_HASH_EXT].data.fn = strdup(optarg);
 			break;
 		case BL30_ID:
-			certs[BL30_CERT].bin = strdup(optarg);
+			extensions[BL30_HASH_EXT].data.fn = strdup(optarg);
 			break;
 		case BL31_ID:
-			certs[BL31_CERT].bin = strdup(optarg);
+			extensions[BL31_HASH_EXT].data.fn = strdup(optarg);
 			break;
 		case BL32_ID:
-			certs[BL32_CERT].bin = strdup(optarg);
+			extensions[BL32_HASH_EXT].data.fn = strdup(optarg);
 			break;
 		case BL33_ID:
-			certs[BL33_CERT].bin = strdup(optarg);
+			extensions[BL33_HASH_EXT].data.fn = strdup(optarg);
 			break;
 		case BL2_CERT_ID:
 			certs[BL2_CERT].fn = strdup(optarg);
@@ -418,16 +411,12 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	/* Set the value of the NVCounters */
-	tf_nvcounter = NVCOUNTER_VALUE;
-	non_tf_nvcounter = NVCOUNTER_VALUE;
-
 	/* Check command line arguments */
 	check_cmd_params();
 
 	/* Register the new types and OIDs for the extensions */
-	if (ext_init(tbb_ext) != 0) {
-		ERROR("Cannot initialize TBB extensions\n");
+	if (ext_register(extensions) != 0) {
+		ERROR("Cannot register TBB extensions\n");
 		exit(1);
 	}
 
@@ -435,12 +424,8 @@ int main(int argc, char *argv[])
 	 * extension */
 	md_info = EVP_sha256();
 
-	/* Get non-volatile counters NIDs */
-	CHECK_OID(tz_nvctr_nid, TZ_FW_NVCOUNTER_OID);
-	CHECK_OID(ntz_nvctr_nid, NTZ_FW_NVCOUNTER_OID);
-
 	/* Load private keys from files (or generate new ones) */
-	for (i = 0 ; i < NUM_KEYS ; i++) {
+	for (i = 0 ; i < num_keys ; i++) {
 		/* First try to load the key from disk */
 		if (key_load(&keys[i], &err_code)) {
 			/* Key loaded successfully */
@@ -478,271 +463,73 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	/* *********************************************************************
-	 * BL2 certificate (Trusted Boot Firmware certificate):
-	 *     - Self-signed with OEM ROT private key
-	 *     - Extensions:
-	 *         - TrustedFirmwareNVCounter (TODO)
-	 *         - BL2 hash
-	 **********************************************************************/
-	CHECK_NULL(sk, sk_X509_EXTENSION_new_null());
+	/* Create the certificates */
+	for (i = 0 ; i < num_certs ; i++) {
 
-	/* Add the NVCounter as a critical extension */
-	CHECK_NULL(nvctr_ext, ext_new_nvcounter(tz_nvctr_nid, EXT_CRIT,
-			tf_nvcounter));
-	sk_X509_EXTENSION_push(sk, nvctr_ext);
+		cert = &certs[i];
 
-	/* Add hash of BL2 as an extension */
-	if (!sha_file(certs[BL2_CERT].bin, md)) {
-		ERROR("Cannot calculate the hash of %s\n", certs[BL2_CERT].bin);
-		exit(1);
-	}
-	CHECK_OID(hash_nid, BL2_HASH_OID);
-	CHECK_NULL(hash_ext, ext_new_hash(hash_nid, EXT_CRIT, md_info, md,
-			SHA256_DIGEST_LENGTH));
-	sk_X509_EXTENSION_push(sk, hash_ext);
-
-	/* Create certificate. Signed with ROT key */
-	if (!cert_new(&certs[BL2_CERT], VAL_DAYS, 0, sk)) {
-		ERROR("Cannot create %s\n", certs[BL2_CERT].cn);
-		exit(1);
-	}
-	sk_X509_EXTENSION_free(sk);
-
-	/* *********************************************************************
-	 * Trusted Key certificate:
-	 *     - Self-signed with OEM ROT private key
-	 *     - Extensions:
-	 *         - TrustedFirmwareNVCounter (TODO)
-	 *         - TrustedWorldPK
-	 *         - NonTrustedWorldPK
-	 **********************************************************************/
-	CHECK_NULL(sk, sk_X509_EXTENSION_new_null());
-	CHECK_NULL(nvctr_ext, ext_new_nvcounter(tz_nvctr_nid, EXT_CRIT,
-			tf_nvcounter));
-	sk_X509_EXTENSION_push(sk, nvctr_ext);
-	CHECK_OID(pk_nid, TZ_WORLD_PK_OID);
-	CHECK_NULL(trusted_key_ext, ext_new_key(pk_nid, EXT_CRIT,
-			keys[TRUSTED_WORLD_KEY].key));
-	sk_X509_EXTENSION_push(sk, trusted_key_ext);
-	CHECK_OID(pk_nid, NTZ_WORLD_PK_OID);
-	CHECK_NULL(non_trusted_key_ext, ext_new_key(pk_nid, EXT_CRIT,
-			keys[NON_TRUSTED_WORLD_KEY].key));
-	sk_X509_EXTENSION_push(sk, non_trusted_key_ext);
-	if (!cert_new(&certs[TRUSTED_KEY_CERT], VAL_DAYS, 0, sk)) {
-		ERROR("Cannot create %s\n", certs[TRUSTED_KEY_CERT].cn);
-		exit(1);
-	}
-	sk_X509_EXTENSION_free(sk);
-
-	/* *********************************************************************
-	 * BL30 Key certificate (Trusted SCP Firmware Key certificate):
-	 *     - Self-signed with Trusted World key
-	 *     - Extensions:
-	 *         - TrustedFirmwareNVCounter (TODO)
-	 *         - SCPFirmwareContentCertPK
-	 **********************************************************************/
-	if (bl30_present) {
+		/* Create a new stack of extensions. This stack will be used
+		 * to create the certificate */
 		CHECK_NULL(sk, sk_X509_EXTENSION_new_null());
-		CHECK_NULL(nvctr_ext, ext_new_nvcounter(tz_nvctr_nid, EXT_CRIT,
-				tf_nvcounter));
-		sk_X509_EXTENSION_push(sk, nvctr_ext);
-		CHECK_OID(pk_nid, BL30_CONTENT_CERT_PK_OID);
-		CHECK_NULL(trusted_key_ext, ext_new_key(pk_nid, EXT_CRIT,
-				keys[BL30_KEY].key));
-		sk_X509_EXTENSION_push(sk, trusted_key_ext);
-		if (!cert_new(&certs[BL30_KEY_CERT], VAL_DAYS, 0, sk)) {
-			ERROR("Cannot create %s\n", certs[BL30_KEY_CERT].cn);
-			exit(1);
+
+		for (j = 0 ; j < cert->num_ext ; j++) {
+
+			ext = &extensions[cert->ext[j]];
+
+			/* Get OpenSSL internal ID for this extension */
+			CHECK_OID(ext_nid, ext->oid);
+
+			/*
+			 * Three types of extensions are currently supported:
+			 *     - EXT_TYPE_NVCOUNTER
+			 *     - EXT_TYPE_HASH
+			 *     - EXT_TYPE_PKEY
+			 */
+			switch (ext->type) {
+			case EXT_TYPE_NVCOUNTER:
+				CHECK_NULL(cert_ext, ext_new_nvcounter(ext_nid,
+						EXT_CRIT, ext->data.nvcounter));
+				break;
+			case EXT_TYPE_HASH:
+				if (ext->data.fn == NULL) {
+					break;
+				}
+				if (!sha_file(ext->data.fn, md)) {
+					ERROR("Cannot calculate hash of %s\n",
+						ext->data.fn);
+					exit(1);
+				}
+				CHECK_NULL(cert_ext, ext_new_hash(ext_nid,
+						EXT_CRIT, md_info, md,
+						SHA256_DIGEST_LENGTH));
+				break;
+			case EXT_TYPE_PKEY:
+				CHECK_NULL(cert_ext, ext_new_key(ext_nid,
+					EXT_CRIT, keys[ext->data.key].key));
+				break;
+			default:
+				ERROR("Unknown extension type in %s\n",
+						cert->cn);
+				exit(1);
+			}
+
+			/* Push the extension into the stack */
+			sk_X509_EXTENSION_push(sk, cert_ext);
 		}
-		sk_X509_EXTENSION_free(sk);
-	}
 
-	/* *********************************************************************
-	 * BL30 certificate (SCP Firmware Content certificate):
-	 *     - Signed with Trusted World Key
-	 *     - Extensions:
-	 *         - TrustedFirmwareNVCounter (TODO)
-	 *         - SCPFirmwareHash
-	 **********************************************************************/
-	if (bl30_present) {
-		CHECK_NULL(sk, sk_X509_EXTENSION_new_null());
-		CHECK_NULL(nvctr_ext, ext_new_nvcounter(tz_nvctr_nid, EXT_CRIT,
-				tf_nvcounter));
-		sk_X509_EXTENSION_push(sk, nvctr_ext);
-
-		if (!sha_file(certs[BL30_CERT].bin, md)) {
-			ERROR("Cannot calculate the hash of %s\n",
-					certs[BL30_CERT].bin);
-			exit(1);
-		}
-		CHECK_OID(hash_nid, BL30_HASH_OID);
-		CHECK_NULL(hash_ext, ext_new_hash(hash_nid, EXT_CRIT, md_info,
-				md, SHA256_DIGEST_LENGTH));
-		sk_X509_EXTENSION_push(sk, hash_ext);
-
-		if (!cert_new(&certs[BL30_CERT], VAL_DAYS, 0, sk)) {
-			ERROR("Cannot create %s\n", certs[BL30_CERT].cn);
+		/* Create certificate. Signed with ROT key */
+		if (!cert_new(cert, VAL_DAYS, 0, sk)) {
+			ERROR("Cannot create %s\n", cert->cn);
 			exit(1);
 		}
 
 		sk_X509_EXTENSION_free(sk);
 	}
 
-	/* *********************************************************************
-	 * BL31 Key certificate (Trusted SoC Firmware Key certificate):
-	 *     - Self-signed with Trusted World key
-	 *     - Extensions:
-	 *         - TrustedFirmwareNVCounter (TODO)
-	 *         - SoCFirmwareContentCertPK
-	 **********************************************************************/
-	CHECK_NULL(sk, sk_X509_EXTENSION_new_null());
-	CHECK_NULL(nvctr_ext, ext_new_nvcounter(tz_nvctr_nid, EXT_CRIT,
-			tf_nvcounter));
-	sk_X509_EXTENSION_push(sk, nvctr_ext);
-	CHECK_OID(pk_nid, BL31_CONTENT_CERT_PK_OID);
-	CHECK_NULL(trusted_key_ext, ext_new_key(pk_nid, EXT_CRIT,
-			keys[BL31_KEY].key));
-	sk_X509_EXTENSION_push(sk, trusted_key_ext);
-	if (!cert_new(&certs[BL31_KEY_CERT], VAL_DAYS, 0, sk)) {
-		ERROR("Cannot create %s\n", certs[BL31_KEY_CERT].cn);
-		exit(1);
-	}
-	sk_X509_EXTENSION_free(sk);
-
-	/* *********************************************************************
-	 * BL31 certificate (SOC Firmware Content certificate):
-	 *     - Signed with Trusted World Key
-	 *     - Extensions:
-	 *         - TrustedFirmwareNVCounter (TODO)
-	 *         - BL31 hash
-	 **********************************************************************/
-	CHECK_NULL(sk, sk_X509_EXTENSION_new_null());
-	CHECK_NULL(nvctr_ext, ext_new_nvcounter(tz_nvctr_nid, EXT_CRIT,
-			tf_nvcounter));
-	sk_X509_EXTENSION_push(sk, nvctr_ext);
-
-	if (!sha_file(certs[BL31_CERT].bin, md)) {
-		ERROR("Cannot calculate the hash of %s\n", certs[BL31_CERT].bin);
-		exit(1);
-	}
-	CHECK_OID(hash_nid, BL31_HASH_OID);
-	CHECK_NULL(hash_ext, ext_new_hash(hash_nid, EXT_CRIT, md_info, md,
-			SHA256_DIGEST_LENGTH));
-	sk_X509_EXTENSION_push(sk, hash_ext);
-
-	if (!cert_new(&certs[BL31_CERT], VAL_DAYS, 0, sk)) {
-		ERROR("Cannot create %s\n", certs[BL31_CERT].cn);
-		exit(1);
-	}
-
-	sk_X509_EXTENSION_free(sk);
-
-	/* *********************************************************************
-	 * BL32 Key certificate (Trusted OS Firmware Key certificate):
-	 *     - Self-signed with Trusted World key
-	 *     - Extensions:
-	 *         - TrustedFirmwareNVCounter (TODO)
-	 *         - TrustedOSFirmwareContentCertPK
-	 **********************************************************************/
-	if (bl32_present) {
-		CHECK_NULL(sk, sk_X509_EXTENSION_new_null());
-		CHECK_NULL(nvctr_ext, ext_new_nvcounter(tz_nvctr_nid, EXT_CRIT,
-				tf_nvcounter));
-		sk_X509_EXTENSION_push(sk, nvctr_ext);
-		CHECK_OID(pk_nid, BL32_CONTENT_CERT_PK_OID);
-		CHECK_NULL(trusted_key_ext, ext_new_key(pk_nid, EXT_CRIT,
-				keys[BL32_KEY].key));
-		sk_X509_EXTENSION_push(sk, trusted_key_ext);
-		if (!cert_new(&certs[BL32_KEY_CERT], VAL_DAYS, 0, sk)) {
-			ERROR("Cannot create %s\n", certs[BL32_KEY_CERT].cn);
-			exit(1);
-		}
-		sk_X509_EXTENSION_free(sk);
-	}
-
-	/* *********************************************************************
-	 * BL32 certificate (TrustedOS Firmware Content certificate):
-	 *     - Signed with Trusted World Key
-	 *     - Extensions:
-	 *         - TrustedFirmwareNVCounter (TODO)
-	 *         - BL32 hash
-	 **********************************************************************/
-	if (bl32_present) {
-		CHECK_NULL(sk, sk_X509_EXTENSION_new_null());
-		CHECK_NULL(nvctr_ext, ext_new_nvcounter(tz_nvctr_nid, EXT_CRIT,
-				tf_nvcounter));
-		sk_X509_EXTENSION_push(sk, nvctr_ext);
-
-		if (!sha_file(certs[BL32_CERT].bin, md)) {
-			ERROR("Cannot calculate the hash of %s\n",
-					certs[BL32_CERT].bin);
-			exit(1);
-		}
-		CHECK_OID(hash_nid, BL32_HASH_OID);
-		CHECK_NULL(hash_ext, ext_new_hash(hash_nid, EXT_CRIT, md_info,
-				md, SHA256_DIGEST_LENGTH));
-		sk_X509_EXTENSION_push(sk, hash_ext);
-
-		if (!cert_new(&certs[BL32_CERT], VAL_DAYS, 0, sk)) {
-			ERROR("Cannot create %s\n", certs[BL32_CERT].cn);
-			exit(1);
-		}
-
-		sk_X509_EXTENSION_free(sk);
-	}
-
-	/* *********************************************************************
-	 * BL33 Key certificate (Non Trusted Firmware Key certificate):
-	 *     - Self-signed with Non Trusted World key
-	 *     - Extensions:
-	 *         - NonTrustedFirmwareNVCounter (TODO)
-	 *         - NonTrustedFirmwareContentCertPK
-	 **********************************************************************/
-	CHECK_NULL(sk, sk_X509_EXTENSION_new_null());
-	CHECK_NULL(nvctr_ext, ext_new_nvcounter(ntz_nvctr_nid, EXT_CRIT,
-			non_tf_nvcounter));
-	sk_X509_EXTENSION_push(sk, nvctr_ext);
-	CHECK_OID(pk_nid, BL33_CONTENT_CERT_PK_OID);
-	CHECK_NULL(non_trusted_key_ext, ext_new_key(pk_nid, EXT_CRIT,
-			keys[BL33_KEY].key));
-	sk_X509_EXTENSION_push(sk, non_trusted_key_ext);
-	if (!cert_new(&certs[BL33_KEY_CERT], VAL_DAYS, 0, sk)) {
-		ERROR("Cannot create %s\n", certs[BL33_KEY_CERT].cn);
-		exit(1);
-	}
-	sk_X509_EXTENSION_free(sk);
-
-	/* *********************************************************************
-	 * BL33 certificate (Non-Trusted World Content certificate):
-	 *     - Signed with Non-Trusted World Key
-	 *     - Extensions:
-	 *         - NonTrustedFirmwareNVCounter (TODO)
-	 *         - BL33 hash
-	 **********************************************************************/
-	CHECK_NULL(sk, sk_X509_EXTENSION_new_null());
-	CHECK_NULL(nvctr_ext, ext_new_nvcounter(ntz_nvctr_nid, EXT_CRIT,
-			non_tf_nvcounter));
-	sk_X509_EXTENSION_push(sk, nvctr_ext);
-
-	if (!sha_file(certs[BL33_CERT].bin, md)) {
-		ERROR("Cannot calculate the hash of %s\n", certs[BL33_CERT].bin);
-		exit(1);
-	}
-	CHECK_OID(hash_nid, BL33_HASH_OID);
-	CHECK_NULL(hash_ext, ext_new_hash(hash_nid, EXT_CRIT, md_info, md,
-			SHA256_DIGEST_LENGTH));
-	sk_X509_EXTENSION_push(sk, hash_ext);
-
-	if (!cert_new(&certs[BL33_CERT], VAL_DAYS, 0, sk)) {
-		ERROR("Cannot create %s\n", certs[BL33_CERT].cn);
-		exit(1);
-	}
-	sk_X509_EXTENSION_free(sk);
 
 	/* Print the certificates */
 	if (print_cert) {
-		for (i = 0 ; i < NUM_CERTIFICATES ; i++) {
+		for (i = 0 ; i < num_certs ; i++) {
 			if (!certs[i].x) {
 				continue;
 			}
@@ -752,7 +539,7 @@ int main(int argc, char *argv[])
 	}
 
 	/* Save created certificates to files */
-	for (i = 0 ; i < NUM_CERTIFICATES ; i++) {
+	for (i = 0 ; i < num_certs ; i++) {
 		if (certs[i].x && certs[i].fn) {
 			file = fopen(certs[i].fn, "w");
 			if (file != NULL) {
@@ -766,17 +553,12 @@ int main(int argc, char *argv[])
 
 	/* Save keys */
 	if (save_keys) {
-		for (i = 0 ; i < NUM_KEYS ; i++) {
+		for (i = 0 ; i < num_keys ; i++) {
 			if (!key_store(&keys[i])) {
 				ERROR("Cannot save %s\n", keys[i].desc);
 			}
 		}
 	}
-
-	X509_EXTENSION_free(hash_ext);
-	X509_EXTENSION_free(nvctr_ext);
-	X509_EXTENSION_free(trusted_key_ext);
-	X509_EXTENSION_free(non_trusted_key_ext);
 
 #ifndef OPENSSL_NO_ENGINE
 	ENGINE_cleanup();

--- a/tools/cert_create/src/tbbr/tbb_cert.c
+++ b/tools/cert_create/src/tbbr/tbb_cert.c
@@ -28,84 +28,129 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "tbb_cert.h"
-#include "tbb_key.h"
+#include "tbbr/tbb_cert.h"
+#include "tbbr/tbb_ext.h"
+#include "tbbr/tbb_key.h"
 
 /*
  * Certificates used in the chain of trust
  *
  * The order of the certificates must follow the enumeration specified in
- * tbb_cert.h. All certificates are self-signed.
+ * tbb_cert.h. All certificates are self-signed, so the issuer certificate
+ * field points to itself.
  */
-cert_t certs[NUM_CERTIFICATES] = {
-	{
+static cert_t tbb_certs[] = {
+	[BL2_CERT] = {
 		.id = BL2_CERT,
 		.fn = NULL,
 		.cn = "BL2 Certificate",
-		.key = &keys[ROT_KEY],
-		.issuer = &certs[BL2_CERT],
+		.key = ROT_KEY,
+		.issuer = BL2_CERT,
+		.ext = {
+			BL2_HASH_EXT
+		},
+		.num_ext = 1
 	},
-	{
+	[TRUSTED_KEY_CERT] = {
 		.id = TRUSTED_KEY_CERT,
 		.fn = NULL,
 		.cn = "Trusted Key Certificate",
-		.key = &keys[ROT_KEY],
-		.issuer = &certs[TRUSTED_KEY_CERT],
+		.key = ROT_KEY,
+		.issuer = TRUSTED_KEY_CERT,
+		.ext = {
+			TZ_WORLD_PK_EXT,
+			NTZ_WORLD_PK_EXT
+		},
+		.num_ext = 2
 	},
-	{
+	[BL30_KEY_CERT] = {
 		.id = BL30_KEY_CERT,
 		.fn = NULL,
 		.cn = "BL3-0 Key Certificate",
-		.key = &keys[TRUSTED_WORLD_KEY],
-		.issuer = &certs[BL30_KEY_CERT],
+		.key = TRUSTED_WORLD_KEY,
+		.issuer = BL30_KEY_CERT,
+		.ext = {
+			BL30_CONTENT_CERT_PK_EXT
+		},
+		.num_ext = 1
 	},
-	{
+	[BL30_CERT] = {
 		.id = BL30_CERT,
 		.fn = NULL,
 		.cn = "BL3-0 Content Certificate",
-		.key = &keys[BL30_KEY],
-		.issuer = &certs[BL30_CERT],
+		.key = BL30_KEY,
+		.issuer = BL30_CERT,
+		.ext = {
+			BL30_HASH_EXT
+		},
+		.num_ext = 1
 	},
-	{
+	[BL31_KEY_CERT] = {
 		.id = BL31_KEY_CERT,
 		.fn = NULL,
 		.cn = "BL3-1 Key Certificate",
-		.key = &keys[TRUSTED_WORLD_KEY],
-		.issuer = &certs[BL31_KEY_CERT],
+		.key = TRUSTED_WORLD_KEY,
+		.issuer = BL31_KEY_CERT,
+		.ext = {
+			BL31_CONTENT_CERT_PK_EXT
+		},
+		.num_ext = 1
 	},
-	{
+	[BL31_CERT] = {
 		.id = BL31_CERT,
 		.fn = NULL,
 		.cn = "BL3-1 Content Certificate",
-		.key = &keys[BL31_KEY],
-		.issuer = &certs[BL31_CERT],
+		.key = BL31_KEY,
+		.issuer = BL31_CERT,
+		.ext = {
+			BL31_HASH_EXT
+		},
+		.num_ext = 1
 	},
-	{
+	[BL32_KEY_CERT] = {
 		.id = BL32_KEY_CERT,
 		.fn = NULL,
 		.cn = "BL3-2 Key Certificate",
-		.key = &keys[TRUSTED_WORLD_KEY],
-		.issuer = &certs[BL32_KEY_CERT],
+		.key = TRUSTED_WORLD_KEY,
+		.issuer = BL32_KEY_CERT,
+		.ext = {
+			BL32_CONTENT_CERT_PK_EXT
+		},
+		.num_ext = 1
 	},
-	{
+	[BL32_CERT] = {
 		.id = BL32_CERT,
 		.fn = NULL,
 		.cn = "BL3-2 Content Certificate",
-		.key = &keys[BL32_KEY],
-		.issuer = &certs[BL32_CERT],
+		.key = BL32_KEY,
+		.issuer = BL32_CERT,
+		.ext = {
+			BL32_HASH_EXT
+		},
+		.num_ext = 1
 	},
-	{
+	[BL33_KEY_CERT] = {
 		.id = BL33_KEY_CERT,
 		.fn = NULL,
 		.cn = "BL3-3 Key Certificate",
-		.key = &keys[NON_TRUSTED_WORLD_KEY],
-		.issuer = &certs[BL33_KEY_CERT],
+		.key = NON_TRUSTED_WORLD_KEY,
+		.issuer = BL33_KEY_CERT,
+		.ext = {
+			BL33_CONTENT_CERT_PK_EXT
+		},
+		.num_ext = 1
 	},
-	{
+	[BL33_CERT] = {
 		.id = BL33_CERT,
 		.fn = NULL,
 		.cn = "BL3-3 Content Certificate",
-		.key = &keys[BL33_KEY],
-		.issuer = &certs[BL33_CERT],
+		.key = BL33_KEY,
+		.issuer = BL33_CERT,
+		.ext = {
+			BL33_HASH_EXT
+		},
+		.num_ext = 1
 	}
 };
+
+REGISTER_COT(tbb_certs);

--- a/tools/cert_create/src/tbbr/tbb_ext.c
+++ b/tools/cert_create/src/tbbr/tbb_ext.c
@@ -34,85 +34,113 @@
 #include <openssl/x509v3.h>
 #include "ext.h"
 #include "platform_oid.h"
+#include "tbbr/tbb_ext.h"
+#include "tbbr/tbb_key.h"
 
-ext_t tbb_ext[] = {
-	{
+/* TODO: get these values from the command line */
+#define TRUSTED_WORLD_NVCTR_VALUE	0
+#define NORMAL_WORLD_NVCTR_VALUE	0
+
+static ext_t tbb_ext[] = {
+	[TZ_FW_NVCOUNTER_EXT] = {
 		.oid = TZ_FW_NVCOUNTER_OID,
-		.sn = "TrustedNvCounter",
-		.ln = "Non-volatile trusted counter",
-		.type = V_ASN1_INTEGER
+		.sn = "TrustedWorldNVCounter",
+		.ln = "Trusted World Non-Volatile counter",
+		.asn1_type = V_ASN1_INTEGER,
+		.type = EXT_TYPE_NVCOUNTER,
+		.data.nvcounter = TRUSTED_WORLD_NVCTR_VALUE
 	},
-	{
+	[NTZ_FW_NVCOUNTER_EXT] = {
 		.oid = NTZ_FW_NVCOUNTER_OID,
-		.sn = "NonTrustedNvCounter",
-		.ln = "Non-volatile non-trusted counter",
-		.type = V_ASN1_INTEGER
+		.sn = "NormalWorldNVCounter",
+		.ln = "Normal World Non-Volatile counter",
+		.asn1_type = V_ASN1_INTEGER,
+		.type = EXT_TYPE_NVCOUNTER,
+		.data.nvcounter = NORMAL_WORLD_NVCTR_VALUE
 	},
-	{
+	[BL2_HASH_EXT] = {
 		.oid = BL2_HASH_OID,
 		.sn = "TrustedBootFirmwareHash",
 		.ln = "Trusted Boot Firmware (BL2) hash (SHA256)",
-		.type = V_ASN1_OCTET_STRING
+		.asn1_type = V_ASN1_OCTET_STRING,
+		.type = EXT_TYPE_HASH
 	},
-	{
+	[TZ_WORLD_PK_EXT] = {
 		.oid = TZ_WORLD_PK_OID,
 		.sn = "TrustedWorldPublicKey",
 		.ln = "Trusted World Public Key",
-		.type = V_ASN1_OCTET_STRING
+		.asn1_type = V_ASN1_OCTET_STRING,
+		.type = EXT_TYPE_PKEY,
+		.data.key = TRUSTED_WORLD_KEY
 	},
-	{
+	[NTZ_WORLD_PK_EXT] = {
 		.oid = NTZ_WORLD_PK_OID,
 		.sn = "NonTrustedWorldPublicKey",
 		.ln = "Non-Trusted World Public Key",
-		.type = V_ASN1_OCTET_STRING
+		.asn1_type = V_ASN1_OCTET_STRING,
+		.type = EXT_TYPE_PKEY,
+		.data.key = NON_TRUSTED_WORLD_KEY
 	},
-	{
-		.oid = BL31_CONTENT_CERT_PK_OID,
-		.sn = "SoCFirmwareContentCertPK",
-		.ln = "SoC Firmware content certificate public key",
-		.type = V_ASN1_OCTET_STRING
-	},
-	{
-		.oid = BL31_HASH_OID,
-		.sn = "APROMPatchHash",
-		.ln = "AP ROM patch hash",
-		.type = V_ASN1_OCTET_STRING
-	},
-	{
+	[BL30_CONTENT_CERT_PK_EXT] = {
 		.oid = BL30_CONTENT_CERT_PK_OID,
 		.sn = "SCPFirmwareContentCertPK",
 		.ln = "SCP Firmware content certificate public key",
-		.type = V_ASN1_OCTET_STRING
+		.asn1_type = V_ASN1_OCTET_STRING,
+		.type = EXT_TYPE_PKEY,
+		.data.key = BL30_KEY
 	},
-	{
+	[BL30_HASH_EXT] = {
 		.oid = BL30_HASH_OID,
 		.sn = "SCPFirmwareHash",
 		.ln = "SCP Firmware (BL30) hash (SHA256)",
-		.type = V_ASN1_OCTET_STRING
+		.asn1_type = V_ASN1_OCTET_STRING,
+		.type = EXT_TYPE_HASH
 	},
-	{
+	[BL31_CONTENT_CERT_PK_EXT] = {
+		.oid = BL31_CONTENT_CERT_PK_OID,
+		.sn = "SoCFirmwareContentCertPK",
+		.ln = "SoC Firmware content certificate public key",
+		.asn1_type = V_ASN1_OCTET_STRING,
+		.type = EXT_TYPE_PKEY,
+		.data.key = BL31_KEY
+	},
+	[BL31_HASH_EXT] = {
+		.oid = BL31_HASH_OID,
+		.sn = "SoCAPFirmwareHash",
+		.ln = "SoC AP Firmware (BL31) hash (SHA256)",
+		.asn1_type = V_ASN1_OCTET_STRING,
+		.type = EXT_TYPE_HASH
+	},
+	[BL32_CONTENT_CERT_PK_EXT] = {
 		.oid = BL32_CONTENT_CERT_PK_OID,
 		.sn = "TrustedOSFirmwareContentCertPK",
 		.ln = "Trusted OS Firmware content certificate public key",
-		.type = V_ASN1_OCTET_STRING
+		.asn1_type = V_ASN1_OCTET_STRING,
+		.type = EXT_TYPE_PKEY,
+		.data.key = BL32_KEY
 	},
-	{
+	[BL32_HASH_EXT] = {
 		.oid = BL32_HASH_OID,
 		.sn = "TrustedOSHash",
 		.ln = "Trusted OS (BL32) hash (SHA256)",
-		.type = V_ASN1_OCTET_STRING
+		.asn1_type = V_ASN1_OCTET_STRING,
+		.type = EXT_TYPE_HASH
 	},
-	{
+	[BL33_CONTENT_CERT_PK_EXT] = {
 		.oid = BL33_CONTENT_CERT_PK_OID,
 		.sn = "NonTrustedFirmwareContentCertPK",
 		.ln = "Non-Trusted Firmware content certificate public key",
-		.type = V_ASN1_OCTET_STRING
+		.asn1_type = V_ASN1_OCTET_STRING,
+		.type = EXT_TYPE_PKEY,
+		.data.key = BL33_KEY
 	},
-	{
+	[BL33_HASH_EXT] = {
 		.oid = BL33_HASH_OID,
 		.sn = "NonTrustedWorldBootloaderHash",
 		.ln = "Non-Trusted World (BL33) hash (SHA256)",
-		.type = V_ASN1_OCTET_STRING
-	},
-	{ 0, 0, 0, 0 }
+		.asn1_type = V_ASN1_OCTET_STRING,
+		.type = EXT_TYPE_HASH
+	}
 };
+
+REGISTER_EXTENSIONS(tbb_ext);

--- a/tools/cert_create/src/tbbr/tbb_key.c
+++ b/tools/cert_create/src/tbbr/tbb_key.c
@@ -28,28 +28,42 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef TBB_KEY_H_
-#define TBB_KEY_H_
-
-#include "key.h"
+#include "tbbr/tbb_key.h"
 
 /*
- * Enumerate the keys that are used to establish the chain of trust
+ * Keys used to establish the chain of trust
+ *
+ * The order of the keys must follow the enumeration specified in tbb_key.h
  */
-enum {
-	ROT_KEY,
-	TRUSTED_WORLD_KEY,
-	NON_TRUSTED_WORLD_KEY,
-	BL30_KEY,
-	BL31_KEY,
-	BL32_KEY,
-	BL33_KEY,
-	NUM_KEYS
+static key_t tbb_keys[] = {
+	[ROT_KEY] = {
+		.id = ROT_KEY,
+		.desc = "Root Of Trust key"
+	},
+	[TRUSTED_WORLD_KEY] = {
+		.id = TRUSTED_WORLD_KEY,
+		.desc = "Trusted World key"
+	},
+	[NON_TRUSTED_WORLD_KEY] = {
+		.id = NON_TRUSTED_WORLD_KEY,
+		.desc = "Non Trusted World key"
+	},
+	[BL30_KEY] = {
+		.id = BL30_KEY,
+		.desc = "BL30 key"
+	},
+	[BL31_KEY] = {
+		.id = BL31_KEY,
+		.desc = "BL31 key"
+	},
+	[BL32_KEY] = {
+		.id = BL32_KEY,
+		.desc = "BL32 key"
+	},
+	[BL33_KEY] = {
+		.id = BL33_KEY,
+		.desc = "BL33 key"
+	}
 };
 
-/*
- * Array containing the key instances
- */
-extern key_t keys[];
-
-#endif /* TBB_KEY_H_ */
+REGISTER_KEYS(tbb_keys);


### PR DESCRIPTION
This patch reworks the certificate generation tool to follow a data
driven approach. The user may specify at build time the certificates,
keys and extensions defined in the CoT, register them using the
appropiate macros and the tool will take care of creating the
certificates corresponding to the CoT specified.

Change-Id: I29950b39343c3e1b71718fce0e77dcf2a9a0be2f