### PR TITLE
FWU: Pass client cookie to FWU_SMC_UPDATE_DONE

### DIFF
--- a/bl1/bl1_fwu.c
+++ b/bl1/bl1_fwu.c
@@ -64,7 +64,7 @@ static register_t bl1_fwu_image_resume(unsigned int image_id,
 			unsigned int flags);
 static int bl1_fwu_sec_image_done(void **handle,
 			unsigned int flags);
-__dead2 static void bl1_fwu_done(void *cookie, void *reserved);
+__dead2 static void bl1_fwu_done(void *client_cookie, void *reserved);
 
 /*
  * This keeps track of last executed secure image id.
@@ -101,7 +101,7 @@ register_t bl1_fwu_smc_handler(unsigned int smc_fid,
 		SMC_RET1(handle, bl1_fwu_sec_image_done(&handle, flags));
 
 	case FWU_SMC_UPDATE_DONE:
-		bl1_fwu_done(cookie, NULL);
+		bl1_fwu_done((void *)x1, NULL);
 		/* We should never return from bl1_fwu_done() */
 
 	default:
@@ -492,13 +492,13 @@ static int bl1_fwu_sec_image_done(void **handle, unsigned int flags)
  * This function provides the opportunity for users to perform any
  * platform specific handling after the Firmware update is done.
  ******************************************************************************/
-__dead2 static void bl1_fwu_done(void *cookie, void *reserved)
+__dead2 static void bl1_fwu_done(void *client_cookie, void *reserved)
 {
 	NOTICE("BL1-FWU: *******FWU Process Completed*******\n");
 
 	/*
 	 * Call platform done function.
 	 */
-	bl1_plat_fwu_done(cookie, reserved);
+	bl1_plat_fwu_done(client_cookie, reserved);
 	assert(0);
 }

--- a/include/plat/common/platform.h
+++ b/include/plat/common/platform.h
@@ -121,7 +121,7 @@ struct image_desc *bl1_plat_get_image_desc(unsigned int image_id);
  * The following functions are used by firmware update
  * feature and may optionally be overridden.
  */
-__dead2 void bl1_plat_fwu_done(void *cookie, void *reserved);
+__dead2 void bl1_plat_fwu_done(void *client_cookie, void *reserved);
 
 
 /*******************************************************************************

--- a/plat/arm/board/juno/juno_bl1_setup.c
+++ b/plat/arm/board/juno/juno_bl1_setup.c
@@ -72,7 +72,7 @@ void bl1_plat_set_ep_info(unsigned int image_id,
 /*******************************************************************************
  * On Juno clear SYS_NVFLAGS and wait for watchdog reset.
  ******************************************************************************/
-__dead2 void bl1_plat_fwu_done(void *cookie, void *rsvd_ptr)
+__dead2 void bl1_plat_fwu_done(void *client_cookie, void *reserved)
 {
 	unsigned int *nv_flags_clr = (unsigned int *)
 			(V2M_SYSREGS_BASE + V2M_SYS_NVFLAGSCLR);

--- a/plat/common/plat_bl1_common.c
+++ b/plat/common/plat_bl1_common.c
@@ -69,7 +69,7 @@ image_desc_t *bl1_plat_get_image_desc(unsigned int image_id)
 	return &bl2_img_desc;
 }
 
-__dead2 void bl1_plat_fwu_done(void *cookie, void *rsvd_ptr)
+__dead2 void bl1_plat_fwu_done(void *client_cookie, void *reserved)
 {
 	while (1)
 		wfi();


### PR DESCRIPTION
The current FWU_SMC_UPDATE_DONE implementation incorrectly passes
an unused framework cookie through to the 1st argument in the
platform function `bl1_plat_fwu_done`. The intent is to allow
the SMC caller to pass a cookie through to this function.

This patch fixes FWU_SMC_UPDATE_DONE to pass x1 from the caller
through to `bl1_plat_fwu_done`. The argument names are updated
for clarity.

Upstream platforms currently do not use this argument so no
impact is expected.

Change-Id: I107f4b51eb03e7394f66d9a534ffab1cbc09a9b2