### PR TITLE
Fix build error with optimizations disabled (-O0)

### DIFF
--- a/include/plat/arm/common/arm_config.h
+++ b/include/plat/arm/common/arm_config.h
@@ -55,7 +55,7 @@ typedef struct arm_config {
 /* If used, arm_config must be defined and populated in the platform port */
 extern arm_config_t arm_config;
 
-inline const arm_config_t *get_arm_config(void)
+static inline const arm_config_t *get_arm_config(void)
 {
 	return &arm_config;
 }

--- a/include/plat/arm/soc/common/soc_css.h
+++ b/include/plat/arm/soc/common/soc_css.h
@@ -37,7 +37,7 @@
 void soc_css_init_nic400(void);
 void soc_css_init_pcie(void);
 
-inline void soc_css_security_setup(void)
+static inline void soc_css_security_setup(void)
 {
 	soc_css_init_nic400();
 	soc_css_init_pcie();


### PR DESCRIPTION
If Trusted Firmware is built with optimizations disabled (-O0), the
linker throws the following error:

    undefined reference to 'xxx'

Where 'xxx' is a raw inline function defined in a header file. The
reason is that, with optimizations disabled, GCC may decide to skip
the inlining. If that is the case, an external definition to the
compilation unit must be provided. Because no external definition
is present, the linker throws the error.

This patch fixes the problem by declaring the following inline
functions static, so the internal definition is used:

    inline void soc_css_security_setup(void)
    inline const arm_config_t *get_arm_config(void)

Change-Id: Id650d6be1b1396bdb48af1ac8a4c7900d212e95f