### PR TITLE
Add NULL pointer check before reading BL32 entry point information

### DIFF
--- a/plat/arm/common/arm_bl31_setup.c
+++ b/plat/arm/common/arm_bl31_setup.c
@@ -124,7 +124,8 @@ void arm_bl31_early_platform_setup(bl31_params_t *from_bl2,
 	assert(from_bl2 == NULL);
 	assert(plat_params_from_bl2 == NULL);
 
-	/* Populate entry point information for BL3-2 and BL3-3 */
+#ifdef BL32_BASE
+	/* Populate entry point information for BL3-2 */
 	SET_PARAM_HEAD(&bl32_image_ep_info,
 				PARAM_EP,
 				VERSION_1,
@@ -132,7 +133,9 @@ void arm_bl31_early_platform_setup(bl31_params_t *from_bl2,
 	SET_SECURITY_STATE(bl32_image_ep_info.h.attr, SECURE);
 	bl32_image_ep_info.pc = BL32_BASE;
 	bl32_image_ep_info.spsr = arm_get_spsr_for_bl32_entry();
+#endif /* BL32_BASE */
 
+	/* Populate entry point information for BL3-3 */
 	SET_PARAM_HEAD(&bl33_image_ep_info,
 				PARAM_EP,
 				VERSION_1,
@@ -161,10 +164,11 @@ void arm_bl31_early_platform_setup(bl31_params_t *from_bl2,
 		ARM_BL31_PLAT_PARAM_VAL);
 
 	/*
-	 * Copy BL3-2 and BL3-3 entry point information.
+	 * Copy BL3-2 (if populated by BL2) and BL3-3 entry point information.
 	 * They are stored in Secure RAM, in BL2's address space.
 	 */
-	bl32_image_ep_info = *from_bl2->bl32_ep_info;
+	if (from_bl2->bl32_ep_info)
+		bl32_image_ep_info = *from_bl2->bl32_ep_info;
 	bl33_image_ep_info = *from_bl2->bl33_ep_info;
 #endif
 }


### PR DESCRIPTION
BL2 is responsible for loading BL32 and passing a pointer to the
BL32 entrypoint info to BL31 in the BL31 parameters. If no BL32
image is loaded, a NULL pointer is passed. The platform is
responsible for accessing BL31 parameters and extracting the
corresponding BL32 EP info.

In ARM platforms, arm_bl31_early_platform_setup() dereferences the
pointer to the BL32 EP info without checking first if the pointer
is NULL. This will cause an exception if a BL32 entrypoint has not
been populated by BL2. FVP and Juno are not affected because they
always define BL32_BASE, irrespective of whether a BL32 image is
included in the FIP or not.

This patches fixes the issue by checking the BL32 ep_info pointer
before trying to access the data.

If `RESET_TO_BL31` is enabled, the BL32 entrypoint is not
populated if BL32_BASE is not defined.

NOTE: Maintainers of partner platforms should check for this issue
in their ports.

Fixes ARM-software/tf-issues#320

Change-Id: I31456155503f2765766e8b7cd30ab4a40958fb96