### PR TITLE
Tlkd pm handlers v3

### DIFF
--- a/include/bl31/services/psci.h
+++ b/include/bl31/services/psci.h
@@ -286,7 +286,7 @@ typedef struct plat_psci_ops {
 typedef struct spd_pm_ops {
 	void (*svc_on)(uint64_t target_cpu);
 	int32_t (*svc_off)(uint64_t __unused);
-	void (*svc_suspend)(uint64_t __unused);
+	void (*svc_suspend)(uint64_t suspend_level);
 	void (*svc_on_finish)(uint64_t __unused);
 	void (*svc_suspend_finish)(uint64_t suspend_level);
 	int32_t (*svc_migrate)(uint64_t from_cpu, uint64_t to_cpu);

--- a/include/bl32/payloads/tlk.h
+++ b/include/bl32/payloads/tlk.h
@@ -43,6 +43,9 @@
 #define TLK_REGISTER_LOGBUF	TLK_TOS_STD_FID(0x1)
 #define TLK_REGISTER_REQBUF	TLK_TOS_STD_FID(0x2)
 #define TLK_RESUME_FID		TLK_TOS_STD_FID(0x100)
+#define TLK_SYSTEM_SUSPEND	TLK_TOS_STD_FID(0xE001)
+#define TLK_SYSTEM_RESUME	TLK_TOS_STD_FID(0xE002)
+#define TLK_SYSTEM_OFF		TLK_TOS_STD_FID(0xE003)
 
 /*
  * SMC function IDs that TLK uses to signal various forms of completions
@@ -52,6 +55,9 @@
 #define TLK_PREEMPTED		(0x32000002 | (1 << 31))
 #define TLK_ENTRY_DONE		(0x32000003 | (1 << 31))
 #define TLK_VA_TRANSLATE	(0x32000004 | (1 << 31))
+#define TLK_SUSPEND_DONE	(0x32000005 | (1 << 31))
+#define TLK_RESUME_DONE		(0x32000006 | (1 << 31))
+#define TLK_SYSTEM_OFF_DONE	(0x32000007 | (1 << 31))
 
 /*
  * Trusted Application specific function IDs

--- a/services/spd/opteed/opteed_pm.c
+++ b/services/spd/opteed/opteed_pm.c
@@ -81,7 +81,7 @@ static int32_t opteed_cpu_off_handler(uint64_t unused)
  * This cpu is being suspended. S-EL1 state must have been saved in the
  * resident cpu (mpidr format) if it is a UP/UP migratable OPTEE.
  ******************************************************************************/
-static void opteed_cpu_suspend_handler(uint64_t unused)
+static void opteed_cpu_suspend_handler(uint64_t suspend_level)
 {
 	int32_t rc = 0;
 	uint32_t linear_id = plat_my_core_pos();

--- a/services/spd/tlkd/tlkd_pm.c
+++ b/services/spd/tlkd/tlkd_pm.c
@@ -28,7 +28,17 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <arch_helpers.h>
+#include <assert.h>
+#include <bl_common.h>
+#include <debug.h>
 #include <psci.h>
+#include <context_mgmt.h>
+#include <tlk.h>
+
+#include "tlkd_private.h"
+
+extern tlk_context_t tlk_ctx;
 
 #define MPIDR_CPU0	0x80000000
 
@@ -46,9 +56,101 @@ static int32_t cpu_migrate_info(uint64_t *resident_cpu)
 }
 
 /*******************************************************************************
+ * This cpu is being suspended. Inform TLK of the SYSTEM_SUSPEND event, so
+ * that it can pass this information to its Trusted Apps.
+ ******************************************************************************/
+static void cpu_suspend_handler(uint64_t suspend_level)
+{
+	gp_regs_t *gp_regs;
+	int cpu = read_mpidr() & MPIDR_CPU_MASK;
+	int32_t rc = 0;
+
+	/*
+	 * TLK runs only on CPU0 and suspends its Trusted Apps during
+	 * SYSTEM_SUSPEND. It has no role to play during CPU_SUSPEND.
+	 */
+	if ((cpu != 0) || (suspend_level != PLAT_MAX_PWR_LVL))
+		return;
+
+	/* pass system suspend event to TLK */
+	gp_regs = get_gpregs_ctx(&tlk_ctx.cpu_ctx);
+	write_ctx_reg(gp_regs, CTX_GPREG_X0, TLK_SYSTEM_SUSPEND);
+
+	/* Program the entry point and enter TLK */
+	rc = tlkd_synchronous_sp_entry(&tlk_ctx);
+
+	/*
+	 * Read the response from TLK. A non-zero return means that
+	 * something went wrong while communicating with it.
+	 */
+	if (rc != 0)
+		panic();
+}
+
+/*******************************************************************************
+ * This cpu is being resumed. Inform TLK of the SYSTEM_SUSPEND exit, so
+ * that it can pass this information to its Trusted Apps.
+ ******************************************************************************/
+static void cpu_resume_handler(uint64_t suspend_level)
+{
+	gp_regs_t *gp_regs;
+	int cpu = read_mpidr() & MPIDR_CPU_MASK;
+	int32_t rc = 0;
+
+	/*
+	 * TLK runs only on CPU0 and resumes its Trusted Apps during
+	 * SYSTEM_SUSPEND exit. It has no role to play during CPU_SUSPEND
+	 * exit.
+	 */
+	if ((cpu != 0) || (suspend_level != PLAT_MAX_PWR_LVL))
+		return;
+
+	/* pass system resume event to TLK */
+	gp_regs = get_gpregs_ctx(&tlk_ctx.cpu_ctx);
+	write_ctx_reg(gp_regs, CTX_GPREG_X0, TLK_SYSTEM_RESUME);
+
+	/* Program the entry point and enter TLK */
+	rc = tlkd_synchronous_sp_entry(&tlk_ctx);
+
+	/*
+	 * Read the response from TLK. A non-zero return means that
+	 * something went wrong while communicating with it.
+	 */
+	if (rc != 0)
+		panic();
+}
+
+/*******************************************************************************
+ * System is about to be reset. Inform the SP to allow any book-keeping
+ ******************************************************************************/
+static void system_off_handler(void)
+{
+	int cpu = read_mpidr() & MPIDR_CPU_MASK;
+	gp_regs_t *gp_regs;
+
+	/* TLK runs only on CPU0 */
+	if (cpu != 0)
+		return;
+
+	/* pass system off/reset events to TLK */
+	gp_regs = get_gpregs_ctx(&tlk_ctx.cpu_ctx);
+	write_ctx_reg(gp_regs, CTX_GPREG_X0, TLK_SYSTEM_OFF);
+
+	/*
+	 * Enter the SP. We do not care about the return value because we
+	 * must continue with the shutdown anyway.
+	 */
+	(void)tlkd_synchronous_sp_entry(&tlk_ctx);
+}
+
+/*******************************************************************************
  * Structure populated by the Dispatcher to be given a chance to perform any
  * bookkeeping before PSCI executes a power mgmt.  operation.
  ******************************************************************************/
 const spd_pm_ops_t tlkd_pm_ops = {
 	.svc_migrate_info = cpu_migrate_info,
+	.svc_suspend = cpu_suspend_handler,
+	.svc_suspend_finish = cpu_resume_handler,
+	.svc_system_off = system_off_handler,
+	.svc_system_reset = system_off_handler
 };

--- a/services/spd/tspd/tspd_pm.c
+++ b/services/spd/tspd/tspd_pm.c
@@ -82,7 +82,7 @@ static int32_t tspd_cpu_off_handler(uint64_t unused)
  * This cpu is being suspended. S-EL1 state must have been saved in the
  * resident cpu (mpidr format) if it is a UP/UP migratable TSP.
  ******************************************************************************/
-static void tspd_cpu_suspend_handler(uint64_t unused)
+static void tspd_cpu_suspend_handler(uint64_t suspend_level)
 {
 	int32_t rc = 0;
 	uint32_t linear_id = plat_my_core_pos();

--- a/services/std_svc/psci/psci_suspend.c
+++ b/services/std_svc/psci/psci_suspend.c
@@ -91,7 +91,7 @@ static void psci_suspend_to_pwrdown_start(unsigned int end_pwrlvl,
 	 * error, it's expected to assert within
 	 */
 	if (psci_spd_pm && psci_spd_pm->svc_suspend)
-		psci_spd_pm->svc_suspend(0);
+		psci_spd_pm->svc_suspend(end_pwrlvl);
 
 	/*
 	 * Store the re-entry information for the non-secure world.


### PR DESCRIPTION
This PR modifies the PSCI service to send current suspend levels to the dispatcher's suspend handler. This would allow payloads to take different actions for CPU_SUSPEND/SYSTEM_SUSPEND.

This would allow TLK to save/restore certain hardware registers across SYSTEM_SUSPEND. This save/restore is not required for CPU_SUSPEND as the hardware blocks lose their settings only during SYSTEM_SUSPEND.

Previous PRs - #373, #376 