### PR TITLE
Rearrange fields in TF data structures to reduce padding

### DIFF
--- a/include/bl31/runtime_svc.h
+++ b/include/bl31/runtime_svc.h
@@ -89,12 +89,12 @@ typedef struct rt_svc_desc {
 #define DECLARE_RT_SVC(_name, _start, _end, _type, _setup, _smch) \
 	static const rt_svc_desc_t __svc_desc_ ## _name \
 		__attribute__ ((section("rt_svc_descs"), used)) = { \
-			_start, \
-			_end, \
-			_type, \
-			#_name, \
-			_setup, \
-			_smch }
+			.start_oen = _start, \
+			.end_oen = _end, \
+			.call_type = _type, \
+			.name = #_name, \
+			.init = _setup, \
+			.handle = _smch }
 
 /*
  * Compile time assertions related to the 'rt_svc_desc' structure to:

--- a/include/common/bl_common.h
+++ b/include/common/bl_common.h
@@ -202,8 +202,9 @@ typedef struct param_header {
  * switching exception levels. The only two mechanisms to do so are
  * ERET & SMC. Security state is indicated using bit zero of header
  * attribute
- * NOTE: BL1 expects entrypoint followed by spsr while processing
- * SMC to jump to BL31 from the start of entry_point_info
+ * NOTE: BL1 expects entrypoint followed by spsr at an offset from the start
+ * of this structure defined by the macro `ENTRY_POINT_INFO_PC_OFFSET` while
+ * processing SMC to jump to BL31.
  *****************************************************************************/
 typedef struct entry_point_info {
 	param_header_t h;
@@ -232,13 +233,13 @@ typedef struct image_info {
 typedef struct image_desc {
 	/* Contains unique image id for the image. */
 	unsigned int image_id;
-	image_info_t image_info;
-	entry_point_info_t ep_info;
 	/*
 	 * This member contains Image state information.
 	 * Refer IMAGE_STATE_XXX defined above.
 	 */
 	unsigned int state;
+	image_info_t image_info;
+	entry_point_info_t ep_info;
 } image_desc_t;
 
 /*******************************************************************************

--- a/include/drivers/auth/auth_mod.h
+++ b/include/drivers/auth/auth_mod.h
@@ -48,8 +48,8 @@
  */
 typedef struct auth_img_desc_s {
 	unsigned int img_id;
-	const struct auth_img_desc_s *parent;
 	img_type_t img_type;
+	const struct auth_img_desc_s *parent;
 	auth_method_desc_t img_auth_methods[AUTH_METHOD_NUM];
 	auth_param_desc_t authenticated_data[COT_MAX_VERIFIED_PARAMS];
 } auth_img_desc_t;


### PR DESCRIPTION
This patchset rearranges fields of some TF data structures to reduce
padding and thereby reduce memory footprint. It also changes the
`DECLARE_RT_SVC` macro to use designated initialization of
`rt_svc_desc` structure which is less error prone.