### PR TITLE
Fix TZC-400 peripheral detection

### DIFF
--- a/include/drivers/arm/tzc400.h
+++ b/include/drivers/arm/tzc400.h
@@ -147,7 +147,9 @@
 #define TZC_REGION_ACCESS_RDWR(id)					\
 		(TZC_REGION_ACCESS_RD(id) | TZC_REGION_ACCESS_WR(id))
 
-#define TZC400_COMPONENT_ID	0xb105f00d
+/* Consist of part_number_1 and part_number_0 */
+#define TZC400_PERIPHERAL_ID	0x0460
+
 
 
 #ifndef __ASSEMBLY__


### PR DESCRIPTION
The TZC-400 driver implementation incorrectly uses the component
ID registers to detect the TZC-400 peripheral. As all ARM
peripherals share the same component ID, it doesn't allow to
uniquely identify the TZC-400 peripheral. This patch fixes the
TZC-400 driver by relying on the `part_number_0` and
`part_number_1` fields in the `PID` registers instead.
The `tzc_read_component_id` function has been replaced by
`tzc_read_peripheral_id`, which reads the 'part_number' values
and compares them with the TZC-400 peripheral ID.

Also, it adds a debug assertion to detect when the TZC driver
initialisation function is called multiple times.

Change-Id: I35949f6501a51c0a794144cd1c3a6db62440dce6