### PR TITLE
Fix relocation of __PERCPU_BAKERY_LOCK_SIZE__ in PR #390

### DIFF
--- a/bl31/bl31.ld.S
+++ b/bl31/bl31.ld.S
@@ -124,7 +124,7 @@ SECTIONS
         __BAKERY_LOCK_START__ = .;
         *(bakery_lock)
         . = ALIGN(CACHE_WRITEBACK_GRANULE);
-        __PERCPU_BAKERY_LOCK_SIZE__ = . - __BAKERY_LOCK_START__;
+        __PERCPU_BAKERY_LOCK_SIZE__ = ABSOLUTE(. - __BAKERY_LOCK_START__);
         . = . + (__PERCPU_BAKERY_LOCK_SIZE__ * (PLATFORM_CORE_COUNT - 1));
         __BAKERY_LOCK_END__ = .;
 #ifdef PLAT_PERCPU_BAKERY_LOCK_SIZE

--- a/docs/porting-guide.md
+++ b/docs/porting-guide.md
@@ -1153,11 +1153,23 @@ of the system counter, which is retrieved from the first entry in the frequency
 modes table.
 
 
-*   **#define : PLAT_PERCPU_BAKERY_LOCK_SIZE** [optional]
+### #define : PLAT_PERCPU_BAKERY_LOCK_SIZE [optional]
 
-    It is used if the bakery locks are using normal memory. It defines the memory
-   (in bytes) to be allocated for the bakery locks and needs to be a multiple of
-   cache line size.
+   When `USE_COHERENT_MEM = 0`, this constant defines the total memory (in
+   bytes) aligned to the cache line boundary that should be allocated per-cpu to
+   accommodate all the bakery locks.
+
+   If this constant is not defined when `USE_COHERENT_MEM = 0`, the linker
+   calculates the size of the `bakery_lock` input section, aligns it to the
+   nearest `CACHE_WRITEBACK_GRANULE`, multiplies it with `PLATFORM_CORE_COUNT`
+   and stores the result in a linker symbol. This constant prevents a platform
+   from relying on the linker and provide a more efficient mechanism for
+   accessing per-cpu bakery lock information.
+
+   If this constant is defined and its value is not equal to the value
+   calculated by the linker then a link time assertion is raised. A compile time
+   assertion is raised if the value of the constant is not aligned to the cache
+   line boundary.
 
 3.3 Power State Coordination Interface (in BL3-1)
 ------------------------------------------------


### PR DESCRIPTION
When a platform port does not define PLAT_PERCPU_BAKERY_LOCK_SIZE, the total
memory that should be allocated per-cpu to accommodate all bakery locks is
calculated by the linker in bl31.ld.S. The linker stores this value in the
__PERCPU_BAKERY_LOCK_SIZE__ linker symbol. The runtime value of this symbol is
different from the link time value as the symbol is relocated into the current
section (.bss). This patch fixes this issue by marking the symbol as ABSOLUTE
which allows it to retain its correct value even at runtime.

The description of PLAT_PERCPU_BAKERY_LOCK_SIZE in the porting-guide.md has been
made clearer as well.

Change-Id: Ia0cfd42f51deaf739d792297e60cad5c6e6e610b