### PR TITLE
Fix #include path in ARM platform BL1 setup code

### DIFF
--- a/plat/arm/common/arm_bl1_setup.c
+++ b/plat/arm/common/arm_bl1_setup.c
@@ -35,7 +35,7 @@
 #include <console.h>
 #include <platform_def.h>
 #include <plat_arm.h>
-#include "../../bl1/bl1_private.h"
+#include "../../../bl1/bl1_private.h"
 
 
 #if USE_COHERENT_MEM


### PR DESCRIPTION
This patch fixes the relative path to the 'bl1_private.h' header file
included from 'arm_bl1_setup.c'. Note that, although the path was
incorrect, it wasn't causing a compilation error because the header
file still got included through an alternative include search path.
