### PR TITLE
Configure all secure interrupts on ARM platforms

### DIFF
--- a/docs/firmware-design.md
+++ b/docs/firmware-design.md
@@ -347,9 +347,9 @@ level implementation of the generic timer through the memory mapped interface.
     -   Disable the legacy interrupt bypass mechanism.
     -   Configure the priority mask register to allow interrupts of all
         priorities to be signaled to the CPU interface.
-    -   Mark SGIs 8-15, the secure physical timer interrupt (#29) and the
-        trusted watchdog interrupt (#56) as group0 (secure).
-    -   Target the trusted watchdog interrupt to CPU0.
+    -   Mark SGIs 8-15 and the other secure interrupts on the platform
+        as group0 (secure).
+    -   Target all secure SPIs to CPU0.
     -   Enable these group0 interrupts in the GIC distributor.
     -   Configure all other interrupts as group1 (non-secure).
     -   Enable signaling of group0 interrupts in the GIC distributor.

--- a/include/plat/arm/css/common/css_def.h
+++ b/include/plat/arm/css/common/css_def.h
@@ -58,10 +58,9 @@
 /* Interrupt handling constants */
 #define CSS_IRQ_MHU			69
 #define CSS_IRQ_GPU_SMMU_0		71
-#define CSS_IRQ_GPU_SMMU_1		73
-#define CSS_IRQ_ETR_SMMU		75
 #define CSS_IRQ_TZC			80
 #define CSS_IRQ_TZ_WDOG			86
+#define CSS_IRQ_SEC_SYS_TIMER		91
 
 /*
  * SCP <=> AP boot configuration

--- a/plat/arm/board/fvp/aarch64/fvp_common.c
+++ b/plat/arm/board/fvp/aarch64/fvp_common.c
@@ -113,7 +113,6 @@ ARM_CASSERT_MMAP
 #if IMAGE_BL31 || IMAGE_BL32
 /* Array of secure interrupts to be configured by the gic driver */
 const unsigned int irq_sec_array[] = {
-	IRQ_TZ_WDOG,
 	ARM_IRQ_SEC_PHY_TIMER,
 	ARM_IRQ_SEC_SGI_0,
 	ARM_IRQ_SEC_SGI_1,
@@ -122,7 +121,9 @@ const unsigned int irq_sec_array[] = {
 	ARM_IRQ_SEC_SGI_4,
 	ARM_IRQ_SEC_SGI_5,
 	ARM_IRQ_SEC_SGI_6,
-	ARM_IRQ_SEC_SGI_7
+	ARM_IRQ_SEC_SGI_7,
+	FVP_IRQ_TZ_WDOG,
+	FVP_IRQ_SEC_SYS_TIMER
 };
 
 void plat_arm_gic_init(void)

--- a/plat/arm/board/fvp/fvp_def.h
+++ b/plat/arm/board/fvp/fvp_def.h
@@ -115,7 +115,8 @@
 #define BASE_GICH_BASE			0x2c010000
 #define BASE_GICV_BASE			0x2c02f000
 
-#define IRQ_TZ_WDOG			56
+#define FVP_IRQ_TZ_WDOG			56
+#define FVP_IRQ_SEC_SYS_TIMER		57
 
 
 /*******************************************************************************

--- a/plat/arm/board/juno/include/platform_def.h
+++ b/plat/arm/board/juno/include/platform_def.h
@@ -96,12 +96,19 @@
 #define PLAT_CSS_GICH_BASE		0x2c04f000
 #define PLAT_CSS_GICV_BASE		0x2c06f000
 
-#define PLAT_CSS_IRQ_SEC_LIST		CSS_IRQ_MHU,		\
-					CSS_IRQ_GPU_SMMU_0,	\
-					CSS_IRQ_GPU_SMMU_1,	\
-					CSS_IRQ_ETR_SMMU,	\
-					CSS_IRQ_TZC,		\
-					CSS_IRQ_TZ_WDOG
+#define PLAT_CSS_IRQ_SEC_LIST		CSS_IRQ_MHU,			\
+					CSS_IRQ_GPU_SMMU_0,		\
+					CSS_IRQ_TZC,			\
+					CSS_IRQ_TZ_WDOG,		\
+					CSS_IRQ_SEC_SYS_TIMER,		\
+					JUNO_IRQ_DMA_SMMU,		\
+					JUNO_IRQ_HDLCD0_SMMU,		\
+					JUNO_IRQ_HDLCD1_SMMU,		\
+					JUNO_IRQ_USB_SMMU,		\
+					JUNO_IRQ_THIN_LINKS_SMMU,	\
+					JUNO_IRQ_SEC_I2C,		\
+					JUNO_IRQ_GPU_SMMU_1,		\
+					JUNO_IRQ_ETR_SMMU
 
 /*
  * Required ARM CSS SoC based platform porting definitions

--- a/plat/arm/board/juno/juno_def.h
+++ b/plat/arm/board/juno/juno_def.h
@@ -71,5 +71,16 @@
 #define MMU401_SSD_OFFSET		0x4000
 #define MMU401_DMA330_BASE		0x7fb00000
 
+/*******************************************************************************
+ * Interrupt handling constants
+ ******************************************************************************/
+#define JUNO_IRQ_DMA_SMMU		126
+#define JUNO_IRQ_HDLCD0_SMMU		128
+#define JUNO_IRQ_HDLCD1_SMMU		130
+#define JUNO_IRQ_USB_SMMU		132
+#define JUNO_IRQ_THIN_LINKS_SMMU	134
+#define JUNO_IRQ_SEC_I2C		137
+#define JUNO_IRQ_GPU_SMMU_1		73
+#define JUNO_IRQ_ETR_SMMU		75
 
 #endif /* __JUNO_DEF_H__ */


### PR DESCRIPTION
ARM TF configures all interrupts as non-secure except those which
are present in irq_sec_array. This patch updates the irq_sec_array
with the missing secure interrupts for ARM platforms.

It also updates the documentation to be inline with the latest
implementation.

Fixes ARM-software/tf-issues#312

Change-Id: I39956c56a319086e3929d1fa89030b4ec4b01fcc