### PR TITLE
FWU: Fix secure memory check in image auth

### DIFF
--- a/bl1/bl1_fwu.c
+++ b/bl1/bl1_fwu.c
@@ -298,7 +298,8 @@ static int bl1_fwu_image_auth(unsigned int image_id,
 		 * Image is in RESET state.
 		 * Check the parameters and authenticate the source image in place.
 		 */
-		if (bl1_plat_mem_check(image_src, image_size, flags)) {
+		if (bl1_plat_mem_check(image_src, image_size,	\
+					image_desc->ep_info.h.attr)) {
 			WARN("BL1-FWU: Authentication arguments source/size not mapped\n");
 			return -ENOMEM;
 		}


### PR DESCRIPTION
The implementation of FWU_SMC_IMAGE_AUTH performs a number of
pre-condition checks before authenticating the image. One of
these checks calls `bl1_plat_mem_check()` to ensure the image
source is mapped in when authenticating an image in place.
The framework incorrectly passes the security state of the
caller into this function instead of the security state of
the source image.

This patch corrects the defect. The defect would only
manifest itself for secure world callers authenticating
non-secure images in place, which is not done by current
upstream platforms.

Change-Id: I617c7b43e02ac7149f266aeaf3874316e62f3003