### PR TITLE
Add CCI-400 specific driver to deprecated driver list

### DIFF
--- a/include/drivers/arm/cci400.h
+++ b/include/drivers/arm/cci400.h
@@ -31,6 +31,14 @@
 #ifndef __CCI_400_H__
 #define __CCI_400_H__
 
+/**************************************************************
+ * THIS DRIVER IS DEPRECATED. Please use the driver in cci.h
+ **************************************************************/
+#if ERROR_DEPRECATED
+#error " The CCI-400 specific driver is deprecated."
+#endif
+
+
 /* Slave interface offsets from PERIPHBASE */
 #define SLAVE_IFACE4_OFFSET		0x5000
 #define SLAVE_IFACE3_OFFSET		0x4000
@@ -68,6 +76,7 @@
 
 #ifndef __ASSEMBLY__
 
+#include <common_def.h>
 #include <stdint.h>
 
 /* Function declarations */
@@ -83,10 +92,10 @@
  */
 void cci_init(uintptr_t cci_base,
 		int slave_iface3_cluster_ix,
-		int slave_iface4_cluster_ix);
+		int slave_iface4_cluster_ix) __warn_deprecated;
 
-void cci_enable_cluster_coherency(unsigned long mpidr);
-void cci_disable_cluster_coherency(unsigned long mpidr);
+void cci_enable_cluster_coherency(unsigned long mpidr) __warn_deprecated;
+void cci_disable_cluster_coherency(unsigned long mpidr) __warn_deprecated;
 
 #endif /* __ASSEMBLY__ */
 #endif /* __CCI_400_H__ */


### PR DESCRIPTION
Add compile time `__warn_deprecated` flag to public api's in CCI-400
specific driver so that user is aware of the driver being deprecated.
Similarly, it also adds an error message when `ERROR_DEPRECATED` is set
to prevent succesful compilation if CCI-400 specific driver is used.

Change-Id: Id7e61a560262abc01cbbd432ca85b9bf448a194d