### PR TITLE
Always build with '-pedantic'

### DIFF
--- a/drivers/auth/mbedtls/mbedtls_common.mk
+++ b/drivers/auth/mbedtls/mbedtls_common.mk
@@ -55,6 +55,5 @@ MBEDTLS_COMMON_SOURCES	:=	drivers/auth/mbedtls/mbedtls_common.c	\
 
 BL1_SOURCES		+=	${MBEDTLS_COMMON_SOURCES}
 BL2_SOURCES		+=	${MBEDTLS_COMMON_SOURCES}
-DISABLE_PEDANTIC	:=	1
 
 endif

--- a/drivers/auth/mbedtls/mbedtls_crypto.c
+++ b/drivers/auth/mbedtls/mbedtls_crypto.c
@@ -174,7 +174,7 @@ static int verify_hash(void *data_ptr, unsigned int data_len,
 
 	/* Digest info should be an MBEDTLS_ASN1_SEQUENCE */
 	p = (unsigned char *)digest_info_ptr;
-	end = (unsigned char *)(digest_info_ptr + digest_info_len);
+	end = p + digest_info_len;
 	rc = mbedtls_asn1_get_tag(&p, end, &len, MBEDTLS_ASN1_CONSTRUCTED |
 				  MBEDTLS_ASN1_SEQUENCE);
 	if (rc != 0) {

--- a/include/drivers/auth/auth_mod.h
+++ b/include/drivers/auth/auth_mod.h
@@ -65,7 +65,7 @@ int auth_mod_verify_img(unsigned int img_id,
 #define REGISTER_COT(_cot) \
 	const auth_img_desc_t *const cot_desc_ptr = \
 			(const auth_img_desc_t *const)&_cot[0]; \
-	unsigned int auth_img_flags[sizeof(_cot)/sizeof(_cot[0])];
+	unsigned int auth_img_flags[sizeof(_cot)/sizeof(_cot[0])]
 
 #endif /* TRUSTED_BOARD_BOOT */
 

--- a/tools/cert_create/include/cert.h
+++ b/tools/cert_create/include/cert.h
@@ -76,7 +76,7 @@ int cert_new(cert_t *cert, int days, int ca, STACK_OF(X509_EXTENSION) * sk);
 /* Macro to register the certificates used in the CoT */
 #define REGISTER_COT(_certs) \
 	cert_t *certs = &_certs[0]; \
-	const unsigned int num_certs = sizeof(_certs)/sizeof(_certs[0]);
+	const unsigned int num_certs = sizeof(_certs)/sizeof(_certs[0])
 
 /* Exported variables */
 extern cert_t *certs;

--- a/tools/cert_create/include/ext.h
+++ b/tools/cert_create/include/ext.h
@@ -92,7 +92,7 @@ X509_EXTENSION *ext_new_key(int nid, int crit, EVP_PKEY *k);
 /* Macro to register the extensions used in the CoT */
 #define REGISTER_EXTENSIONS(_ext) \
 	ext_t *extensions = &_ext[0]; \
-	const unsigned int num_extensions = sizeof(_ext)/sizeof(_ext[0]);
+	const unsigned int num_extensions = sizeof(_ext)/sizeof(_ext[0])
 
 /* Exported variables */
 extern ext_t *extensions;

--- a/tools/cert_create/include/key.h
+++ b/tools/cert_create/include/key.h
@@ -79,7 +79,7 @@ int key_store(key_t *key);
 /* Macro to register the keys used in the CoT */
 #define REGISTER_KEYS(_keys) \
 	key_t *keys = &_keys[0]; \
-	const unsigned int num_keys = sizeof(_keys)/sizeof(_keys[0]);
+	const unsigned int num_keys = sizeof(_keys)/sizeof(_keys[0])
 
 /* Exported variables */
 extern key_t *keys;


### PR DESCRIPTION
* Fix build errors flagged by '-pedantic' in the mbed TLS authentication module
* Enable '-pedantic' compiler flag in the mbed TLS authentication module makefile
