### PR TITLE
Bug fix in the SP804 dual timer driver

### DIFF
--- a/drivers/arm/sp804/sp804_delay_timer.c
+++ b/drivers/arm/sp804/sp804_delay_timer.c
@@ -33,6 +33,7 @@
 #include <mmio.h>
 
 uintptr_t sp804_base_addr;
+static timer_ops_t sp804_ops;
 
 #define SP804_TIMER1_LOAD	(sp804_base_addr + 0x000)
 #define SP804_TIMER1_VALUE	(sp804_base_addr + 0x004)
@@ -60,13 +61,15 @@ uint32_t sp804_get_timer_value(void)
  * Initialize the 1st timer in the SP804 dual timer with a base
  * address and a timer ops
  ********************************************************************/
-void sp804_timer_ops_init(uintptr_t base_addr, const timer_ops_t *ops)
+void sp804_timer_init(uintptr_t base_addr, uint32_t clk_mult, uint32_t clk_div)
 {
 	assert(base_addr != 0);
-	assert(ops != 0 && ops->get_timer_value == sp804_get_timer_value);
 
 	sp804_base_addr = base_addr;
-	timer_init(ops);
+	sp804_ops.get_timer_value = sp804_get_timer_value;
+	sp804_ops.clk_mult = clk_mult;
+	sp804_ops.clk_div = clk_div;
+	timer_init(&sp804_ops);
 
 	/* disable timer1 */
 	mmio_write_32(SP804_TIMER1_CONTROL, 0);

--- a/include/drivers/arm/sp804_delay_timer.h
+++ b/include/drivers/arm/sp804_delay_timer.h
@@ -34,14 +34,8 @@
 #include <delay_timer.h>
 #include <stdint.h>
 
-
 uint32_t sp804_get_timer_value(void);
 
-void sp804_timer_ops_init(uintptr_t base_addr, const timer_ops_t *ops);
-
-#define sp804_timer_init(base_addr, clk_mult, clk_div)			\
-	sp804_timer_ops_init((base_addr), &(const timer_ops_t)		\
-			{ sp804_get_timer_value, (clk_mult), (clk_div) })
-
+void sp804_timer_init(uintptr_t base_addr, uint32_t clk_mult, uint32_t clk_div);
 
 #endif /* __SP804_DELAY_TIMER_H__ */


### PR DESCRIPTION
The generic delay timer driver expects a pointer to a timer_ops_t
structure containing the specific timer driver information. It
doesn't make a copy of the structure, instead it just keeps the
pointer. Therefore, this pointer must remain valid over time.

The SP804 driver doesn't satisfy this requirement. The
sp804_timer_init() macro creates a temporary instanciation of the
timer_ops_t structure on the fly and passes it to the generic
delay timer. When this temporary instanciation gets deallocated,
the generic delay timer is left with a pointer to invalid data.

This patch fixes this bug by statically allocating the SP804
timer_ops_t structure in the SP804 driver. As a result, the SP804
driver init function no longer expects the timer_ops_t structure in
argument, instead it receives the clock multiplier and divider as
arguments and populates its internal timer_ops_t structure itself.
