### PR TITLE
Bug fix in the SP804 dual timer driver (v2)

### DIFF
--- a/include/drivers/arm/sp804_delay_timer.h
+++ b/include/drivers/arm/sp804_delay_timer.h
@@ -40,8 +40,13 @@ uint32_t sp804_get_timer_value(void);
 void sp804_timer_ops_init(uintptr_t base_addr, const timer_ops_t *ops);
 
 #define sp804_timer_init(base_addr, clk_mult, clk_div)			\
-	sp804_timer_ops_init((base_addr), &(const timer_ops_t)		\
-			{ sp804_get_timer_value, (clk_mult), (clk_div) })
-
+	do {								\
+		static const timer_ops_t sp804_timer_ops = {		\
+			sp804_get_timer_value,				\
+			(clk_mult),					\
+			(clk_div)					\
+		};							\
+		sp804_timer_ops_init((base_addr), &sp804_timer_ops);	\
+	} while (0)
 
 #endif /* __SP804_DELAY_TIMER_H__ */


### PR DESCRIPTION
The generic delay timer driver expects a pointer to a timer_ops_t
structure containing the specific timer driver information. It
doesn't make a copy of the structure, instead it just keeps the
pointer. Therefore, this pointer must remain valid over time.

The SP804 driver doesn't satisfy this requirement. The
sp804_timer_init() macro creates a temporary instanciation of the
timer_ops_t structure on the fly and passes it to the generic
delay timer. When this temporary instanciation gets deallocated,
the generic delay timer is left with a pointer to invalid data.

This patch fixes this bug by statically allocating the SP804
timer_ops_t structure.
