### PR TITLE
Fix build error when `BL32` is not defined

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,10 +240,15 @@ ifneq (${SPD},none)
         $(info Including ${SPD_MAKE})
         include ${SPD_MAKE}
 
-        # If there's BL3-2 companion for the chosen SPD, and the SPD wants to build the
-        # BL3-2 from source, we expect that the SPD's Makefile would set NEED_BL32
-        # variable to "yes". In case the BL3-2 is a binary which needs to be included in
-        # fip, then the NEED_BL32 needs to be set and BL3-2 would need to point to the bin.
+        # If there's BL32 companion for the chosen SPD, we expect that the SPD's
+        # Makefile would set NEED_BL32 to "yes". In this case, the build system
+        # supports two mutually exclusive options:
+        # * BL32 is built from source: then BL32_SOURCES must contain the list
+        #   of source files to build BL32
+        # * BL32 is a prebuilt binary: then BL32 must point to the image file
+        #   that will be included in the FIP
+        # If both BL32_SOURCES and BL32 are defined, the binary takes precedence
+        # over the sources.
 endif
 
 
@@ -414,9 +419,13 @@ $(if ${BL31}, $(eval $(call MAKE_TOOL_ARGS,31,${BL31},in_fip)),\
 	$(eval $(call MAKE_BL,31,in_fip)))
 endif
 
+# If a BL32 image is needed but neither BL32 nor BL32_SOURCES is defined, the
+# build system will call FIP_ADD_IMG to print a warning message and abort the
+# process. Note that the dependency on BL32 applies to the FIP only.
 ifeq (${NEED_BL32},yes)
 $(if ${BL32}, $(eval $(call MAKE_TOOL_ARGS,32,${BL32},in_fip)),\
-	$(eval $(call MAKE_BL,32,in_fip)))
+	$(if ${BL32_SOURCES}, $(eval $(call MAKE_BL,32,in_fip)),\
+		$(eval $(call FIP_ADD_IMG,BL32,--bl32))))
 endif
 
 # Add the BL33 image if required by the platform

--- a/make_helpers/tbbr/tbbr_tools.mk
+++ b/make_helpers/tbbr/tbbr_tools.mk
@@ -97,7 +97,7 @@ $(eval $(call FIP_ADD_PAYLOAD,${BUILD_PLAT}/bl31_key.crt,--bl31-key-cert))
 # Add the BL32 CoT (key cert + img cert + image)
 ifeq (${NEED_BL32},yes)
     $(if ${BL32},$(eval $(call CERT_ADD_CMD_OPT,${BL32},--bl32,true)),\
-                 $(eval $(call CERT_ADD_CMD_OPT,$(call IMG_BIN,32),--bl32,true)))
+                 $(if ${BL32_SOURCES},$(eval $(call CERT_ADD_CMD_OPT,$(call IMG_BIN,32),--bl32,true))))
     $(if ${BL32_KEY},$(eval $(call CERT_ADD_CMD_OPT,${BL32_KEY},--bl32-key)))
     $(eval $(call CERT_ADD_CMD_OPT,${BUILD_PLAT}/bl32.crt,--bl32-cert))
     $(eval $(call CERT_ADD_CMD_OPT,${BUILD_PLAT}/bl32_key.crt,--bl32-key-cert))


### PR DESCRIPTION
If an SPD wants to use a prebuilt binary as BL32 image (for example,
the OPTEE Dispatcher), it must point the `BL32` variable to the
image file. This dependency should apply only to the `fip` target.
However, it also applies to the `all` target at the moment. If the
user tries to build all individual TF images using `make all`
without setting BL32, the build fails. The following command will
throw the error:

    make CROSS_COMPILE=aarch64-linux-gnu- SPD=opteed all
    ...
    ...
    aarch64-linux-gnu-gcc: fatal error: no input files
    compilation terminated.
    make: *** [build/fvp/release/bl32/bl32.ld] Error 1

The reason is that the build system checks if BL32 is defined, and
if it is not, it will try to build BL32 from source. If the SPD
makefile does not provide support for that (as is the case of the
OPTEE Dispatcher, since OPTEE is provided as an external binary),
the build will fail.

This patch fixes the issue by checking if `BL32_SOURCES` has been
defined by the SPD before attempting to build BL32 from source.
If neither `BL32` nor `BL32_SOURCES` is defined when building the
FIP, a warning message will be printed and the process aborted.

Fixes ARM-software/tf-issues#333

Change-Id: I5e801ad333103ed9b042e5c4757424c8df2ff6e4