### PR TITLE
Include xlat_tables.h in plat_arm.h

### DIFF
--- a/include/plat/arm/common/plat_arm.h
+++ b/include/plat/arm/common/plat_arm.h
@@ -35,6 +35,7 @@
 #include <cassert.h>
 #include <cpu_data.h>
 #include <stdint.h>
+#include <xlat_tables.h>
 
 
 /*


### PR DESCRIPTION
This patch fixes a compilation issue for platforms that are aligned to ARM
Standard platforms and include the `plat_arm.h` header in their platform port.
The compilation would fail for such a platform because `xlat_tables.h` which
has the definition for `mmap_region_t` is not included in `plat_arm.h`. This
patch fixes this by including `xlat_tables.h` in `plat_arm.h` header.

Fixes ARM-Software/tf-issues#318

Change-Id: I75f990cfb4078b3996fc353c8cd37c9de61d555e