### PR TITLE
Pass the target suspend level to SPD suspend hooks

### DIFF
--- a/bl32/tsp/tsp_main.c
+++ b/bl32/tsp/tsp_main.c
@@ -251,7 +251,7 @@ tsp_args_t *tsp_cpu_suspend_main(uint64_t arg0,
  * cpu's architectural state has been restored after wakeup from an earlier psci
  * cpu_suspend request.
  ******************************************************************************/
-tsp_args_t *tsp_cpu_resume_main(uint64_t suspend_level,
+tsp_args_t *tsp_cpu_resume_main(uint64_t max_off_pwrlvl,
 			      uint64_t arg1,
 			      uint64_t arg2,
 			      uint64_t arg3,
@@ -272,8 +272,8 @@ tsp_args_t *tsp_cpu_resume_main(uint64_t suspend_level,
 
 #if LOG_LEVEL >= LOG_LEVEL_INFO
 	spin_lock(&console_lock);
-	INFO("TSP: cpu 0x%lx resumed. suspend level %ld\n",
-		read_mpidr(), suspend_level);
+	INFO("TSP: cpu 0x%lx resumed. maximum off power level %ld\n",
+	     read_mpidr(), max_off_pwrlvl);
 	INFO("TSP: cpu 0x%lx: %d smcs, %d erets %d cpu suspend requests\n",
 		read_mpidr(),
 		tsp_stats[linear_id].smc_count,

--- a/include/bl31/services/psci.h
+++ b/include/bl31/services/psci.h
@@ -286,9 +286,9 @@ typedef struct plat_psci_ops {
 typedef struct spd_pm_ops {
 	void (*svc_on)(uint64_t target_cpu);
 	int32_t (*svc_off)(uint64_t __unused);
-	void (*svc_suspend)(uint64_t __unused);
+	void (*svc_suspend)(uint64_t max_off_pwrlvl);
 	void (*svc_on_finish)(uint64_t __unused);
-	void (*svc_suspend_finish)(uint64_t suspend_level);
+	void (*svc_suspend_finish)(uint64_t max_off_pwrlvl);
 	int32_t (*svc_migrate)(uint64_t from_cpu, uint64_t to_cpu);
 	int32_t (*svc_migrate_info)(uint64_t *resident_cpu);
 	void (*svc_system_off)(void);

--- a/services/spd/opteed/opteed_pm.c
+++ b/services/spd/opteed/opteed_pm.c
@@ -81,7 +81,7 @@ static int32_t opteed_cpu_off_handler(uint64_t unused)
  * This cpu is being suspended. S-EL1 state must have been saved in the
  * resident cpu (mpidr format) if it is a UP/UP migratable OPTEE.
  ******************************************************************************/
-static void opteed_cpu_suspend_handler(uint64_t unused)
+static void opteed_cpu_suspend_handler(uint64_t max_off_pwrlvl)
 {
 	int32_t rc = 0;
 	uint32_t linear_id = plat_my_core_pos();
@@ -147,7 +147,7 @@ static void opteed_cpu_on_finish_handler(uint64_t unused)
  * completed the preceding suspend call. Use that context to program an entry
  * into OPTEE to allow it to do any remaining book keeping
  ******************************************************************************/
-static void opteed_cpu_suspend_finish_handler(uint64_t suspend_level)
+static void opteed_cpu_suspend_finish_handler(uint64_t max_off_pwrlvl)
 {
 	int32_t rc = 0;
 	uint32_t linear_id = plat_my_core_pos();
@@ -156,10 +156,10 @@ static void opteed_cpu_suspend_finish_handler(uint64_t suspend_level)
 	assert(optee_vectors);
 	assert(get_optee_pstate(optee_ctx->state) == OPTEE_PSTATE_SUSPEND);
 
-	/* Program the entry point, suspend_level and enter the SP */
+	/* Program the entry point, max_off_pwrlvl and enter the SP */
 	write_ctx_reg(get_gpregs_ctx(&optee_ctx->cpu_ctx),
 		      CTX_GPREG_X0,
-		      suspend_level);
+		      max_off_pwrlvl);
 	cm_set_elr_el3(SECURE, (uint64_t) &optee_vectors->cpu_resume_entry);
 	rc = opteed_synchronous_sp_entry(optee_ctx);
 

--- a/services/spd/tspd/tspd_pm.c
+++ b/services/spd/tspd/tspd_pm.c
@@ -82,7 +82,7 @@ static int32_t tspd_cpu_off_handler(uint64_t unused)
  * This cpu is being suspended. S-EL1 state must have been saved in the
  * resident cpu (mpidr format) if it is a UP/UP migratable TSP.
  ******************************************************************************/
-static void tspd_cpu_suspend_handler(uint64_t unused)
+static void tspd_cpu_suspend_handler(uint64_t max_off_pwrlvl)
 {
 	int32_t rc = 0;
 	uint32_t linear_id = plat_my_core_pos();
@@ -157,7 +157,7 @@ static void tspd_cpu_on_finish_handler(uint64_t unused)
  * completed the preceding suspend call. Use that context to program an entry
  * into the TSP to allow it to do any remaining book keeping
  ******************************************************************************/
-static void tspd_cpu_suspend_finish_handler(uint64_t suspend_level)
+static void tspd_cpu_suspend_finish_handler(uint64_t max_off_pwrlvl)
 {
 	int32_t rc = 0;
 	uint32_t linear_id = plat_my_core_pos();
@@ -166,10 +166,10 @@ static void tspd_cpu_suspend_finish_handler(uint64_t suspend_level)
 	assert(tsp_vectors);
 	assert(get_tsp_pstate(tsp_ctx->state) == TSP_PSTATE_SUSPEND);
 
-	/* Program the entry point, suspend_level and enter the SP */
+	/* Program the entry point, max_off_pwrlvl and enter the SP */
 	write_ctx_reg(get_gpregs_ctx(&tsp_ctx->cpu_ctx),
 		      CTX_GPREG_X0,
-		      suspend_level);
+		      max_off_pwrlvl);
 	cm_set_elr_el3(SECURE, (uint64_t) &tsp_vectors->cpu_resume_entry);
 	rc = tspd_synchronous_sp_entry(tsp_ctx);
 


### PR DESCRIPTION
In certain Trusted OS implementations it is a requirement to pass them the
highest power level which will enter a power down state during a PSCI
CPU_SUSPEND or SYSTEM_SUSPEND API invocation. This patch passes this power level
to the SPD in the "max_off_pwrlvl" parameter of the svc_suspend() hook.

Currently, the highest power level which was requested to be placed in a low
power state (retention or power down) is passed to the SPD svc_suspend_finish()
hook. This hook is called after emerging from the low power state. It is more
useful to pass the highest power level which was powered down instead. This
patch does this by changing the semantics of the parameter passed to an SPD's
svc_suspend_finish() hook. The name of the parameter has been changed from
"suspend_level" to "max_off_pwrlvl" as well. Same changes have been made to the
parameter passed to the tsp_cpu_resume_main() function.

Change-Id: If3a9d39b13119bbb6281f508a91f78a2f46a8b90

Supersedes #386 

Changelog:
*  Made parameter names more consistent. References to `suspend_level` have been replaced by `max_off_pwrlvl`