### PR TITLE
Ensure BL2 security state is secure

### DIFF
--- a/bl1/bl1_main.c
+++ b/bl1/bl1_main.c
@@ -44,13 +44,15 @@
  ******************************************************************************/
 static void __dead2 bl1_run_bl2(entry_point_info_t *bl2_ep)
 {
+	/* Check bl2 security state is expected as secure */
+	assert(GET_SECURITY_STATE(bl2_ep->h.attr) == SECURE);
+	/* Check NS Bit is also set as secure */
+	assert(!(read_scr_el3() & SCR_NS_BIT));
+
 	bl1_arch_next_el_setup();
 
 	/* Tell next EL what we want done */
 	bl2_ep->args.arg0 = RUN_IMAGE;
-
-	if (GET_SECURITY_STATE(bl2_ep->h.attr) == NON_SECURE)
-		change_security_state(GET_SECURITY_STATE(bl2_ep->h.attr));
 
 	write_spsr_el3(bl2_ep->spsr);
 	write_elr_el3(bl2_ep->pc);

--- a/common/bl_common.c
+++ b/common/bl_common.c
@@ -59,19 +59,6 @@ static inline unsigned int is_page_aligned (unsigned long addr) {
 	return (addr & (page_size - 1)) == 0;
 }
 
-void change_security_state(unsigned int target_security_state)
-{
-	unsigned long scr = read_scr();
-
-	assert(sec_state_is_valid(target_security_state));
-	if (target_security_state == SECURE)
-		scr &= ~SCR_NS_BIT;
-	else
-		scr |= SCR_NS_BIT;
-
-	write_scr(scr);
-}
-
 /******************************************************************************
  * Determine whether the memory region delimited by 'addr' and 'size' is free,
  * given the extents of free memory.

--- a/include/common/bl_common.h
+++ b/include/common/bl_common.h
@@ -234,7 +234,6 @@ CASSERT(sizeof(unsigned long) ==
  * Function & variable prototypes
  ******************************************************************************/
 unsigned long page_align(unsigned long, unsigned);
-void change_security_state(unsigned int);
 unsigned long image_size(unsigned int image_id);
 int load_image(meminfo_t *mem_layout,
 	       unsigned int image_id,


### PR DESCRIPTION
BL2 loads secure runtime code(BL3-1, BL3-2) and hence it has to
run in secure world otherwise BL3-1/BL3-2 have to execute from
non-secure memory. Hence, This patch removes the change_security_state()
call in bl1_run_bl2() and replaces it with an assert to confirm
the BL2 as secure.

Fixes ARM-software/tf-issues#314

Change-Id: I611b83f5c4090e58a76a2e950b0d797b46df3c29