### PR TITLE
Clean up __attribute__ usage

### DIFF
--- a/docs/porting-guide.md
+++ b/docs/porting-guide.md
@@ -85,7 +85,7 @@ section identified by name `bakery_lock` inside `coherent_ram` so that its
 possible for the firmware to place variables in it using the following C code
 directive:
 
-    __attribute__ ((section("bakery_lock")))
+    __section("bakery_lock")
 
 Or alternatively the following assembler code directive:
 

--- a/drivers/io/io_fip.c
+++ b/drivers/io/io_fip.c
@@ -128,7 +128,7 @@ static const io_dev_info_t fip_dev_info = {
 
 
 /* Open a connection to the FIP device */
-static int fip_dev_open(const uintptr_t dev_spec __attribute__((unused)),
+static int fip_dev_open(const uintptr_t dev_spec __unused,
 			 io_dev_info_t **dev_info)
 {
 	assert(dev_info != NULL);

--- a/drivers/io/io_memmap.c
+++ b/drivers/io/io_memmap.c
@@ -95,7 +95,7 @@ static const io_dev_info_t memmap_dev_info = {
 
 
 /* Open a connection to the memmap device */
-static int memmap_dev_open(const uintptr_t dev_spec __attribute__((unused)),
+static int memmap_dev_open(const uintptr_t dev_spec __unused,
 			   io_dev_info_t **dev_info)
 {
 	assert(dev_info != NULL);

--- a/drivers/io/io_semihosting.c
+++ b/drivers/io/io_semihosting.c
@@ -91,7 +91,7 @@ static int sh_dev_open(const uintptr_t dev_spec __unused,
 
 
 /* Open a file on the semi-hosting device */
-static int sh_file_open(io_dev_info_t *dev_info __attribute__((unused)),
+static int sh_file_open(io_dev_info_t *dev_info __unused,
 		const uintptr_t spec, io_entity_t *entity)
 {
 	int result = -ENOENT;

--- a/include/bl31/runtime_svc.h
+++ b/include/bl31/runtime_svc.h
@@ -88,7 +88,7 @@ typedef struct rt_svc_desc {
  */
 #define DECLARE_RT_SVC(_name, _start, _end, _type, _setup, _smch) \
 	static const rt_svc_desc_t __svc_desc_ ## _name \
-		__attribute__ ((section("rt_svc_descs"), used)) = { \
+		__section("rt_svc_descs") __used = { \
 			.start_oen = _start, \
 			.end_oen = _end, \
 			.call_type = _type, \

--- a/include/common/context_mgmt.h
+++ b/include/common/context_mgmt.h
@@ -33,7 +33,6 @@
 
 #include <arch.h>
 #include <bl_common.h>
-#include <common_def.h>
 
 /*******************************************************************************
  * Forward declarations
@@ -45,10 +44,10 @@ struct entry_point_info;
  ******************************************************************************/
 void cm_init(void);
 void *cm_get_context_by_mpidr(uint64_t mpidr,
-			      uint32_t security_state) __warn_deprecated;
+			      uint32_t security_state) __deprecated;
 void cm_set_context_by_mpidr(uint64_t mpidr,
 			     void *context,
-			     uint32_t security_state) __warn_deprecated;
+			     uint32_t security_state) __deprecated;
 void *cm_get_context_by_index(unsigned int cpu_idx,
 			      unsigned int security_state);
 void cm_set_context_by_index(unsigned int cpu_idx,
@@ -58,7 +57,7 @@ void *cm_get_context(uint32_t security_state);
 void cm_set_context(void *context, uint32_t security_state);
 inline void cm_set_next_context(void *context);
 void cm_init_context(uint64_t mpidr,
-		     const struct entry_point_info *ep) __warn_deprecated;
+		     const struct entry_point_info *ep) __deprecated;
 void cm_init_my_context(const struct entry_point_info *ep);
 void cm_init_context_by_index(unsigned int cpu_idx,
 			      const struct entry_point_info *ep);

--- a/include/drivers/arm/arm_gic.h
+++ b/include/drivers/arm/arm_gic.h
@@ -31,7 +31,6 @@
 #ifndef __ARM_GIC_H__
 #define __ARM_GIC_H__
 
-#include <common_def.h>
 #include <stdint.h>
 
 /*******************************************************************************
@@ -41,18 +40,18 @@ void arm_gic_init(uintptr_t gicc_base,
 		  uintptr_t gicd_base,
 		  uintptr_t gicr_base,
 		  const unsigned int *irq_sec_ptr,
-		  unsigned int num_irqs) __warn_deprecated;
-void arm_gic_setup(void) __warn_deprecated;
-void arm_gic_cpuif_deactivate(void) __warn_deprecated;
-void arm_gic_cpuif_setup(void) __warn_deprecated;
-void arm_gic_pcpu_distif_setup(void) __warn_deprecated;
+		  unsigned int num_irqs) __deprecated;
+void arm_gic_setup(void) __deprecated;
+void arm_gic_cpuif_deactivate(void) __deprecated;
+void arm_gic_cpuif_setup(void) __deprecated;
+void arm_gic_pcpu_distif_setup(void) __deprecated;
 
 uint32_t arm_gic_interrupt_type_to_line(uint32_t type,
-				uint32_t security_state) __warn_deprecated;
-uint32_t arm_gic_get_pending_interrupt_type(void) __warn_deprecated;
-uint32_t arm_gic_get_pending_interrupt_id(void) __warn_deprecated;
-uint32_t arm_gic_acknowledge_interrupt(void) __warn_deprecated;
-void arm_gic_end_of_interrupt(uint32_t id) __warn_deprecated;
-uint32_t arm_gic_get_interrupt_type(uint32_t id) __warn_deprecated;
+				uint32_t security_state) __deprecated;
+uint32_t arm_gic_get_pending_interrupt_type(void) __deprecated;
+uint32_t arm_gic_get_pending_interrupt_id(void) __deprecated;
+uint32_t arm_gic_acknowledge_interrupt(void) __deprecated;
+void arm_gic_end_of_interrupt(uint32_t id) __deprecated;
+uint32_t arm_gic_get_interrupt_type(uint32_t id) __deprecated;
 
 #endif /* __GIC_H__ */

--- a/include/drivers/arm/cci400.h
+++ b/include/drivers/arm/cci400.h
@@ -76,7 +76,6 @@
 
 #ifndef __ASSEMBLY__
 
-#include <common_def.h>
 #include <stdint.h>
 
 /* Function declarations */
@@ -92,10 +91,10 @@
  */
 void cci_init(uintptr_t cci_base,
 		int slave_iface3_cluster_ix,
-		int slave_iface4_cluster_ix) __warn_deprecated;
+		int slave_iface4_cluster_ix) __deprecated;
 
-void cci_enable_cluster_coherency(unsigned long mpidr) __warn_deprecated;
-void cci_disable_cluster_coherency(unsigned long mpidr) __warn_deprecated;
+void cci_enable_cluster_coherency(unsigned long mpidr) __deprecated;
+void cci_disable_cluster_coherency(unsigned long mpidr) __deprecated;
 
 #endif /* __ASSEMBLY__ */
 #endif /* __CCI_400_H__ */

--- a/include/drivers/auth/img_parser_mod.h
+++ b/include/drivers/auth/img_parser_mod.h
@@ -77,7 +77,7 @@ int img_parser_get_auth_param(img_type_t img_type,
 /* Macro to register an image parser library */
 #define REGISTER_IMG_PARSER_LIB(_type, _name, _init, _check_int, _get_param) \
 	static const img_parser_lib_desc_t __img_parser_lib_desc_##_type \
-	__attribute__ ((section(".img_parser_lib_descs"), used)) = { \
+	__section(".img_parser_lib_descs") __used = { \
 		.img_type = _type, \
 		.name = _name, \
 		.init = _init, \

--- a/include/lib/bakery_lock.h
+++ b/include/lib/bakery_lock.h
@@ -100,8 +100,7 @@ inline void bakery_lock_init(bakery_lock_t *bakery) {}
 void bakery_lock_get(bakery_lock_t *bakery);
 void bakery_lock_release(bakery_lock_t *bakery);
 
-#define DEFINE_BAKERY_LOCK(_name) bakery_lock_t _name \
-			__attribute__ ((section("bakery_lock")))
+#define DEFINE_BAKERY_LOCK(_name) bakery_lock_t _name __section("bakery_lock")
 
 #define DECLARE_BAKERY_LOCK(_name) extern bakery_lock_t _name
 

--- a/include/lib/cassert.h
+++ b/include/lib/cassert.h
@@ -40,6 +40,6 @@
  * compiler warning.
  ******************************************************************************/
 #define CASSERT(cond, msg)	\
-	typedef char msg[(cond) ? 1 : -1] __attribute__((unused))
+	typedef char msg[(cond) ? 1 : -1] __unused
 
 #endif /* __CASSERT_H__ */

--- a/include/plat/common/common_def.h
+++ b/include/plat/common/common_def.h
@@ -70,13 +70,6 @@
   #define MAKE_ULL(x)			x
 #endif
 
-/*
- * Macros to wrap declarations of deprecated APIs within Trusted Firmware.
- * The callers of these APIs will continue to compile with a warning as long
- * as the build flag ERROR_DEPRECATED is zero.
- */
-#define __warn_deprecated	__attribute__ ((deprecated))
-
 #define BL2_IMAGE_DESC {				\
 	.image_id = BL2_IMAGE_ID,			\
 	.image_info.h.version = VERSION_1,		\

--- a/include/plat/common/platform.h
+++ b/include/plat/common/platform.h
@@ -273,7 +273,7 @@ unsigned int plat_get_aff_state(unsigned int, unsigned long);
  * haven't migrated to the new platform API to compile on platforms which
  * have the compatibility layer disabled.
  */
-unsigned int platform_get_core_pos(unsigned long mpidr) __warn_deprecated;
+unsigned int platform_get_core_pos(unsigned long mpidr) __deprecated;
 
 #endif /* __ENABLE_PLAT_COMPAT__ */
 #endif /* __PLATFORM_H__ */

--- a/include/stdlib/sys/cdefs.h
+++ b/include/stdlib/sys/cdefs.h
@@ -283,8 +283,10 @@
 
 #if __GNUC_PREREQ__(3, 1)
 #define	__noinline	__attribute__ ((__noinline__))
+#define	__deprecated	__attribute__ ((deprecated))
 #else
 #define	__noinline
+#define	__deprecated
 #endif
 
 #if __GNUC_PREREQ__(3, 3)

--- a/lib/aarch64/xlat_tables.c
+++ b/lib/aarch64/xlat_tables.c
@@ -58,7 +58,7 @@ static uint64_t l1_xlation_table[NUM_L1_ENTRIES]
 __aligned(NUM_L1_ENTRIES * sizeof(uint64_t));
 
 static uint64_t xlat_tables[MAX_XLAT_TABLES][XLAT_TABLE_ENTRIES]
-__aligned(XLAT_TABLE_SIZE) __attribute__((section("xlat_table")));
+__aligned(XLAT_TABLE_SIZE) __section("xlat_table");
 
 static unsigned next_xlat;
 static unsigned long max_pa;

--- a/plat/arm/common/arm_io_storage.c
+++ b/plat/arm/common/arm_io_storage.c
@@ -277,9 +277,9 @@ void plat_arm_io_setup(void)
 }
 
 int plat_arm_get_alt_image_source(
-	unsigned int image_id __attribute__((unused)),
-	uintptr_t *dev_handle __attribute__((unused)),
-	uintptr_t *image_spec __attribute__((unused)))
+	unsigned int image_id __unused,
+	uintptr_t *dev_handle __unused,
+	uintptr_t *image_spec __unused)
 {
 	/* By default do not try an alternative */
 	return -ENOENT;

--- a/plat/mediatek/mt8173/drivers/spm/spm.c
+++ b/plat/mediatek/mt8173/drivers/spm/spm.c
@@ -55,9 +55,9 @@ static int spm_dormant_sta = CPU_DORMANT_RESET;
 
 DEFINE_BAKERY_LOCK(spm_lock);
 
-static int spm_hotplug_ready __attribute__ ((section("tzfw_coherent_mem")));
-static int spm_mcdi_ready __attribute__ ((section("tzfw_coherent_mem")));
-static int spm_suspend_ready __attribute__ ((section("tzfw_coherent_mem")));
+static int spm_hotplug_ready __section("tzfw_coherent_mem");
+static int spm_mcdi_ready __section("tzfw_coherent_mem");
+static int spm_suspend_ready __section("tzfw_coherent_mem");
 
 void spm_lock_init(void)
 {

--- a/services/std_svc/psci/psci_common.c
+++ b/services/std_svc/psci/psci_common.c
@@ -74,7 +74,7 @@ static plat_local_state_t
  ******************************************************************************/
 non_cpu_pd_node_t psci_non_cpu_pd_nodes[PSCI_NUM_NON_CPU_PWR_DOMAINS]
 #if USE_COHERENT_MEM
-__attribute__ ((section("tzfw_coherent_mem")))
+__section("tzfw_coherent_mem")
 #endif
 ;
 


### PR DESCRIPTION
Move common compiler-specific macros into a generic, common header.

Fixes ARM-software/tf-issues#340

Signed-off-by: Soren Brinkmann <soren.brinkmann@xilinx.com>