### PR TITLE
Remove deprecated IO return definitions

### DIFF
--- a/common/bl_common.c
+++ b/common/bl_common.c
@@ -151,11 +151,11 @@ unsigned long image_size(unsigned int image_id)
 	uintptr_t image_handle;
 	uintptr_t image_spec;
 	size_t image_size = 0;
-	int io_result = IO_FAIL;
+	int io_result;
 
 	/* Obtain a reference to the image by querying the platform layer */
 	io_result = plat_get_image_source(image_id, &dev_handle, &image_spec);
-	if (io_result != IO_SUCCESS) {
+	if (io_result != 0) {
 		WARN("Failed to obtain reference to image id=%u (%i)\n",
 			image_id, io_result);
 		return 0;
@@ -163,7 +163,7 @@ unsigned long image_size(unsigned int image_id)
 
 	/* Attempt to access the image */
 	io_result = io_open(dev_handle, image_spec, &image_handle);
-	if (io_result != IO_SUCCESS) {
+	if (io_result != 0) {
 		WARN("Failed to access image id=%u (%i)\n",
 			image_id, io_result);
 		return 0;
@@ -171,7 +171,7 @@ unsigned long image_size(unsigned int image_id)
 
 	/* Find the size of the image */
 	io_result = io_size(image_handle, &image_size);
-	if ((io_result != IO_SUCCESS) || (image_size == 0)) {
+	if ((io_result != 0) || (image_size == 0)) {
 		WARN("Failed to determine the size of the image id=%u (%i)\n",
 			image_id, io_result);
 	}

--- a/drivers/io/io_fip.c
+++ b/drivers/io/io_fip.c
@@ -134,14 +134,14 @@ static int fip_dev_open(const uintptr_t dev_spec __attribute__((unused)),
 	assert(dev_info != NULL);
 	*dev_info = (io_dev_info_t *)&fip_dev_info; /* cast away const */
 
-	return IO_SUCCESS;
+	return 0;
 }
 
 
 /* Do some basic package checks. */
 static int fip_dev_init(io_dev_info_t *dev_info, const uintptr_t init_params)
 {
-	int result = IO_FAIL;
+	int result;
 	unsigned int image_id = (unsigned int)init_params;
 	uintptr_t backend_handle;
 	fip_toc_header_t header;
@@ -150,28 +150,28 @@ static int fip_dev_init(io_dev_info_t *dev_info, const uintptr_t init_params)
 	/* Obtain a reference to the image by querying the platform layer */
 	result = plat_get_image_source(image_id, &backend_dev_handle,
 				       &backend_image_spec);
-	if (result != IO_SUCCESS) {
+	if (result != 0) {
 		WARN("Failed to obtain reference to image id=%u (%i)\n",
 			image_id, result);
-		result = IO_FAIL;
+		result = -ENOENT;
 		goto fip_dev_init_exit;
 	}
 
 	/* Attempt to access the FIP image */
 	result = io_open(backend_dev_handle, backend_image_spec,
 			 &backend_handle);
-	if (result != IO_SUCCESS) {
+	if (result != 0) {
 		WARN("Failed to access image id=%u (%i)\n", image_id, result);
-		result = IO_FAIL;
+		result = -ENOENT;
 		goto fip_dev_init_exit;
 	}
 
 	result = io_read(backend_handle, (uintptr_t)&header, sizeof(header),
 			&bytes_read);
-	if (result == IO_SUCCESS) {
+	if (result == 0) {
 		if (!is_valid_header(&header)) {
 			WARN("Firmware Image Package header check failed.\n");
-			result = IO_FAIL;
+			result = -ENOENT;
 		} else {
 			VERBOSE("FIP header looks OK.\n");
 		}
@@ -192,7 +192,7 @@ static int fip_dev_close(io_dev_info_t *dev_info)
 	backend_dev_handle = (uintptr_t)NULL;
 	backend_image_spec = (uintptr_t)NULL;
 
-	return IO_SUCCESS;
+	return 0;
 }
 
 
@@ -200,7 +200,7 @@ static int fip_dev_close(io_dev_info_t *dev_info)
 static int fip_file_open(io_dev_info_t *dev_info, const uintptr_t spec,
 			 io_entity_t *entity)
 {
-	int result = IO_FAIL;
+	int result;
 	uintptr_t backend_handle;
 	const io_uuid_spec_t *uuid_spec = (io_uuid_spec_t *)spec;
 	size_t bytes_read;
@@ -217,23 +217,23 @@ static int fip_file_open(io_dev_info_t *dev_info, const uintptr_t spec,
 	 */
 	if (current_file.entry.offset_address != 0) {
 		WARN("fip_file_open : Only one open file at a time.\n");
-		return IO_RESOURCES_EXHAUSTED;
+		return -ENOMEM;
 	}
 
 	/* Attempt to access the FIP image */
 	result = io_open(backend_dev_handle, backend_image_spec,
 			 &backend_handle);
-	if (result != IO_SUCCESS) {
+	if (result != 0) {
 		WARN("Failed to open Firmware Image Package (%i)\n", result);
-		result = IO_FAIL;
+		result = -ENOENT;
 		goto fip_file_open_exit;
 	}
 
 	/* Seek past the FIP header into the Table of Contents */
 	result = io_seek(backend_handle, IO_SEEK_SET, sizeof(fip_toc_header_t));
-	if (result != IO_SUCCESS) {
+	if (result != 0) {
 		WARN("fip_file_open: failed to seek\n");
-		result = IO_FAIL;
+		result = -ENOENT;
 		goto fip_file_open_close;
 	}
 
@@ -243,7 +243,7 @@ static int fip_file_open(io_dev_info_t *dev_info, const uintptr_t spec,
 				 (uintptr_t)&current_file.entry,
 				 sizeof(current_file.entry),
 				 &bytes_read);
-		if (result == IO_SUCCESS) {
+		if (result == 0) {
 			if (compare_uuids(&current_file.entry.uuid,
 					  &uuid_spec->uuid) == 0) {
 				found_file = 1;
@@ -265,7 +265,7 @@ static int fip_file_open(io_dev_info_t *dev_info, const uintptr_t spec,
 	} else {
 		/* Did not find the file in the FIP. */
 		current_file.entry.offset_address = 0;
-		result = IO_FAIL;
+		result = -ENOENT;
 	}
 
  fip_file_open_close:
@@ -284,7 +284,7 @@ static int fip_file_len(io_entity_t *entity, size_t *length)
 
 	*length =  ((file_state_t *)entity->info)->entry.size;
 
-	return IO_SUCCESS;
+	return 0;
 }
 
 
@@ -292,7 +292,7 @@ static int fip_file_len(io_entity_t *entity, size_t *length)
 static int fip_file_read(io_entity_t *entity, uintptr_t buffer, size_t length,
 			  size_t *length_read)
 {
-	int result = IO_FAIL;
+	int result;
 	file_state_t *fp;
 	size_t file_offset;
 	size_t bytes_read;
@@ -306,9 +306,9 @@ static int fip_file_read(io_entity_t *entity, uintptr_t buffer, size_t length,
 	/* Open the backend, attempt to access the blob image */
 	result = io_open(backend_dev_handle, backend_image_spec,
 			 &backend_handle);
-	if (result != IO_SUCCESS) {
+	if (result != 0) {
 		WARN("Failed to open FIP (%i)\n", result);
-		result = IO_FAIL;
+		result = -ENOENT;
 		goto fip_file_read_exit;
 	}
 
@@ -317,17 +317,17 @@ static int fip_file_read(io_entity_t *entity, uintptr_t buffer, size_t length,
 	/* Seek to the position in the FIP where the payload lives */
 	file_offset = fp->entry.offset_address + fp->file_pos;
 	result = io_seek(backend_handle, IO_SEEK_SET, file_offset);
-	if (result != IO_SUCCESS) {
+	if (result != 0) {
 		WARN("fip_file_read: failed to seek\n");
-		result = IO_FAIL;
+		result = -ENOENT;
 		goto fip_file_read_close;
 	}
 
 	result = io_read(backend_handle, buffer, length, &bytes_read);
-	if (result != IO_SUCCESS) {
+	if (result != 0) {
 		/* We cannot read our data. Fail. */
 		WARN("Failed to read payload (%i)\n", result);
-		result = IO_FAIL;
+		result = -ENOENT;
 		goto fip_file_read_close;
 	} else {
 		/* Set caller length and new file position. */
@@ -357,7 +357,7 @@ static int fip_file_close(io_entity_t *entity)
 	/* Clear the Entity info. */
 	entity->info = 0;
 
-	return IO_SUCCESS;
+	return 0;
 }
 
 /* Exported functions */
@@ -365,11 +365,11 @@ static int fip_file_close(io_entity_t *entity)
 /* Register the Firmware Image Package driver with the IO abstraction */
 int register_io_dev_fip(const io_dev_connector_t **dev_con)
 {
-	int result = IO_FAIL;
+	int result;
 	assert(dev_con != NULL);
 
 	result = io_register_device(&fip_dev_info);
-	if (result == IO_SUCCESS)
+	if (result == 0)
 		*dev_con = &fip_dev_connector;
 
 	return result;

--- a/include/drivers/io/io_storage.h
+++ b/include/drivers/io/io_storage.h
@@ -89,15 +89,6 @@ typedef struct io_block_spec {
 #define IO_MODE_RW	(1 << 1)
 
 
-/* Return codes reported by 'io_*' APIs.
- * IMPORTANT: these definitions are deprecated. Callers should use standard
- * errno definitions when checking the return value of io_* APIs. */
-#define IO_SUCCESS		(0)
-#define IO_FAIL			(-ENOENT)
-#define IO_NOT_SUPPORTED	(-ENODEV)
-#define IO_RESOURCES_EXHAUSTED	(-ENOMEM)
-
-
 /* Open a connection to a device */
 int io_dev_open(const struct io_dev_connector *dev_con,
 		const uintptr_t dev_spec,

--- a/plat/arm/board/fvp/fvp_io_storage.c
+++ b/plat/arm/board/fvp/fvp_io_storage.c
@@ -114,14 +114,14 @@ static const io_file_spec_t sh_file_spec[] = {
 
 static int open_semihosting(const uintptr_t spec)
 {
-	int result = IO_FAIL;
+	int result;
 	uintptr_t local_image_handle;
 
 	/* See if the file exists on semi-hosting.*/
 	result = io_dev_init(sh_dev_handle, (uintptr_t)NULL);
-	if (result == IO_SUCCESS) {
+	if (result == 0) {
 		result = io_open(sh_dev_handle, spec, &local_image_handle);
-		if (result == IO_SUCCESS) {
+		if (result == 0) {
 			VERBOSE("Using Semi-hosting IO\n");
 			io_close(local_image_handle);
 		}
@@ -137,11 +137,11 @@ void plat_arm_io_setup(void)
 
 	/* Register the additional IO devices on this platform */
 	io_result = register_io_dev_sh(&sh_dev_con);
-	assert(io_result == IO_SUCCESS);
+	assert(io_result == 0);
 
 	/* Open connections to devices and cache the handles */
 	io_result = io_dev_open(sh_dev_con, (uintptr_t)NULL, &sh_dev_handle);
-	assert(io_result == IO_SUCCESS);
+	assert(io_result == 0);
 
 	/* Ignore improbable errors in release builds */
 	(void)io_result;
@@ -154,7 +154,7 @@ int plat_arm_get_alt_image_source(unsigned int image_id, uintptr_t *dev_handle,
 				  uintptr_t *image_spec)
 {
 	int result = open_semihosting((const uintptr_t)&sh_file_spec[image_id]);
-	if (result == IO_SUCCESS) {
+	if (result == 0) {
 		*dev_handle = sh_dev_handle;
 		*image_spec = (uintptr_t)&sh_file_spec[image_id];
 	}

--- a/plat/arm/common/arm_io_storage.c
+++ b/plat/arm/common/arm_io_storage.c
@@ -220,9 +220,9 @@ static int open_fip(const uintptr_t spec)
 
 	/* See if a Firmware Image Package is available */
 	result = io_dev_init(fip_dev_handle, (uintptr_t)FIP_IMAGE_ID);
-	if (result == IO_SUCCESS) {
+	if (result == 0) {
 		result = io_open(fip_dev_handle, spec, &local_image_handle);
-		if (result == IO_SUCCESS) {
+		if (result == 0) {
 			VERBOSE("Using FIP\n");
 			io_close(local_image_handle);
 		}
@@ -237,9 +237,9 @@ static int open_memmap(const uintptr_t spec)
 	uintptr_t local_image_handle;
 
 	result = io_dev_init(memmap_dev_handle, (uintptr_t)NULL);
-	if (result == IO_SUCCESS) {
+	if (result == 0) {
 		result = io_open(memmap_dev_handle, spec, &local_image_handle);
-		if (result == IO_SUCCESS) {
+		if (result == 0) {
 			VERBOSE("Using Memmap\n");
 			io_close(local_image_handle);
 		}
@@ -253,19 +253,19 @@ void arm_io_setup(void)
 	int io_result;
 
 	io_result = register_io_dev_fip(&fip_dev_con);
-	assert(io_result == IO_SUCCESS);
+	assert(io_result == 0);
 
 	io_result = register_io_dev_memmap(&memmap_dev_con);
-	assert(io_result == IO_SUCCESS);
+	assert(io_result == 0);
 
 	/* Open connections to devices and cache the handles */
 	io_result = io_dev_open(fip_dev_con, (uintptr_t)NULL,
 				&fip_dev_handle);
-	assert(io_result == IO_SUCCESS);
+	assert(io_result == 0);
 
 	io_result = io_dev_open(memmap_dev_con, (uintptr_t)NULL,
 				&memmap_dev_handle);
-	assert(io_result == IO_SUCCESS);
+	assert(io_result == 0);
 
 	/* Ignore improbable errors in release builds */
 	(void)io_result;
@@ -282,7 +282,7 @@ int plat_arm_get_alt_image_source(
 	uintptr_t *image_spec __attribute__((unused)))
 {
 	/* By default do not try an alternative */
-	return IO_FAIL;
+	return -ENOENT;
 }
 
 /* Return an IO device handle and specification which can be used to access
@@ -290,14 +290,14 @@ int plat_arm_get_alt_image_source(
 int plat_get_image_source(unsigned int image_id, uintptr_t *dev_handle,
 			  uintptr_t *image_spec)
 {
-	int result = IO_FAIL;
+	int result;
 	const struct plat_io_policy *policy;
 
 	assert(image_id < ARRAY_SIZE(policies));
 
 	policy = &policies[image_id];
 	result = policy->check(policy->image_spec);
-	if (result == IO_SUCCESS) {
+	if (result == 0) {
 		*image_spec = policy->image_spec;
 		*dev_handle = *(policy->dev_handle);
 	} else {


### PR DESCRIPTION
Patch 7e26fe1f deprecates IO specific return definitions in favour
of standard errno codes. This patch removes those definitions
and its usage from the IO framework, IO drivers and IO platform
layer. Following this patch, standard errno codes must be used
when checking the return value of an IO function.

Change-Id: Id6e0e9d0a7daf15a81ec598cf74de83d5768650f