### PR TITLE
Make CASSERT() macro callable from anywhere

### DIFF
--- a/include/lib/cassert.h
+++ b/include/lib/cassert.h
@@ -34,9 +34,12 @@
 /*******************************************************************************
  * Macro to flag a compile time assertion. It uses the preprocessor to generate
  * an invalid C construct if 'cond' evaluates to false.
- * The following  compilation error is triggered if the assertion fails:
+ * The following compilation error is triggered if the assertion fails:
  * "error: size of array 'msg' is negative"
+ * The 'unused' attribute ensures that the unused typedef does not emit a
+ * compiler warning.
  ******************************************************************************/
-#define CASSERT(cond, msg)	typedef char msg[(cond) ? 1 : -1]
+#define CASSERT(cond, msg)	\
+	typedef char msg[(cond) ? 1 : -1] __attribute__((unused))
 
 #endif /* __CASSERT_H__ */


### PR DESCRIPTION
The CASSERT() macro introduces a typedef for the sole purpose of
triggering a compilation error if the condition to check is false.
This typedef is not used afterwards. As a consequence, when the
CASSERT() macro is called from withing a function block, the compiler
complains and outputs the following error message:

  error: typedef 'msg' locally defined but not used [-Werror=unused-local-typedefs]

This patch adds the "unused" attribute for the aforementioned
typedef. This silences the compiler warning and thus makes the
CASSERT() macro callable from within function blocks as well.
