### PR TITLE
Remove the assert for TZC base during initialization

### DIFF
--- a/drivers/arm/tzc400/tzc400.c
+++ b/drivers/arm/tzc400/tzc400.c
@@ -170,9 +170,6 @@ void tzc_init(uintptr_t base)
 
 	assert(base);
 
-	/* Assert if already initialised */
-	assert(!tzc.base);
-
 	tzc.base = base;
 
 	/*


### PR DESCRIPTION
When resuming from system suspend the TZC needs to be
re-initialized. Hence the assertion for TZC base address
to detect re-initialization is removed.

Change-Id: I53d64146f6c919e95526441bb997f7b309c68141