### PR TITLE
platform.h: Include common_def.h

### DIFF
--- a/include/plat/common/platform.h
+++ b/include/plat/common/platform.h
@@ -31,6 +31,7 @@
 #ifndef __PLATFORM_H__
 #define __PLATFORM_H__
 
+#include <common_def.h>
 #include <psci.h>
 #include <stdint.h>
 #include <types.h>


### PR DESCRIPTION
APIs in platform.h are marked as deprecated using the macro
'__warn_deprecated' which is defined in the header common_def.h.
Include that header from platform.h to avoid compilation errors like:
  In file included from plat/common/aarch64/plat_psci_common.c:33:0:
  include/plat/common/platform.h: In function 'platform_get_core_pos':
  include/plat/common/platform.h:276:57: error: expected declaration specifiers before '__warn_deprecated'
   unsigned int platform_get_core_pos(unsigned long mpidr) __warn_deprecated;
                                                           ^

Fixes ARM-software/tf-issues#340

Signed-off-by: Soren Brinkmann <soren.brinkmann@xilinx.com>