### PR TITLE
Allow CSS to redefine function `plat_arm_calc_core_pos`

### DIFF
--- a/plat/arm/board/juno/aarch64/juno_helpers.S
+++ b/plat/arm/board/juno/aarch64/juno_helpers.S
@@ -37,7 +37,7 @@
 
 
 	.globl	plat_reset_handler
-
+	.globl	plat_arm_calc_core_pos
 
 	/* --------------------------------------------------------------------
 	 * void plat_reset_handler(void);
@@ -117,3 +117,12 @@ ret:
 	isb
 	ret
 endfunc plat_reset_handler
+
+	/* -----------------------------------------------------
+	 *  unsigned int plat_arm_calc_core_pos(uint64_t mpidr)
+	 *  Helper function to calculate the core position.
+	 * -----------------------------------------------------
+	 */
+func plat_arm_calc_core_pos
+	b	css_calc_core_pos_swap_cluster
+endfunc plat_arm_calc_core_pos

--- a/plat/arm/css/common/aarch64/css_helpers.S
+++ b/plat/arm/css/common/aarch64/css_helpers.S
@@ -34,7 +34,7 @@
 
 	.weak	plat_secondary_cold_boot_setup
 	.weak	plat_get_my_entrypoint
-	.globl	plat_arm_calc_core_pos
+	.globl	css_calc_core_pos_swap_cluster
 	.weak	plat_is_my_cpu_primary
 
 	/* -----------------------------------------------------
@@ -73,20 +73,20 @@ func plat_get_my_entrypoint
 endfunc plat_get_my_entrypoint
 
 	/* -----------------------------------------------------------
-	 * unsigned int plat_arm_calc_core_pos(uint64_t mpidr)
-	 * Function to calculate the core position by
+	 * unsigned int css_calc_core_pos_swap_cluster(uint64_t mpidr)
+	 * Utility function to calculate the core position by
 	 * swapping the cluster order. This is necessary in order to
 	 * match the format of the boot information passed by the SCP
 	 * and read in plat_is_my_cpu_primary below.
 	 * -----------------------------------------------------------
 	 */
-func plat_arm_calc_core_pos
+func css_calc_core_pos_swap_cluster
 	and	x1, x0, #MPIDR_CPU_MASK
 	and	x0, x0, #MPIDR_CLUSTER_MASK
 	eor	x0, x0, #(1 << MPIDR_AFFINITY_BITS)  // swap cluster order
 	add	x0, x1, x0, LSR #6
 	ret
-endfunc plat_arm_calc_core_pos
+endfunc css_calc_core_pos_swap_cluster
 
 	/* -----------------------------------------------------
 	 * unsigned int plat_is_my_cpu_primary (void);


### PR DESCRIPTION
Currently all ARM CSS platforms that include css_helpers.S use the same
strong definition of `plat_arm_calc_core_pos`. This patch allows these CSS
platforms to define their own strong definition of this function.

* Replace the strong definition of `plat_arm_calc_core_pos` in
  css_helpers.S with a utility function `css_calc_core_pos_swap_cluster`
  does the same thing (swaps cluster IDs). ARM CSS platforms may choose
  to use this function or not.

* Add a Juno strong definition of `plat_arm_calc_core_pos`, which uses
  `css_calc_core_pos_swap_cluster`.