### PR TITLE
TLKD: pass results with TLK_RESUME_FID function ID

### DIFF
--- a/services/spd/tlkd/tlkd_main.c
+++ b/services/spd/tlkd/tlkd_main.c
@@ -199,41 +199,6 @@ uint64_t tlkd_smc_handler(uint32_t smc_fid,
 		SMC_RET1(ns_cpu_context, x1);
 
 	/*
-	 * Request from non secure world to resume the preempted
-	 * Standard SMC call.
-	 */
-	case TLK_RESUME_FID:
-
-		/* RESUME should be invoked only by normal world */
-		if (!ns)
-			SMC_RET1(handle, SMC_UNK);
-
-		/*
-		 * This is a resume request from the non-secure client.
-		 * save the non-secure state and send the request to
-		 * the secure payload.
-		 */
-		assert(handle == cm_get_context(NON_SECURE));
-
-		/* Check if we are already preempted before resume */
-		if (!get_std_smc_active_flag(tlk_ctx.state))
-			SMC_RET1(handle, SMC_UNK);
-
-		cm_el1_sysregs_context_save(NON_SECURE);
-
-		/*
-		 * We are done stashing the non-secure context. Ask the
-		 * secure payload to do the work now.
-		 */
-
-		/* We just need to return to the preempted point in
-		 * SP and the execution will resume as normal.
-		 */
-		cm_el1_sysregs_context_restore(SECURE);
-		cm_set_next_eret_context(SECURE);
-		SMC_RET0(handle);
-
-	/*
 	 * This is a request from the non-secure context to:
 	 *
 	 * a. register shared memory with the SP for storing it's
@@ -243,6 +208,7 @@ uint64_t tlkd_smc_handler(uint32_t smc_fid,
 	 *    Applications.
 	 * c. open/close sessions
 	 * d. issue commands to the Trusted Apps
+	 * e. resume the preempted standard SMC call.
 	 */
 	case TLK_REGISTER_LOGBUF:
 	case TLK_REGISTER_REQBUF:
@@ -250,6 +216,7 @@ uint64_t tlkd_smc_handler(uint32_t smc_fid,
 	case TLK_CLOSE_TA_SESSION:
 	case TLK_TA_LAUNCH_OP:
 	case TLK_TA_SEND_EVENT:
+	case TLK_RESUME_FID:
 
 		if (!ns)
 			SMC_RET1(handle, SMC_UNK);


### PR DESCRIPTION
TLK sends the "preempted" event to the NS world along with an
identifier for certain use cases. The NS world driver is then
expected to take appropriate action depending on the identifier
value. Upon completion, the NS world driver then sends the
results to TLK (via x1-x3) with the TLK_RESUME_FID function ID.

This patch uses the already present code to pass the results
from the NS world to TLK for the TLK_RESUME_FID function ID.

Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>