### PR TITLE
Add ret to return from console_uninit() function

### DIFF
--- a/drivers/console/console.S
+++ b/drivers/console/console.S
@@ -79,6 +79,7 @@ func console_uninit
 	mov	x0, #0
 	adrp	x3, console_base
 	str	x0, [x3, :lo12:console_base]
+	ret
 endfunc console_uninit
 
 	/* ---------------------------------------------


### PR DESCRIPTION
The 'ret' was missing in console_uninit() implementation, so the
program doesn't return from console_uninit(). Instead, it keeps
executing the following instructions which is not expected.

Change-Id: I810684f37f61c41c6f95a3bb36914d0765da8571
Signed-off-by: Jimmy Huang <jimmy.huang@mediatek.com>