### PR TITLE
Tegra: memmap the actual memory available for BL31

### DIFF
--- a/plat/nvidia/tegra/common/tegra_bl31_setup.c
+++ b/plat/nvidia/tegra/common/tegra_bl31_setup.c
@@ -195,7 +195,7 @@ void bl31_plat_arch_setup(void)
 {
 	unsigned long bl31_base_pa = tegra_bl31_phys_base;
 	unsigned long total_base = bl31_base_pa;
-	unsigned long total_size = TZDRAM_END - BL31_RO_BASE;
+	unsigned long total_size = BL32_BASE - BL31_RO_BASE;
 	unsigned long ro_start = bl31_base_pa;
 	unsigned long ro_size = BL31_RO_LIMIT - BL31_RO_BASE;
 	const mmap_region_t *plat_mmio_map = NULL;


### PR DESCRIPTION
On Tegra SoCs, the TZDRAM contains the BL31 and BL32 images. This patch
uses only the actual memory available for BL31 instead of mapping the
entire TZDRAM.

Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>