### PR TITLE
De-feature PL011 UART driver to match generic UART spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,8 @@ COLD_BOOT_SINGLE_CPU		:= 0
 # Flag to introduce an infinite loop in BL1 just before it exits into the next
 # image. This is meant to help debugging the post-BL2 phase.
 SPIN_ON_BL1_EXIT		:= 0
+# Build PL011 UART driver in minimal generic UART mode
+PL011_GENERIC_UART		:= 0
 
 
 ################################################################################
@@ -365,6 +367,7 @@ $(eval $(call assert_boolean,PSCI_EXTENDED_STATE_ID))
 $(eval $(call assert_boolean,ERROR_DEPRECATED))
 $(eval $(call assert_boolean,ENABLE_PLAT_COMPAT))
 $(eval $(call assert_boolean,SPIN_ON_BL1_EXIT))
+$(eval $(call assert_boolean,PL011_GENERIC_UART))
 
 
 ################################################################################
@@ -393,6 +396,7 @@ $(eval $(call add_define,SPIN_ON_BL1_EXIT))
 ifdef EL3_PAYLOAD_BASE
 $(eval $(call add_define,EL3_PAYLOAD_BASE))
 endif
+$(eval $(call add_define,PL011_GENERIC_UART))
 
 
 ################################################################################

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -388,6 +388,12 @@ performed.
     payload. Please refer to the "Booting an EL3 payload" section for more
     details.
 
+*   `PL011_GENERIC_UART`: Boolean option to indicate the PL011 driver that
+    the underlying hardware is not a full PL011 UART but a minimally compliant
+    generic UART, which is a subset of the PL011. The driver will not access
+    any register that is not part of the SBSA generic UART specification.
+    Default value is 0 (a full PL011 compliant UART is present).
+
 #### ARM development platform specific build options
 
 *   `ARM_TSP_RAM_LOCATION`: location of the TSP binary. Options:

--- a/drivers/arm/pl011/pl011_console.S
+++ b/drivers/arm/pl011/pl011_console.S
@@ -60,6 +60,7 @@
 func console_core_init
 	/* Check the input base address */
 	cbz	x0, core_init_fail
+#if !PL011_GENERIC_UART
 	/* Check baud rate and uart clock for sanity */
 	cbz	w1, core_init_fail
 	cbz	w2, core_init_fail
@@ -82,6 +83,7 @@ func console_core_init
 	/* Enable tx, rx, and uart overall */
 	mov	w1, #(PL011_UARTCR_RXE | PL011_UARTCR_TXE | PL011_UARTCR_UARTEN)
 	str	w1, [x0, #UARTCR]
+#endif
 	mov	w0, #1
 	ret
 core_init_fail:

--- a/include/drivers/arm/pl011.h
+++ b/include/drivers/arm/pl011.h
@@ -36,17 +36,21 @@
 #define UARTRSR                   0x004
 #define UARTECR                   0x004
 #define UARTFR                    0x018
+#define UARTIMSC                  0x038
+#define UARTRIS                   0x03C
+#define UARTICR                   0x044
+
+/* PL011 registers (out of the SBSA specification) */
+#if !PL011_GENERIC_UART
 #define UARTILPR                  0x020
 #define UARTIBRD                  0x024
 #define UARTFBRD                  0x028
 #define UARTLCR_H                 0x02C
 #define UARTCR                    0x030
 #define UARTIFLS                  0x034
-#define UARTIMSC                  0x038
-#define UARTRIS                   0x03C
 #define UARTMIS                   0x040
-#define UARTICR                   0x044
 #define UARTDMACR                 0x048
+#endif /* !PL011_GENERIC_UART */
 
 /* Data status bits */
 #define UART_DATA_ERROR_MASK      0x0F00
@@ -69,6 +73,7 @@
 #define PL011_UARTFR_RXFE_BIT	4	/* Receive FIFO empty bit in UARTFR register */
 
 /* Control reg bits */
+#if !PL011_GENERIC_UART
 #define PL011_UARTCR_CTSEN        (1 << 15)	/* CTS hardware flow control enable */
 #define PL011_UARTCR_RTSEN        (1 << 14)	/* RTS hardware flow control enable */
 #define PL011_UARTCR_RTS          (1 << 11)	/* Request to send */
@@ -94,5 +99,7 @@
 #define PL011_UARTLCR_H_EPS       (1 << 2)	/* Even parity select */
 #define PL011_UARTLCR_H_PEN       (1 << 1)	/* Parity Enable */
 #define PL011_UARTLCR_H_BRK       (1 << 0)	/* Send break */
+
+#endif /* !PL011_GENERIC_UART */
 
 #endif	/* __PL011_H__ */


### PR DESCRIPTION
The Server Base System Architecture document (ARM-DEN-0029)
specifies a generic UART device. The programmer's view of this
generic UART is a subset of the ARM PL011 UART. However, the
current PL011 driver in Trusted Firmware uses some features
that are outside the generic UART specification.

This patch modifies the PL011 driver to exclude features outside
the SBSA generic UART specification by setting the boolean build
option 'PL011_GENERIC_UART=1'. Default value is 0 (use full
PL011 features).

User guide updated.

Fixes ARM-software/tf-issues#216

Change-Id: I6e0eb86f9d69569bc3980fb57e70d6da5d91a737