### PR TITLE
Fix debug assertion in deprecated CCI-400 driver

### DIFF
--- a/drivers/arm/cci400/cci400.c
+++ b/drivers/arm/cci400/cci400.c
@@ -48,14 +48,14 @@ void cci_init(uintptr_t cci_base,
 	/*
 	 * Check the passed arguments are valid. The cluster indices must be
 	 * less than MAX_CLUSTERS, not the same as each other and at least one
-	 * of them must be refer to a valid cluster index.
+	 * of them must refer to a valid cluster index.
 	 */
 	assert(cci_base);
 	assert(slave_iface3_cluster_ix < MAX_CLUSTERS);
 	assert(slave_iface4_cluster_ix < MAX_CLUSTERS);
 	assert(slave_iface3_cluster_ix != slave_iface4_cluster_ix);
 	assert((slave_iface3_cluster_ix >= 0) ||
-		(slave_iface3_cluster_ix >= 0));
+		(slave_iface4_cluster_ix >= 0));
 
 	WARN("Please migrate to common cci driver, This driver will be" \
 		" deprecated in future\n");


### PR DESCRIPTION
This patch fixes a copy and paste issue that resulted in the cluster
indexes not being checked as intended. Note that this fix applies to
the deprecated CCI-400 driver, not the unified one.
