### PR TITLE
Fix issue in Floating point register restore

### DIFF
--- a/bl31/aarch64/context.S
+++ b/bl31/aarch64/context.S
@@ -291,7 +291,7 @@ func fpregs_context_restore
 	ldr	x9, [x0, #CTX_FP_FPSR]
 	msr	fpsr, x9
 
-	str	x10, [x0, #CTX_FP_FPCR]
+	ldr	x10, [x0, #CTX_FP_FPCR]
 	msr	fpcr, x10
 
 	/*


### PR DESCRIPTION
The `fpregs_context_restore()` function used to restore the floating point
regsiter context had a typo error wherein it was doing `str` instead of
`ldr` for a register. This issue remained undetected becuase none of the ARM
Standard development platforms save and restore the floating point register
context when a context switch is done. This patch corrects the issue.

Change-Id: Id178e0ba254a5e0a4a844f54b39d71dc34e0f6ea