### PR TITLE
mmu: Add non-cacheable memory attribute to mmu memory type

### DIFF
--- a/include/lib/aarch64/arch.h
+++ b/include/lib/aarch64/arch.h
@@ -419,10 +419,12 @@
 #define AP_RW			(0x0 << 5)
 
 #define NS				(0x1 << 3)
+#define ATTR_MEMORY_NC_INDEX		0x3
 #define ATTR_SO_INDEX			0x2
 #define ATTR_DEVICE_INDEX		0x1
 #define ATTR_IWBWA_OWBWA_NTR_INDEX	0x0
 #define LOWER_ATTRS(x)			(((x) & 0xfff) << 2)
+#define ATTR_MEMORY_NC			(0x44)
 #define ATTR_SO				(0x0)
 #define ATTR_DEVICE			(0x4)
 #define ATTR_IWBWA_OWBWA_NTR		(0xff)

--- a/include/lib/aarch64/xlat_tables.h
+++ b/include/lib/aarch64/xlat_tables.h
@@ -53,8 +53,8 @@
 
 /*
  * Flags for building up memory mapping attributes.
- * These are organised so that a clear bit gives a more restrictive  mapping
- * that a set bit, that way a bitwise-and two sets of attributes will never give
+ * These are organised so that a clear bit gives a more restrictive mapping
+ * than a set bit, that way a bitwise-and two sets of attributes will never give
  * an attribute which has greater access rights that any of the original
  * attributes.
  */
@@ -66,7 +66,9 @@ typedef enum  {
 	MT_RW		= 1 << 1,
 
 	MT_SECURE	= 0 << 2,
-	MT_NS		= 1 << 2
+	MT_NS		= 1 << 2,
+
+	MT_MEMORY_NC	= 1 << 3
 } mmap_attr_t;
 
 /*

--- a/lib/aarch64/xlat_tables.c
+++ b/lib/aarch64/xlat_tables.c
@@ -147,6 +147,8 @@ static unsigned long mmap_desc(unsigned attr, unsigned long addr_pa,
 		desc |= LOWER_ATTRS(ATTR_IWBWA_OWBWA_NTR_INDEX | ISH);
 		if (attr & MT_RW)
 			desc |= UPPER_ATTRS(XN);
+		if (attr & MT_MEMORY_NC)
+			desc |= LOWER_ATTRS(ATTR_MEMORY_NC_INDEX | OSH);
 	} else {
 		desc |= LOWER_ATTRS(ATTR_DEVICE_INDEX | OSH);
 		desc |= UPPER_ATTRS(XN);
@@ -305,6 +307,8 @@ void init_xlat_tables(void)
 		mair = MAIR_ATTR_SET(ATTR_DEVICE, ATTR_DEVICE_INDEX);	\
 		mair |= MAIR_ATTR_SET(ATTR_IWBWA_OWBWA_NTR,		\
 				ATTR_IWBWA_OWBWA_NTR_INDEX);		\
+		mair |= MAIR_ATTR_SET(ATTR_MEMORY_NC,			\
+				ATTR_MEMORY_NC_INDEX);			\
 		write_mair_el##_el(mair);				\
 									\
 		/* Invalidate TLBs at the current exception level */	\


### PR DESCRIPTION
This patch adds non-cacheable memory attribute to mmu memory type.
For a non-cacheable memory region, such as DMA buffer, we can now
setup the mmu entry with proper attribute.

TEST=setup mmu with a non-cacheable memory region, confirmed the
     attribute of the corresponding mmu entry and MAIR_EL3 register
     are correctly set.

Change-Id: I4639cfb92f4c822d97566a663cef5ec39e36f855
Signed-off-by: Jimmy Huang <jimmy.huang@mediatek.com>