### PR TITLE
Add -mstrict-align to the gcc options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,8 @@ ASFLAGS			+= 	-nostdinc -ffreestanding -Wa,--fatal-warnings	\
 				${DEFINES} ${INCLUDES}
 CFLAGS			+= 	-nostdinc -ffreestanding -Wall			\
 				-Werror -Wmissing-include-dirs			\
-				-mgeneral-regs-only -std=c99 -c -Os		\
+				-mgeneral-regs-only -mstrict-align		\
+				-std=c99 -c -Os					\
 				${DEFINES} ${INCLUDES}
 CFLAGS			+=	-ffunction-sections -fdata-sections
 


### PR DESCRIPTION
ARMv8 architecture allows unaligned memory accesses. However,
Trusted Firmware disables such feature by setting the SCTLR_A_BIT
and SCTLR_SA_BIT in the SCTLR_EL3 register (it enables alignment
checks).

This patch adds -mstrict-align to the gcc build options. Although
there are not explicit unaligned memory accesses in Trusted Firmware,
this flag will tell the compiler not to use them.

Fixes ARM-software/tf-issues#294

Change-Id: I69748c6cf28504be9ca3dc975a331d14459c9ef1