### PR TITLE
Include psci.h from tegra platform header

### DIFF
--- a/plat/nvidia/tegra/include/tegra_private.h
+++ b/plat/nvidia/tegra/include/tegra_private.h
@@ -33,6 +33,7 @@
 
 #include <arch.h>
 #include <platform_def.h>
+#include <psci.h>
 #include <xlat_tables.h>
 
 /*******************************************************************************


### PR DESCRIPTION
The `plat/nvidia/tegra/include/tegra_private.h` file uses resources
from psci.h (for example, psci_power_state_t) but does not explicitly
include psci.h. This does not currently cause a problem since psci.h
is indirectly included via other headers. However, this may not be
the case in future.

This patch explicitly includes psci.h from tegra_private.h

Change-Id: Ia991147898dbd117c1d3496a95850995a5554c05