### PR TITLE
Replace build macro WARN_DEPRECATED with ERROR_DEPRECATED

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,8 @@ TRUSTED_BOARD_BOOT		:= 0
 # By default, consider that the platform's reset address is not programmable.
 # The platform Makefile is free to override this value.
 PROGRAMMABLE_RESET_ADDRESS	:= 0
-# Build flag to warn about usage of deprecated platform and framework APIs
-WARN_DEPRECATED			:= 0
+# Build flag to treat usage of deprecated platform and framework APIs as error.
+ERROR_DEPRECATED		:= 0
 
 
 ################################################################################
@@ -346,7 +346,7 @@ $(eval $(call assert_boolean,SAVE_KEYS))
 $(eval $(call assert_boolean,TRUSTED_BOARD_BOOT))
 $(eval $(call assert_boolean,PROGRAMMABLE_RESET_ADDRESS))
 $(eval $(call assert_boolean,PSCI_EXTENDED_STATE_ID))
-$(eval $(call assert_boolean,WARN_DEPRECATED))
+$(eval $(call assert_boolean,ERROR_DEPRECATED))
 $(eval $(call assert_boolean,ENABLE_PLAT_COMPAT))
 
 
@@ -368,7 +368,7 @@ $(eval $(call add_define,USE_COHERENT_MEM))
 $(eval $(call add_define,TRUSTED_BOARD_BOOT))
 $(eval $(call add_define,PROGRAMMABLE_RESET_ADDRESS))
 $(eval $(call add_define,PSCI_EXTENDED_STATE_ID))
-$(eval $(call add_define,WARN_DEPRECATED))
+$(eval $(call add_define,ERROR_DEPRECATED))
 $(eval $(call add_define,ENABLE_PLAT_COMPAT))
 
 
@@ -403,6 +403,11 @@ all: msg_start
 
 msg_start:
 	@echo "Building ${PLAT}"
+
+# Check if deprecated declarations should be treated as error or not.
+ifeq (${ERROR_DEPRECATED},0)
+    CFLAGS		+= 	-Wno-error=deprecated-declarations
+endif
 
 # Expand build macros for the different images
 ifeq (${NEED_BL1},yes)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -367,10 +367,10 @@ performed.
     and it governs the return value of PSCI_FEATURES API for CPU_SUSPEND
     smc function id.
 
-*   `WARN_DEPRECATED`: This option decides whether to warn the usage of
-    deprecated platform APIs and context management helpers within Trusted
-    Firmware. It can take the value 1 (warn the use of deprecated APIs) or
-    0. The default is 0.
+*   `ERROR_DEPRECATED`: This option decides whether to treat the usage of
+    deprecated platform APIs, helper functions or drivers within Trusted
+    Firmware as error. It can take the value 1 (flag the use of deprecated
+    APIs as error) or 0. The default is 0.
 
 #### ARM development platform specific build options
 

--- a/include/common/asm_macros.S
+++ b/include/common/asm_macros.S
@@ -101,10 +101,10 @@
 
 	/*
 	 * Theses macros are used to create function labels for deprecated
-	 * APIs. If WARN_DEPRECATED is non zero, the callers of these APIs
+	 * APIs. If ERROR_DEPRECATED is non zero, the callers of these APIs
 	 * will fail to link and cause build failure.
 	 */
-#if WARN_DEPRECATED
+#if ERROR_DEPRECATED
 	.macro func_deprecated _name
 	func deprecated\_name
 	.endm

--- a/include/plat/common/common_def.h
+++ b/include/plat/common/common_def.h
@@ -69,15 +69,10 @@
 
 /*
  * Macros to wrap declarations of deprecated APIs within Trusted Firmware.
- * The callers of these APIs will continue to compile as long as the build
- * flag WARN_DEPRECATED is zero. Else the compiler will emit a warning
- * when the callers of these APIs are compiled.
+ * The callers of these APIs will continue to compile with a warning as long
+ * as the build flag ERROR_DEPRECATED is zero.
  */
-#if WARN_DEPRECATED
 #define __warn_deprecated	__attribute__ ((deprecated))
-#else
-#define __warn_deprecated
-#endif
 
 #endif /* __COMMON_DEF_H__ */
 


### PR DESCRIPTION
This patch changes the build time behaviour when using deprecated API within
Trusted Firmware. Previously the use of deprecated APIs would only trigger a
build warning (which was always treated as a build error), when
WARN_DEPRECATED = 1. Now, the use of deprecated C declarations will always
trigger a build time warning. Whether this warning is treated as error or not
is determined by the build flag ERROR_DEPRECATED which is disabled by default.
When the build flag ERROR_DEPRECATED=1, the invocation of deprecated API or
inclusion of deprecated headers will result in a build error.

Also the deprecated context management helpers in context_mgmt.c are now
conditionally compiled depending on the value of ERROR_DEPRECATED flag
so that the APIs themselves do not result in a build error when the
ERROR_DEPRECATED flag is set.

NOTE: Build systems that use the macro WARN_DEPRECATED must migrate to
using ERROR_DEPRECATED, otherwise deprecated API usage will no longer
trigger a build error.

Change-Id: I843bceef6bde979af7e9b51dddf861035ec7965a