### PR TITLE
mt8173: Fix cluster 0 core count

### DIFF
--- a/plat/mediatek/mt8173/plat_topology.c
+++ b/plat/mediatek/mt8173/plat_topology.c
@@ -28,18 +28,20 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <arch.h>
+#include <platform_def.h>
 #include <psci.h>
 
 unsigned int plat_get_aff_count(unsigned int aff_lvl, unsigned long mpidr)
 {
 	/* Report 1 (absent) instance at levels higher that the cluster level */
 	if (aff_lvl > MPIDR_AFFLVL1)
-		return 1;
+		return PLATFORM_SYSTEM_COUNT;
 
 	if (aff_lvl == MPIDR_AFFLVL1)
-		return 2; /* We have two clusters */
+		return PLATFORM_CLUSTER_COUNT;
 
-	return mpidr & 0x100 ? 2 : 2; /* 2 cpus in cluster 1, 2 in cluster 0 */
+	return mpidr & 0x100 ? PLATFORM_CLUSTER1_CORE_COUNT :
+			       PLATFORM_CLUSTER0_CORE_COUNT;
 }
 
 unsigned int plat_get_aff_state(unsigned int aff_lvl, unsigned long mpidr)


### PR DESCRIPTION
Use constant macro defined in platform_def.h to replace hardcoded value.
This patch fix following assert in new psci-1.0 framework.

ASSERT: populate_power_domain_tree <183> : j == PLATFORM_CORE_COUNT

Change-Id: I9b7eda525479464a8c3805b6fe14ffb10debaf72
Signed-off-by: Jimmy Huang <jimmy.huang@mediatek.com>