### PR TITLE
Add A72 support for Juno R2

### DIFF
--- a/plat/arm/board/juno/platform.mk
+++ b/plat/arm/board/juno/platform.mk
@@ -33,12 +33,14 @@ PLAT_INCLUDES		:=	-Iplat/arm/board/juno/include
 PLAT_BL_COMMON_SOURCES	:=	plat/arm/board/juno/aarch64/juno_helpers.S
 
 BL1_SOURCES		+=	lib/cpus/aarch64/cortex_a53.S		\
-				lib/cpus/aarch64/cortex_a57.S
+				lib/cpus/aarch64/cortex_a57.S		\
+				lib/cpus/aarch64/cortex_a72.S
 
 BL2_SOURCES		+=	plat/arm/board/juno/juno_security.c	\
 
 BL31_SOURCES		+=	lib/cpus/aarch64/cortex_a53.S		\
-				lib/cpus/aarch64/cortex_a57.S
+				lib/cpus/aarch64/cortex_a57.S		\
+				lib/cpus/aarch64/cortex_a72.S
 
 # Enable workarounds for selected Cortex-A57 erratas.
 ERRATA_A57_806969	:=	0


### PR DESCRIPTION
Cortex-A72 library support is now compiled into the Juno platform port to go
with the existing A53/A57 support. This enables a single set of Juno TF
binaries to run on Juno R0, R1 and R2 boards.

Change-Id: I4a601dc4f671e98bdb19d98bbb66f02f0d8b7fc7