### PR TITLE
Pass the target suspend level to SPD suspend hooks

### DIFF
--- a/include/bl31/services/psci.h
+++ b/include/bl31/services/psci.h
@@ -286,7 +286,7 @@ typedef struct plat_psci_ops {
 typedef struct spd_pm_ops {
 	void (*svc_on)(uint64_t target_cpu);
 	int32_t (*svc_off)(uint64_t __unused);
-	void (*svc_suspend)(uint64_t __unused);
+	void (*svc_suspend)(uint64_t suspend_level);
 	void (*svc_on_finish)(uint64_t __unused);
 	void (*svc_suspend_finish)(uint64_t suspend_level);
 	int32_t (*svc_migrate)(uint64_t from_cpu, uint64_t to_cpu);

--- a/services/spd/opteed/opteed_pm.c
+++ b/services/spd/opteed/opteed_pm.c
@@ -81,7 +81,7 @@ static int32_t opteed_cpu_off_handler(uint64_t unused)
  * This cpu is being suspended. S-EL1 state must have been saved in the
  * resident cpu (mpidr format) if it is a UP/UP migratable OPTEE.
  ******************************************************************************/
-static void opteed_cpu_suspend_handler(uint64_t unused)
+static void opteed_cpu_suspend_handler(uint64_t suspend_level)
 {
 	int32_t rc = 0;
 	uint32_t linear_id = plat_my_core_pos();

--- a/services/spd/tspd/tspd_pm.c
+++ b/services/spd/tspd/tspd_pm.c
@@ -82,7 +82,7 @@ static int32_t tspd_cpu_off_handler(uint64_t unused)
  * This cpu is being suspended. S-EL1 state must have been saved in the
  * resident cpu (mpidr format) if it is a UP/UP migratable TSP.
  ******************************************************************************/
-static void tspd_cpu_suspend_handler(uint64_t unused)
+static void tspd_cpu_suspend_handler(uint64_t suspend_level)
 {
 	int32_t rc = 0;
 	uint32_t linear_id = plat_my_core_pos();


### PR DESCRIPTION
In certain Trusted OS implementations it is a requirement to pass them the
highest power level which will enter a power down state during a PSCI
CPU_SUSPEND or SYSTEM_SUSPEND API invocation. This patch passes this power level
to the SPD in the "suspend_level" parameter of the svc_suspend() hook.

Currently, the highest power level which was requested to be placed in a low
power state (retention or power down) is passed to the SPD svc_suspend_finish()
hook. This hook is called after emerging from the low power state. It is more
useful to pass the highest power level which was powered down instead. This
patch does this by changing the semantics of the SPD svc_suspend_finish() hook's
"suspend_level" parameter.

Change-Id: If3a9d39b13119bbb6281f508a91f78a2f46a8b90