### PR TITLE
Move up to mbed TLS 2.x

### DIFF
--- a/docs/auth-framework.md
+++ b/docs/auth-framework.md
@@ -381,7 +381,7 @@ platform.
     PKI certificates (authentication images). It is expected that open source
     libraries will be available which can be used to parse an image represented
     by this method. Such libraries can be used to write the corresponding IPL
-    e.g. the X.509 parsing library code in PolarSSL.
+    e.g. the X.509 parsing library code in mbed TLS.
 
 3.  Platform defined method: This method caters for platform specific
     proprietary standards to represent authentication or data images. For
@@ -867,7 +867,7 @@ extract the authentication parameters. The number and type of parser libraries
 depend on the images used in the CoT. Raw images do not need a library, so
 only an x509v3 library is required for the TBBR CoT.
 
-ARM platforms will use an x509v3 library based on mbedTLS. This library may be
+ARM platforms will use an x509v3 library based on mbed TLS. This library may be
 found in `drivers/auth/mbedtls/mbedtls_x509_parser.c`. It exports three
 functions:
 
@@ -885,15 +885,17 @@ an image of type `IMG_CERT`, it will call the corresponding function exported
 in this file.
 
 The build system must be updated to include the corresponding library and
-mbedTLS sources. ARM platforms use the `arm_common.mk` file to pull the sources.
+mbed TLS sources. ARM platforms use the `arm_common.mk` file to pull the
+sources.
 
 ### 4.3 The cryptographic library
 
 The cryptographic module relies on a library to perform the required operations,
 i.e. verify a hash or a digital signature. ARM platforms will use a library
-based on mbedTLS, which can be found in `drivers/auth/mbedtls/mbedtls_crypto.c`.
-This library is registered in the authentication framework using the macro
-`REGISTER_CRYPTO_LIB()` and exports three functions:
+based on mbed TLS, which can be found in
+`drivers/auth/mbedtls/mbedtls_crypto.c`. This library is registered in the
+authentication framework using the macro `REGISTER_CRYPTO_LIB()` and exports
+three functions:
 
 ```
 void init(void);

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -603,22 +603,24 @@ following steps should be followed to build a FIP image with support for this
 feature.
 
 1.  Fulfill the dependencies of the `mbedtls` cryptographic and image parser
-    modules by checking out the tag `mbedtls-1.3.11` from the
-    [mbedTLS Repository].
+    modules by checking out a recent version of the [mbed TLS Repository]. It
+    is important to use a version that is compatible with TF and fixes any
+    known security vulnerabilities. See [mbed TLS Security Center] for more
+    information. This version of TF is tested with tag `mbedtls-2.2.0`.
 
-    The `drivers/auth/mbedtls/mbedtls_*.mk` files contain the list of mbedTLS
+    The `drivers/auth/mbedtls/mbedtls_*.mk` files contain the list of mbed TLS
     source files the modules depend upon.
     `include/drivers/auth/mbedtls/mbedtls_config.h` contains the configuration
-    options required to build the mbedTLS sources.
+    options required to build the mbed TLS sources.
 
-    Note that the mbedTLS library is licensed under the GNU GPL version 2
-    or later license. Using mbedTLS source code will affect the licensing of
+    Note that the mbed TLS library is licensed under the Apache version 2.0
+    license. Using mbed TLS source code will affect the licensing of
     Trusted Firmware binaries that are built using this library.
 
 2.  Ensure that the following command line variables are set while invoking
     `make` to build Trusted Firmware:
 
-    *   `MBEDTLS_DIR=<path of the directory containing mbedTLS sources>`
+    *   `MBEDTLS_DIR=<path of the directory containing mbed TLS sources>`
     *   `TRUSTED_BOARD_BOOT=1`
     *   `GENERATE_COT=1`
 
@@ -643,7 +645,7 @@ feature.
 
         CROSS_COMPILE=<path-to-aarch64-gcc>/bin/aarch64-linux-gnu-      \
         BL33=<path-to>/<bl33_image>                                     \
-        MBEDTLS_DIR=<path of the directory containing mbedTLS sources>  \
+        MBEDTLS_DIR=<path of the directory containing mbed TLS sources> \
         make PLAT=<platform> TRUSTED_BOARD_BOOT=1 GENERATE_COT=1        \
         ARM_ROTPK_LOCATION=devel_rsa                                    \
         ROT_KEY=plat/arm/board/common/rotpk/arm_rotprivk_rsa.pem        \
@@ -1257,6 +1259,7 @@ _Copyright (c) 2013-2015, ARM Limited and Contributors. All rights reserved._
 [ARM Connected Community]:     http://community.arm.com
 [Juno Software Guide]:         http://community.arm.com/docs/DOC-8396
 [DS-5]:                        http://www.arm.com/products/tools/software-tools/ds-5/index.php
-[mbedTLS Repository]:          https://github.com/ARMmbed/mbedtls.git
+[mbed TLS Repository]:         https://github.com/ARMmbed/mbedtls.git
+[mbed TLS Security Center]:    https://tls.mbed.org/security
 [PSCI]:                        http://infocenter.arm.com/help/topic/com.arm.doc.den0022c/DEN0022C_Power_State_Coordination_Interface.pdf "Power State Coordination Interface PDD (ARM DEN 0022C)"
 [Trusted Board Boot]:          trusted-board-boot.md

--- a/drivers/auth/mbedtls/mbedtls_common.c
+++ b/drivers/auth/mbedtls/mbedtls_common.c
@@ -30,11 +30,11 @@
 
 #include <assert.h>
 
-/* mbedTLS headers */
-#include <polarssl/memory_buffer_alloc.h>
+/* mbed TLS headers */
+#include <mbedtls/memory_buffer_alloc.h>
 
 /*
- * mbedTLS heap
+ * mbed TLS heap
  */
 #if (MBEDTLS_KEY_ALG_ID == MBEDTLS_ECDSA)
 #define MBEDTLS_HEAP_SIZE		(14*1024)
@@ -44,22 +44,15 @@
 static unsigned char heap[MBEDTLS_HEAP_SIZE];
 
 /*
- * mbedTLS initialization function
- *
- * Return: 0 = success, Otherwise = error
+ * mbed TLS initialization function
  */
 void mbedtls_init(void)
 {
 	static int ready;
-	int rc;
 
 	if (!ready) {
-		/* Initialize the mbedTLS heap */
-		rc = memory_buffer_alloc_init(heap, MBEDTLS_HEAP_SIZE);
-		if (rc == 0) {
-			ready = 1;
-		} else {
-			assert(0);
-		}
+		/* Initialize the mbed TLS heap */
+		mbedtls_memory_buffer_alloc_init(heap, MBEDTLS_HEAP_SIZE);
+		ready = 1;
 	}
 }

--- a/drivers/auth/mbedtls/mbedtls_common.mk
+++ b/drivers/auth/mbedtls/mbedtls_common.mk
@@ -31,7 +31,7 @@
 ifneq (${MBEDTLS_COMMON_MK},1)
 MBEDTLS_COMMON_MK	:=	1
 
-# MBEDTLS_DIR must be set to the mbedTLS main directory (it must contain
+# MBEDTLS_DIR must be set to the mbed TLS main directory (it must contain
 # the 'include' and 'library' subdirectories).
 ifeq (${MBEDTLS_DIR},)
   $(error Error: MBEDTLS_DIR not set)
@@ -40,9 +40,9 @@ endif
 INCLUDES		+=	-I${MBEDTLS_DIR}/include		\
 				-Iinclude/drivers/auth/mbedtls
 
-# Specify mbedTLS configuration file
-POLARSSL_CONFIG_FILE	:=	"<mbedtls_config.h>"
-$(eval $(call add_define,POLARSSL_CONFIG_FILE))
+# Specify mbed TLS configuration file
+MBEDTLS_CONFIG_FILE	:=	"<mbedtls_config.h>"
+$(eval $(call add_define,MBEDTLS_CONFIG_FILE))
 
 MBEDTLS_COMMON_SOURCES	:=	drivers/auth/mbedtls/mbedtls_common.c	\
 				$(addprefix ${MBEDTLS_DIR}/library/,	\

--- a/drivers/auth/mbedtls/mbedtls_crypto.mk
+++ b/drivers/auth/mbedtls/mbedtls_crypto.mk
@@ -62,10 +62,10 @@ else ifeq (${MBEDTLS_KEY_ALG},rsa)
     					)
     MBEDTLS_KEY_ALG_ID		:=	MBEDTLS_RSA
 else
-    $(error "MBEDTLS_KEY_ALG=${MBEDTLS_KEY_ALG} not supported on mbedTLS")
+    $(error "MBEDTLS_KEY_ALG=${MBEDTLS_KEY_ALG} not supported on mbed TLS")
 endif
 
-# mbedTLS libraries rely on this define to build correctly
+# mbed TLS libraries rely on this define to build correctly
 $(eval $(call add_define,MBEDTLS_KEY_ALG_ID))
 
 BL1_SOURCES			+=	${MBEDTLS_CRYPTO_SOURCES}

--- a/include/drivers/auth/mbedtls/mbedtls_config.h
+++ b/include/drivers/auth/mbedtls/mbedtls_config.h
@@ -31,69 +31,69 @@
 #define __MBEDTLS_CONFIG_H__
 
 /*
- * Key algorithms currently supported on mbedTLS libraries
+ * Key algorithms currently supported on mbed TLS libraries
  */
 #define MBEDTLS_RSA			1
 #define MBEDTLS_ECDSA			2
 
 /*
- * Configuration file to build PolarSSL with the required features for
+ * Configuration file to build mbed TLS with the required features for
  * Trusted Boot
  */
 
-#define POLARSSL_PLATFORM_MEMORY
-#define POLARSSL_PLATFORM_NO_STD_FUNCTIONS
+#define MBEDTLS_PLATFORM_MEMORY
+#define MBEDTLS_PLATFORM_NO_STD_FUNCTIONS
 
-#define POLARSSL_PKCS1_V15
-#define POLARSSL_PKCS1_V21
+#define MBEDTLS_PKCS1_V15
+#define MBEDTLS_PKCS1_V21
 
-#define POLARSSL_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION
-#define POLARSSL_X509_CHECK_KEY_USAGE
-#define POLARSSL_X509_CHECK_EXTENDED_KEY_USAGE
+#define MBEDTLS_X509_ALLOW_UNSUPPORTED_CRITICAL_EXTENSION
+#define MBEDTLS_X509_CHECK_KEY_USAGE
+#define MBEDTLS_X509_CHECK_EXTENDED_KEY_USAGE
 
-#define POLARSSL_ASN1_PARSE_C
-#define POLARSSL_ASN1_WRITE_C
+#define MBEDTLS_ASN1_PARSE_C
+#define MBEDTLS_ASN1_WRITE_C
 
-#define POLARSSL_BASE64_C
-#define POLARSSL_BIGNUM_C
+#define MBEDTLS_BASE64_C
+#define MBEDTLS_BIGNUM_C
 
-#define POLARSSL_ERROR_C
-#define POLARSSL_MD_C
+#define MBEDTLS_ERROR_C
+#define MBEDTLS_MD_C
 
-#define POLARSSL_MEMORY_BUFFER_ALLOC_C
-#define POLARSSL_OID_C
+#define MBEDTLS_MEMORY_BUFFER_ALLOC_C
+#define MBEDTLS_OID_C
 
-#define POLARSSL_PK_C
-#define POLARSSL_PK_PARSE_C
-#define POLARSSL_PK_WRITE_C
+#define MBEDTLS_PK_C
+#define MBEDTLS_PK_PARSE_C
+#define MBEDTLS_PK_WRITE_C
 
-#define POLARSSL_PLATFORM_C
+#define MBEDTLS_PLATFORM_C
 
 #if (MBEDTLS_KEY_ALG_ID == MBEDTLS_ECDSA)
-#define POLARSSL_ECDSA_C
-#define POLARSSL_ECP_C
-#define POLARSSL_ECP_DP_SECP256R1_ENABLED
+#define MBEDTLS_ECDSA_C
+#define MBEDTLS_ECP_C
+#define MBEDTLS_ECP_DP_SECP256R1_ENABLED
 #elif (MBEDTLS_KEY_ALG_ID == MBEDTLS_RSA)
-#define POLARSSL_RSA_C
+#define MBEDTLS_RSA_C
 #endif
 
-#define POLARSSL_SHA256_C
+#define MBEDTLS_SHA256_C
 
-#define POLARSSL_VERSION_C
+#define MBEDTLS_VERSION_C
 
-#define POLARSSL_X509_USE_C
-#define POLARSSL_X509_CRT_PARSE_C
+#define MBEDTLS_X509_USE_C
+#define MBEDTLS_X509_CRT_PARSE_C
 
 /* MPI / BIGNUM options */
-#define POLARSSL_MPI_WINDOW_SIZE              2
-#define POLARSSL_MPI_MAX_SIZE               256
+#define MBEDTLS_MPI_WINDOW_SIZE              2
+#define MBEDTLS_MPI_MAX_SIZE               256
 
 /* Memory buffer allocator options */
-#define POLARSSL_MEMORY_ALIGN_MULTIPLE        8
+#define MBEDTLS_MEMORY_ALIGN_MULTIPLE        8
 
-#include "polarssl/check_config.h"
+#include "mbedtls/check_config.h"
 
-/* System headers required to build mbedTLS with the current configuration */
+/* System headers required to build mbed TLS with the current configuration */
 #include <stdlib.h>
 
 #endif /* __MBEDTLS_CONFIG_H__ */


### PR DESCRIPTION
The mbed TLS library has introduced some changes in the API from
the 1.3.x to the 2.x releases. Using the 2.x releases requires
some changes to the crypto and transport modules.

This patch updates both modules to the mbed TLS 2.x API.

All references to the mbed TLS library in the code or documentation
have been updated to 'mbed TLS'. Old references to PolarSSL have
been updated to 'mbed TLS'.

User guide updated to use mbed TLS 2.2.0.

NOTE: moving up to mbed TLS 2.x from 1.3.x is not backward compatible.
Applying this patch will require an mbed TLS 2.x release to be used.
Also note that the mbed TLS license changed to Apache version 2.0.

Change-Id: Iba4584408653cf153091f2ca2ee23bc9add7fda4