### PR TITLE
Tegra: fix PLATFORM_{MAX_AFFLVL|CORE_COUNT|NUM_AFFS} macros

### DIFF
--- a/plat/nvidia/tegra/include/platform_def.h
+++ b/plat/nvidia/tegra/include/platform_def.h
@@ -48,10 +48,10 @@
 #define TEGRA_PRIMARY_CPU		0x0
 
 #define PLATFORM_MAX_AFFLVL		MPIDR_AFFLVL2
-#define PLATFORM_CORE_COUNT		PLATFORM_MAX_CPUS_PER_CLUSTER
-#define PLATFORM_NUM_AFFS		((PLATFORM_CLUSTER_COUNT * \
-					  PLATFORM_CORE_COUNT) + \
-					  PLATFORM_CLUSTER_COUNT + 1)
+#define PLATFORM_CORE_COUNT		(PLATFORM_CLUSTER_COUNT * \
+					 PLATFORM_MAX_CPUS_PER_CLUSTER)
+#define PLATFORM_NUM_AFFS		(PLATFORM_CORE_COUNT + \
+					 PLATFORM_CLUSTER_COUNT + 1)
 
 /*******************************************************************************
  * Platform console related constants


### PR DESCRIPTION
Tegra: fix PLATFORM_{CORE_COUNT|NUM_AFFS} macros

This patch fixes the following macros for Tegra SoCs.

* PLATFORM_CORE_COUNT: PLATFORM_CLUSTER_COUNT * PLATFORM_MAX_CPUS_PER_CLUSTER
* PLATFORM_NUM_AFFS: PLATFORM_CORE_COUNT + PLATFORM_CLUSTER_COUNT + 1

Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>