### PR TITLE
Tegra: support PSCI v1.0 framework implementation

### DIFF
--- a/plat/nvidia/tegra/common/aarch64/tegra_helpers.S
+++ b/plat/nvidia/tegra/common/aarch64/tegra_helpers.S
@@ -36,9 +36,9 @@
 #include <tegra_def.h>
 
 	/* Global functions */
-	.globl	platform_is_primary_cpu
-	.globl	platform_get_core_pos
-	.globl	platform_get_entrypoint
+	.globl	plat_is_my_cpu_primary
+	.globl	plat_my_core_pos
+	.globl	plat_get_my_entrypoint
 	.globl	plat_secondary_cold_boot_setup
 	.globl	platform_mem_init
 	.globl	plat_crash_console_init
@@ -47,7 +47,7 @@
 	.globl	plat_reset_handler
 
 	/* Global variables */
-	.globl	sec_entry_point
+	.globl	tegra_sec_entry_point
 	.globl	ns_image_entrypoint
 	.globl	tegra_bl31_phys_base
 
@@ -115,28 +115,45 @@
 .endm
 
 	/* -----------------------------------------------------
-	 * int platform_is_primary_cpu(int mpidr);
+	 * unsigned int plat_is_my_cpu_primary(void);
 	 *
 	 * This function checks if this is the Primary CPU
 	 * -----------------------------------------------------
 	 */
-func platform_is_primary_cpu
+func plat_is_my_cpu_primary
+	mrs	x0, mpidr_el1
 	and	x0, x0, #(MPIDR_CLUSTER_MASK | MPIDR_CPU_MASK)
 	cmp	x0, #TEGRA_PRIMARY_CPU
 	cset	x0, eq
 	ret
-endfunc platform_is_primary_cpu
+endfunc plat_is_my_cpu_primary
 
 	/* -----------------------------------------------------
-	 * int platform_get_core_pos(int mpidr);
+	 * unsigned int plat_my_core_pos(void);
 	 *
 	 * With this function: CorePos = CoreId
 	 * -----------------------------------------------------
 	 */
-func platform_get_core_pos
+func plat_my_core_pos
+	mrs	x0, mpidr_el1
 	and	x0, x0, #MPIDR_CPU_MASK
 	ret
-endfunc platform_get_core_pos
+endfunc plat_my_core_pos
+
+	/* -----------------------------------------------------
+	 * unsigned long plat_get_my_entrypoint (void);
+	 *
+	 * Main job of this routine is to distinguish between
+	 * a cold and warm boot. If the tegra_sec_entry_point for
+	 * this CPU is present, then it's a warm boot.
+	 *
+	 * -----------------------------------------------------
+	 */
+func plat_get_my_entrypoint
+	adr	x1, tegra_sec_entry_point
+	ldr	x0, [x1]
+	ret
+endfunc plat_get_my_entrypoint
 
 	/* -----------------------------------------------------
 	 * void plat_secondary_cold_boot_setup (void);
@@ -150,22 +167,6 @@ func plat_secondary_cold_boot_setup
 	mov	x0, #0
 	ret
 endfunc plat_secondary_cold_boot_setup
-
-	/* -----------------------------------------------------
-	 * void platform_get_entrypoint (unsigned int mpidr);
-	 *
-	 * Main job of this routine is to distinguish between
-	 * a cold and warm boot. If the sec_entry_point for
-	 * this CPU is present, then it's a warm boot.
-	 *
-	 * -----------------------------------------------------
-	 */
-func platform_get_entrypoint
-	and	x0, x0, #MPIDR_CPU_MASK
-	adr	x1, sec_entry_point
-	ldr	x0, [x1, x0, lsl #3]
-	ret
-endfunc platform_get_entrypoint
 
 	/* --------------------------------------------------------
 	 * void platform_mem_init (void);
@@ -336,8 +337,7 @@ restore_oslock:
 	 * Get secure world's entry point and jump to it
 	 * --------------------------------------------------
 	 */
-	mrs	x0, mpidr_el1
-	bl	platform_get_entrypoint
+	bl	plat_get_my_entrypoint
 	br	x0
 endfunc tegra_secure_entrypoint
 
@@ -345,13 +345,11 @@ endfunc tegra_secure_entrypoint
 	.align 3
 
 	/* --------------------------------------------------
-	 * Per-CPU Secure entry point - resume from suspend
+	 * CPU Secure entry point - resume from suspend
 	 * --------------------------------------------------
 	 */
-sec_entry_point:
-	.rept	PLATFORM_CORE_COUNT
+tegra_sec_entry_point:
 	.quad	0
-	.endr
 
 	/* --------------------------------------------------
 	 * NS world's cold boot entry point

--- a/plat/nvidia/tegra/common/tegra_common.mk
+++ b/plat/nvidia/tegra/common/tegra_common.mk
@@ -51,6 +51,7 @@ BL31_SOURCES		+=	drivers/arm/gic/gic_v2.c			\
 				drivers/delay_timer/delay_timer.c		\
 				drivers/ti/uart/16550_console.S			\
 				plat/common/aarch64/platform_mp_stack.S		\
+				plat/common/aarch64/plat_psci_common.c		\
 				${COMMON_DIR}/aarch64/tegra_helpers.S		\
 				${COMMON_DIR}/drivers/memctrl/memctrl.c		\
 				${COMMON_DIR}/drivers/pmc/pmc.c			\

--- a/plat/nvidia/tegra/include/platform_def.h
+++ b/plat/nvidia/tegra/include/platform_def.h
@@ -33,6 +33,7 @@
 
 #include <arch.h>
 #include <common_def.h>
+#include <tegra_def.h>
 
 /*******************************************************************************
  * Generic platform constants
@@ -47,11 +48,17 @@
 
 #define TEGRA_PRIMARY_CPU		0x0
 
-#define PLATFORM_MAX_AFFLVL		MPIDR_AFFLVL2
+#define PLAT_MAX_PWR_LVL		MPIDR_AFFLVL2
 #define PLATFORM_CORE_COUNT		(PLATFORM_CLUSTER_COUNT * \
 					 PLATFORM_MAX_CPUS_PER_CLUSTER)
-#define PLATFORM_NUM_AFFS		(PLATFORM_CORE_COUNT + \
+#define PLAT_NUM_PWR_DOMAINS		(PLATFORM_CORE_COUNT + \
 					 PLATFORM_CLUSTER_COUNT + 1)
+
+/*******************************************************************************
+ * Platform power states
+ ******************************************************************************/
+#define PLAT_MAX_RET_STATE		1
+#define PLAT_MAX_OFF_STATE		(PLAT_SYS_SUSPEND_STATE_ID + 1)
 
 /*******************************************************************************
  * Platform console related constants

--- a/plat/nvidia/tegra/include/tegra_private.h
+++ b/plat/nvidia/tegra/include/tegra_private.h
@@ -31,8 +31,9 @@
 #ifndef __TEGRA_PRIVATE_H__
 #define __TEGRA_PRIVATE_H__
 
-#include <xlat_tables.h>
+#include <arch.h>
 #include <platform_def.h>
+#include <xlat_tables.h>
 
 /*******************************************************************************
  * Tegra DRAM memory base address
@@ -45,7 +46,8 @@ typedef struct plat_params_from_bl2 {
 } plat_params_from_bl2_t;
 
 /* Declarations for plat_psci_handlers.c */
-int32_t tegra_soc_validate_power_state(unsigned int power_state);
+int32_t tegra_soc_validate_power_state(unsigned int power_state,
+		psci_power_state_t *req_state);
 
 /* Declarations for plat_setup.c */
 const mmap_region_t *plat_get_mmio_map(void);

--- a/plat/nvidia/tegra/platform.mk
+++ b/plat/nvidia/tegra/platform.mk
@@ -28,7 +28,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 
-SOC_DIR		:=	plat/nvidia/tegra/soc/${TARGET_SOC}
+SOC_DIR			:=	plat/nvidia/tegra/soc/${TARGET_SOC}
+
+# Disable the PSCI platform compatibility layer
+ENABLE_PLAT_COMPAT	:=	0
 
 include plat/nvidia/tegra/common/tegra_common.mk
 include ${SOC_DIR}/platform_${TARGET_SOC}.mk

--- a/plat/nvidia/tegra/soc/t132/plat_psci_handlers.c
+++ b/plat/nvidia/tegra/soc/t132/plat_psci_handlers.c
@@ -50,28 +50,45 @@
 
 static int cpu_powergate_mask[PLATFORM_MAX_CPUS_PER_CLUSTER];
 
-int32_t tegra_soc_validate_power_state(unsigned int power_state)
+int32_t tegra_soc_validate_power_state(unsigned int power_state,
+					psci_power_state_t *req_state)
 {
+	int pwr_lvl = psci_get_pstate_pwrlvl(power_state);
+	int state_id = psci_get_pstate_id(power_state);
+
+	if (pwr_lvl > PLAT_MAX_PWR_LVL)
+		return PSCI_E_INVALID_PARAMS;
+
 	/* Sanity check the requested afflvl */
 	if (psci_get_pstate_type(power_state) == PSTATE_TYPE_STANDBY) {
 		/*
 		 * It's possible to enter standby only on affinity level 0 i.e.
 		 * a cpu on Tegra. Ignore any other affinity level.
 		 */
-		if (psci_get_pstate_afflvl(power_state) != MPIDR_AFFLVL0)
+		if (pwr_lvl != MPIDR_AFFLVL0)
 			return PSCI_E_INVALID_PARAMS;
+
+		/* power domain in standby state */
+		req_state->pwr_domain_state[pwr_lvl] = PLAT_MAX_RET_STATE;
+
+		return PSCI_E_SUCCESS;
 	}
 
 	/* Sanity check the requested state id */
-	if (psci_get_pstate_id(power_state) != PLAT_SYS_SUSPEND_STATE_ID) {
-		ERROR("unsupported state id\n");
-		return PSCI_E_NOT_SUPPORTED;
+	if ((pwr_lvl != PLAT_MAX_PWR_LVL) ||
+	    (state_id != PLAT_SYS_SUSPEND_STATE_ID)) {
+		ERROR("unsupported state id @ power level\n");
+		return PSCI_E_INVALID_PARAMS;
 	}
+
+	/* all power domain in 'OFF' state */
+	for (int i = MPIDR_AFFLVL0; i <= pwr_lvl; i++)
+		req_state->pwr_domain_state[i] = power_state;
 
 	return PSCI_E_SUCCESS;
 }
 
-int tegra_soc_prepare_cpu_on(unsigned long mpidr)
+int tegra_soc_pwr_domain_on(u_register_t mpidr)
 {
 	int cpu = mpidr & MPIDR_CPU_MASK;
 	uint32_t mask = CPU_CORE_RESET_MASK << cpu;
@@ -95,21 +112,14 @@ int tegra_soc_prepare_cpu_on(unsigned long mpidr)
 	return PSCI_E_SUCCESS;
 }
 
-int tegra_soc_prepare_cpu_off(unsigned long mpidr)
+int tegra_soc_pwr_domain_off(const psci_power_state_t *target_state)
 {
-	tegra_fc_cpu_off(mpidr & MPIDR_CPU_MASK);
+	tegra_fc_cpu_off(read_mpidr() & MPIDR_CPU_MASK);
 	return PSCI_E_SUCCESS;
 }
 
-int tegra_soc_prepare_cpu_suspend(unsigned int id, unsigned int afflvl)
+int tegra_soc_pwr_domain_suspend(const psci_power_state_t *target_state)
 {
-	/* Nothing to be done for lower affinity levels */
-	if (afflvl < MPIDR_AFFLVL2)
-		return PSCI_E_SUCCESS;
-
-	/* Enter system suspend state */
-	tegra_pm_system_suspend_entry();
-
 	/* Allow restarting CPU #1 using PMC on suspend exit */
 	cpu_powergate_mask[1] = 0;
 
@@ -117,7 +127,7 @@ int tegra_soc_prepare_cpu_suspend(unsigned int id, unsigned int afflvl)
 	tegra_fc_cpu_idle(read_mpidr());
 
 	/* Suspend DCO operations */
-	write_actlr_el1(id);
+	write_actlr_el1(target_state->pwr_domain_state[PLAT_MAX_PWR_LVL]);
 
 	return PSCI_E_SUCCESS;
 }

--- a/plat/nvidia/tegra/soc/t132/plat_setup.c
+++ b/plat/nvidia/tegra/soc/t132/plat_setup.c
@@ -31,6 +31,21 @@
 #include <xlat_tables.h>
 #include <tegra_def.h>
 
+/*******************************************************************************
+ * The Tegra power domain tree has a single system level power domain i.e. a
+ * single root node. The first entry in the power domain descriptor specifies
+ * the number of power domains at the highest power level.
+ *******************************************************************************
+ */
+const unsigned char tegra_power_domain_tree_desc[] = {
+	/* No of root nodes */
+	1,
+	/* No of clusters */
+	PLATFORM_CLUSTER_COUNT,
+	/* No of CPU cores */
+	PLATFORM_CLUSTER_COUNT * PLATFORM_MAX_CPUS_PER_CLUSTER,
+};
+
 /* sets of MMIO ranges setup */
 #define MMIO_RANGE_0_ADDR	0x50000000
 #define MMIO_RANGE_1_ADDR	0x60000000

--- a/plat/nvidia/tegra/soc/t210/plat_psci_handlers.c
+++ b/plat/nvidia/tegra/soc/t210/plat_psci_handlers.c
@@ -49,83 +49,125 @@
 
 static int cpu_powergate_mask[PLATFORM_MAX_CPUS_PER_CLUSTER];
 
-int32_t tegra_soc_validate_power_state(unsigned int power_state)
+int32_t tegra_soc_validate_power_state(unsigned int power_state,
+					psci_power_state_t *req_state)
 {
+	int pwr_lvl = psci_get_pstate_pwrlvl(power_state);
+	int state_id = psci_get_pstate_id(power_state);
+
+	if (pwr_lvl > PLAT_MAX_PWR_LVL) {
+		ERROR("%s: unsupported power_state (0x%x)\n", __func__,
+			power_state);
+		return PSCI_E_INVALID_PARAMS;
+	}
+
 	/* Sanity check the requested afflvl */
 	if (psci_get_pstate_type(power_state) == PSTATE_TYPE_STANDBY) {
 		/*
 		 * It's possible to enter standby only on affinity level 0 i.e.
 		 * a cpu on Tegra. Ignore any other affinity level.
 		 */
-		if (psci_get_pstate_afflvl(power_state) != MPIDR_AFFLVL0)
+		if (pwr_lvl != MPIDR_AFFLVL0)
 			return PSCI_E_INVALID_PARAMS;
+
+		/* power domain in standby state */
+		req_state->pwr_domain_state[pwr_lvl] = PLAT_MAX_RET_STATE;
+
+		return PSCI_E_SUCCESS;
 	}
 
 	/* Sanity check the requested state id */
-	switch (psci_get_pstate_id(power_state)) {
+	switch (state_id) {
 	case PSTATE_ID_CORE_POWERDN:
+		/*
+		 * Core powerdown request only for afflvl 0
+		 */
+		if (pwr_lvl != MPIDR_AFFLVL0)
+			goto error;
+
+		break;
+
 	case PSTATE_ID_CLUSTER_IDLE:
 	case PSTATE_ID_CLUSTER_POWERDN:
+		/*
+		 * Cluster powerdown/idle request only for afflvl 1
+		 */
+		if (pwr_lvl != MPIDR_AFFLVL1)
+			goto error;
+
+		break;
+
 	case PSTATE_ID_SOC_POWERDN:
+		/*
+		 * System powerdown request only for afflvl 2
+		 */
+		if (pwr_lvl != MPIDR_AFFLVL2)
+			goto error;
+
 		break;
 
 	default:
-		ERROR("unsupported state id\n");
+		ERROR("%s: unsupported state id (%d)\n", __func__, state_id);
+		return PSCI_E_INVALID_PARAMS;
+	}
+
+	/* all power domains in 'OFF' state */
+	for (int i = MPIDR_AFFLVL0; i <= pwr_lvl; i++)
+		req_state->pwr_domain_state[i] = power_state;
+
+	return PSCI_E_SUCCESS;
+
+error:
+	ERROR("%s: unsupported state id (%d)\n", __func__,state_id);
+	return PSCI_E_INVALID_PARAMS;
+}
+
+int tegra_soc_pwr_domain_suspend(const psci_power_state_t *target_state)
+{
+	u_register_t mpidr = read_mpidr();
+	const plat_local_state_t *pwr_domain_state =
+		target_state->pwr_domain_state;
+	unsigned int stateid_afflvl2 = pwr_domain_state[MPIDR_AFFLVL2];
+	unsigned int stateid_afflvl1 = pwr_domain_state[MPIDR_AFFLVL1];
+	unsigned int stateid_afflvl0 = pwr_domain_state[MPIDR_AFFLVL0];
+
+	if (stateid_afflvl2 == PSTATE_ID_SOC_POWERDN) {
+
+		/* suspend the entire soc */
+		tegra_fc_soc_powerdn(mpidr);
+
+	} else if (stateid_afflvl1 == PSTATE_ID_CLUSTER_IDLE) {
+
+		/* Prepare for cluster idle */
+		tegra_fc_cluster_idle(mpidr);
+
+	} else if (stateid_afflvl1 == PSTATE_ID_CLUSTER_POWERDN) {
+
+		/* Prepare for cluster powerdn */
+		tegra_fc_cluster_powerdn(mpidr);
+
+	} else if (stateid_afflvl0 == PSTATE_ID_CORE_POWERDN) {
+
+		/* Prepare for cpu idle */
+		tegra_fc_cpu_idle(mpidr);
+
+	} else {
+		ERROR("%s: Unknown state id\n", __func__);
 		return PSCI_E_NOT_SUPPORTED;
 	}
 
 	return PSCI_E_SUCCESS;
 }
 
-int tegra_soc_prepare_cpu_suspend(unsigned int id, unsigned int afflvl)
-{
-	/* There's nothing to be done for affinity level 1 */
-	if (afflvl == MPIDR_AFFLVL1)
-		return PSCI_E_SUCCESS;
-
-	switch (id) {
-	/* Prepare for cpu idle */
-	case PSTATE_ID_CORE_POWERDN:
-		tegra_fc_cpu_idle(read_mpidr());
-		return PSCI_E_SUCCESS;
-
-	/* Prepare for cluster idle */
-	case PSTATE_ID_CLUSTER_IDLE:
-		tegra_fc_cluster_idle(read_mpidr());
-		return PSCI_E_SUCCESS;
-
-	/* Prepare for cluster powerdn */
-	case PSTATE_ID_CLUSTER_POWERDN:
-		tegra_fc_cluster_powerdn(read_mpidr());
-		return PSCI_E_SUCCESS;
-
-	/* Prepare for system idle */
-	case PSTATE_ID_SOC_POWERDN:
-
-		/* Enter system suspend state */
-		tegra_pm_system_suspend_entry();
-
-		/* suspend the entire soc */
-		tegra_fc_soc_powerdn(read_mpidr());
-
-		return PSCI_E_SUCCESS;
-
-	default:
-		ERROR("Unknown state id (%d)\n", id);
-		break;
-	}
-
-	return PSCI_E_NOT_SUPPORTED;
-}
-
-int tegra_soc_prepare_cpu_on_finish(unsigned long mpidr)
+int tegra_soc_pwr_domain_on_finish(const psci_power_state_t *target_state)
 {
 	uint32_t val;
 
 	/*
 	 * Check if we are exiting from SOC_POWERDN.
 	 */
-	if (tegra_system_suspended()) {
+	if (target_state->pwr_domain_state[PLAT_MAX_PWR_LVL] ==
+			PLAT_SYS_SUSPEND_STATE_ID) {
 
 		/*
 		 * Enable WRAP to INCR burst type conversions for
@@ -141,11 +183,6 @@ int tegra_soc_prepare_cpu_on_finish(unsigned long mpidr)
 		 * address and reset it.
 		 */
 		tegra_fc_reset_bpmp();
-
-		/*
-		 * System resume complete.
-		 */
-		tegra_pm_system_suspend_exit();
 	}
 
 	/*
@@ -153,13 +190,12 @@ int tegra_soc_prepare_cpu_on_finish(unsigned long mpidr)
 	 * used for power management and boot purposes. Inform the BPMP that
 	 * we have completed the cluster power up.
 	 */
-	if (psci_get_max_phys_off_afflvl() == MPIDR_AFFLVL1)
-		tegra_fc_lock_active_cluster();
+	tegra_fc_lock_active_cluster();
 
 	return PSCI_E_SUCCESS;
 }
 
-int tegra_soc_prepare_cpu_on(unsigned long mpidr)
+int tegra_soc_pwr_domain_on(u_register_t mpidr)
 {
 	int cpu = mpidr & MPIDR_CPU_MASK;
 	uint32_t mask = CPU_CORE_RESET_MASK << cpu;
@@ -178,8 +214,8 @@ int tegra_soc_prepare_cpu_on(unsigned long mpidr)
 	return PSCI_E_SUCCESS;
 }
 
-int tegra_soc_prepare_cpu_off(unsigned long mpidr)
+int tegra_soc_pwr_domain_off(const psci_power_state_t *target_state)
 {
-	tegra_fc_cpu_off(mpidr & MPIDR_CPU_MASK);
+	tegra_fc_cpu_off(read_mpidr() & MPIDR_CPU_MASK);
 	return PSCI_E_SUCCESS;
 }

--- a/plat/nvidia/tegra/soc/t210/plat_setup.c
+++ b/plat/nvidia/tegra/soc/t210/plat_setup.c
@@ -32,6 +32,21 @@
 #include <tegra_def.h>
 #include <xlat_tables.h>
 
+/*******************************************************************************
+ * The Tegra power domain tree has a single system level power domain i.e. a
+ * single root node. The first entry in the power domain descriptor specifies
+ * the number of power domains at the highest power level.
+ *******************************************************************************
+ */
+const unsigned char tegra_power_domain_tree_desc[] = {
+	/* No of root nodes */
+	1,
+	/* No of clusters */
+	PLATFORM_CLUSTER_COUNT,
+	/* No of CPU cores */
+	PLATFORM_CLUSTER_COUNT * PLATFORM_MAX_CPUS_PER_CLUSTER,
+};
+
 /* sets of MMIO ranges setup */
 #define MMIO_RANGE_0_ADDR	0x50000000
 #define MMIO_RANGE_1_ADDR	0x60000000


### PR DESCRIPTION
This patch modifies the Tegra port to support the new PSCI v1.0
implementation. This includes modifications to the power management
and platform topology code.

Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>