### PR TITLE
IMF: postpone SCR_EL3 update if context is not initialized

### DIFF
--- a/bl31/interrupt_mgmt.c
+++ b/bl31/interrupt_mgmt.c
@@ -129,7 +129,12 @@ static void set_scr_el3_from_rm(uint32_t type,
 	flag = get_interrupt_rm_flag(interrupt_type_flags, security_state);
 	bit_pos = plat_interrupt_type_to_line(type, security_state);
 	intr_type_descs[type].scr_el3[security_state] = flag << bit_pos;
-	cm_write_scr_el3_bit(security_state, bit_pos, flag);
+
+	/* Update scr_el3 only if there is a context available. If not, it
+	 * will be updated later during context initialization which will obtain
+	 * the scr_el3 value to be used via get_scr_el3_from_routing_model() */
+	if (cm_get_context(security_state))
+		cm_write_scr_el3_bit(security_state, bit_pos, flag);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
The set_routing_model() function in the Interrupt Management
Framework calls the context management library to update the
SCR_EL3 register. This context management library assumes that
the context has been previously initialized. Consequently, if
a Secure Payload Dispatcher (SPD) tries to set the routing model
before initializing the context, the system will fail (in debug
mode, an assertion will be raised).

This patch fixes the issue by checking if the context has been
initialized before updating SCR_EL3. If a valid context is not
available, SCR_EL3 update will be done when the SPD calls the
context initialization function. This function will call
get_scr_el3_from_routing_model() to obtain the SCR_EL3 value.
If the SPD does not call the context initialization function
then it is SPD's responsibility to obtain SCR_EL3 from the IMF
and update the context accordingly.

Fixes ARM-software/tf-issues#327

Change-Id: Ic2f1c6e899e578a8db858ec43747c63a8539c16f