### PR TITLE
TBB: abort boot if BL3-2 cannot be authenticated

### DIFF
--- a/bl2/bl2_main.c
+++ b/bl2/bl2_main.c
@@ -238,8 +238,14 @@ void bl2_main(void)
 	}
 
 	e = load_bl32(bl2_to_bl31_params);
-	if (e)
-		WARN("Failed to load BL3-2 (%i)\n", e);
+	if (e) {
+		if (e == LOAD_AUTH_ERR) {
+			ERROR("Failed to authenticate BL3-2\n");
+			panic();
+		} else {
+			WARN("Failed to load BL3-2 (%i)\n", e);
+		}
+	}
 
 	e = load_bl33(bl2_to_bl31_params);
 	if (e) {

--- a/include/common/bl_common.h
+++ b/include/common/bl_common.h
@@ -202,6 +202,15 @@ typedef struct bl31_params {
 	image_info_t *bl33_image_info;
 } bl31_params_t;
 
+/*
+ * load_auth_image() return values
+ */
+enum {
+	LOAD_SUCCESS,		/* Load + authentication success */
+	LOAD_ERR,		/* Load error */
+	LOAD_AUTH_ERR		/* Authentication error */
+};
+
 
 /*
  * Compile time assertions related to the 'entry_point_info' structure to


### PR DESCRIPTION
BL3-2 image (Secure Payload) is optional. If the image cannot be
loaded a warning message is printed and the boot process continues.
According to the TBBR document, this behaviour should not apply in
case of an authentication error, where the boot process should be
aborted.

This patch modifies the load_auth_image() function to distinguish
between a load error and an authentication error. The caller uses
the return value to abort the boot process or continue.

In case of authentication error, the memory region used to store
the image is wiped clean.

Change-Id: I534391d526d514b2a85981c3dda00de67e0e7992