### PR TITLE
Tegra: introduce per-soc system reset handler

### DIFF
--- a/plat/nvidia/tegra/common/tegra_pm.c
+++ b/plat/nvidia/tegra/common/tegra_pm.c
@@ -55,6 +55,7 @@ static int system_suspended;
 #pragma weak tegra_soc_prepare_cpu_on
 #pragma weak tegra_soc_prepare_cpu_off
 #pragma weak tegra_soc_prepare_cpu_on_finish
+#pragma weak tegra_soc_prepare_system_reset
 
 int tegra_soc_prepare_cpu_suspend(unsigned int id, unsigned int afflvl)
 {
@@ -72,6 +73,11 @@ int tegra_soc_prepare_cpu_off(unsigned long mpidr)
 }
 
 int tegra_soc_prepare_cpu_on_finish(unsigned long mpidr)
+{
+	return PSCI_E_SUCCESS;
+}
+
+int tegra_soc_prepare_system_reset(void)
 {
 	return PSCI_E_SUCCESS;
 }
@@ -298,6 +304,9 @@ __dead2 void tegra_system_off(void)
  ******************************************************************************/
 __dead2 void tegra_system_reset(void)
 {
+	/* per-SoC system reset handler */
+	tegra_soc_prepare_system_reset();
+
 	/*
 	 * Program the PMC in order to restart the system.
 	 */

--- a/plat/nvidia/tegra/soc/t132/plat_psci_handlers.c
+++ b/plat/nvidia/tegra/soc/t132/plat_psci_handlers.c
@@ -33,6 +33,7 @@
 #include <assert.h>
 #include <denver.h>
 #include <debug.h>
+#include <delay_timer.h>
 #include <flowctrl.h>
 #include <mmio.h>
 #include <platform_def.h>
@@ -47,6 +48,11 @@
  */
 #define CPU_CMPLX_RESET_CLR		0x344
 #define CPU_CORE_RESET_MASK		0x10001
+
+/* Clock and Reset controller registers for system clock's settings */
+#define SCLK_RATE			0x30
+#define SCLK_BURST_POLICY		0x28
+#define SCLK_BURST_POLICY_DEFAULT	0x10000000
 
 static int cpu_powergate_mask[PLATFORM_MAX_CPUS_PER_CLUSTER];
 
@@ -118,6 +124,22 @@ int tegra_soc_prepare_cpu_suspend(unsigned int id, unsigned int afflvl)
 
 	/* Suspend DCO operations */
 	write_actlr_el1(id);
+
+	return PSCI_E_SUCCESS;
+}
+
+int tegra_soc_prepare_system_reset(void)
+{
+	/*
+	 * Set System Clock (SCLK) to POR default so that the clock source
+	 * for the PMC APB clock would not be changed due to system reset.
+	 */
+	mmio_write_32((uintptr_t)TEGRA_CAR_RESET_BASE + SCLK_BURST_POLICY,
+		       SCLK_BURST_POLICY_DEFAULT);
+	mmio_write_32((uintptr_t)TEGRA_CAR_RESET_BASE + SCLK_RATE, 0);
+
+	/* Wait 1 ms to make sure clock source/device logic is stabilized. */
+	mdelay(1);
 
 	return PSCI_E_SUCCESS;
 }


### PR DESCRIPTION
This patch adds a per-soc system reset handler for Tegra chips. The
handler gets executed before the actual system resets. This allows
for custom handling of the system reset sequence on each SoC.

Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>