### PR TITLE
Re-introduce evaluation of ENABLE_PLAT_COMPAT build flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,6 +262,16 @@ endif
 
 include ${PLAT_MAKEFILE_FULL}
 
+# If the platform has not defined ENABLE_PLAT_COMPAT, then enable it by default
+ifndef ENABLE_PLAT_COMPAT
+ENABLE_PLAT_COMPAT := 1
+endif
+
+# Include the platform compatibility helpers for PSCI
+ifneq (${ENABLE_PLAT_COMPAT}, 0)
+include plat/compat/plat_compat.mk
+endif
+
 # Include the CPU specific operations makefile. By default all CPU errata
 # workarounds and CPU specifc optimisations are disabled. This can be
 # overridden by the platform.
@@ -331,6 +341,7 @@ $(eval $(call assert_boolean,TRUSTED_BOARD_BOOT))
 $(eval $(call assert_boolean,PROGRAMMABLE_RESET_ADDRESS))
 $(eval $(call assert_boolean,PSCI_EXTENDED_STATE_ID))
 $(eval $(call assert_boolean,WARN_DEPRECATED))
+$(eval $(call assert_boolean,ENABLE_PLAT_COMPAT))
 
 
 ################################################################################
@@ -352,6 +363,7 @@ $(eval $(call add_define,TRUSTED_BOARD_BOOT))
 $(eval $(call add_define,PROGRAMMABLE_RESET_ADDRESS))
 $(eval $(call add_define,PSCI_EXTENDED_STATE_ID))
 $(eval $(call add_define,WARN_DEPRECATED))
+$(eval $(call add_define,ENABLE_PLAT_COMPAT))
 
 
 ################################################################################


### PR DESCRIPTION
Commit #73c99d4eb377e0e25f7951be53087bf92e7b4b18 had refactored the top level
Makefile. This commit also broke platform ports that still rely on an enabled
ENABLE_PLAT_COMPAT build option since the evaluation of this option was also
accidentally removed from the Makefile.

This patch fixes this break by re-introducing the necessary support to ensure
that this build option is enabled by default if a platform port does not disable
it explicitly.

Fixes ARM-software/tf-issues#332

Change-Id: I2217595d2e0bccae7de98cc6c0ea448b5bf3dae2