### PR TITLE
Reorganise PSCI PM handler setup on ARM Standard platforms

### DIFF
--- a/include/plat/arm/css/common/css_def.h
+++ b/include/plat/arm/css/common/css_def.h
@@ -39,8 +39,6 @@
  *************************************************************************/
 #define MHU_PAYLOAD_CACHED		0
 
-#define TRUSTED_MAILBOX_BASE		ARM_TRUSTED_SRAM_BASE
-
 #define NSROM_BASE			0x1f000000
 #define NSROM_SIZE			0x00001000
 
@@ -115,5 +113,9 @@
 
 /* System timer related constants */
 #define PLAT_ARM_NSTIMER_FRAME_ID	1
+
+/* Trusted mailbox base address common to all CSS */
+#define PLAT_ARM_TRUSTED_MAILBOX_BASE	ARM_TRUSTED_SRAM_BASE
+
 
 #endif /* __CSS_DEF_H__ */

--- a/include/plat/arm/css/common/css_pm.h
+++ b/include/plat/arm/css/common/css_pm.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * Neither the name of ARM nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __CSS_PM_H__
+#define __CSS_PM_H__
+
+#include <cdefs.h>
+#include <psci.h>
+#include <types.h>
+
+int css_pwr_domain_on(u_register_t mpidr);
+void css_pwr_domain_on_finish(const psci_power_state_t *target_state);
+void css_pwr_domain_off(const psci_power_state_t *target_state);
+void css_pwr_domain_suspend(const psci_power_state_t *target_state);
+void css_pwr_domain_suspend_finish(
+				const psci_power_state_t *target_state);
+void __dead2 css_system_off(void);
+void __dead2 css_system_reset(void);
+void css_cpu_standby(plat_local_state_t cpu_state);
+
+#endif /* __CSS_PM_H__ */

--- a/plat/arm/board/fvp/aarch64/fvp_helpers.S
+++ b/plat/arm/board/fvp/aarch64/fvp_helpers.S
@@ -140,7 +140,7 @@ warm_reset:
 	 * it here with SO attributes.
 	 * ---------------------------------------------------------------------
 	 */
-	mov_imm	x0, MBOX_BASE
+	mov_imm	x0, PLAT_ARM_TRUSTED_MAILBOX_BASE
 	ldr	x0, [x0]
 	cbz	x0, _panic
 	ret

--- a/plat/arm/board/fvp/fvp_def.h
+++ b/plat/arm/board/fvp/fvp_def.h
@@ -134,12 +134,4 @@
 #define FVP_NSAID_HDLCD0		2
 #define FVP_NSAID_CLCD			7
 
-/*******************************************************************************
- *  Shared Data
- ******************************************************************************/
-
-/* Entrypoint mailboxes */
-#define MBOX_BASE			ARM_SHARED_RAM_BASE
-
-
 #endif /* __FVP_DEF_H__ */

--- a/plat/arm/board/fvp/include/platform_def.h
+++ b/plat/arm/board/fvp/include/platform_def.h
@@ -88,6 +88,10 @@
 /* System timer related constants */
 #define PLAT_ARM_NSTIMER_FRAME_ID		1
 
+/* Mailbox base address */
+#define PLAT_ARM_TRUSTED_MAILBOX_BASE	ARM_TRUSTED_SRAM_BASE
+
+
 /* TrustZone controller related constants
  *
  * Currently only filters 0 and 2 are connected on Base FVP.

--- a/plat/arm/css/common/aarch64/css_helpers.S
+++ b/plat/arm/css/common/aarch64/css_helpers.S
@@ -67,7 +67,7 @@ endfunc plat_secondary_cold_boot_setup
 	 * ---------------------------------------------------------------------
 	 */
 func plat_get_my_entrypoint
-	mov_imm	x0, TRUSTED_MAILBOX_BASE
+	mov_imm	x0, PLAT_ARM_TRUSTED_MAILBOX_BASE
 	ldr	x0, [x0]
 	ret
 endfunc plat_get_my_entrypoint


### PR DESCRIPTION
This patch does the following reorganization to psci power management (PM)
handler setup for ARM standard platform ports :

1. The mailbox programming required during `plat_setup_psci_ops()` is identical
   for all ARM platforms. Hence the implementation of this API is now moved
   to the common `arm_pm.c` file. Each ARM platform now must define the
   PLAT_ARM_TRUSTED_MAILBOX_BASE macro, which in current platforms is the same
   as ARM_SHARED_RAM_BASE.

2. The PSCI PM handler callback structure, `plat_psci_ops`, must now be
   exported via `plat_arm_psci_pm_ops`. This allows the common implementation
   of `plat_setup_psci_ops()` to return a platform specific `plat_psci_ops`.
   In the case of CSS platforms, a default weak implementation of the same is
   provided in `css_pm.c` which can be overridden by each CSS platform.

3. For CSS platforms, the PSCI PM handlers defined in `css_pm.c` are now
   made library functions and a new header file `css_pm.h` is added to export
   these generic PM handlers. This allows the platform to reuse the
   adequate CSS PM handlers and redefine others which need to be customized
   when overriding the default `plat_arm_psci_pm_ops` in `css_pm.c`.

Change-Id: I277910f609e023ee5d5ff0129a80ecfce4356ede