### PR TITLE
Doc: Update out-dated info about Juno's mailbox

### DIFF
--- a/docs/firmware-design.md
+++ b/docs/firmware-design.md
@@ -1204,9 +1204,9 @@ The following list describes the memory layout on the ARM development platforms:
     Trusted SRAM. The amount of Trusted SRAM available to load the bootloader
     images is reduced by the size of the shared memory.
 
-    The shared memory is used to store the entrypoint mailboxes for each CPU.
-    On Juno, this is also used for the MHU payload when passing messages to and
-    from the SCP.
+    The shared memory is used to store the CPUs' entrypoint mailbox. On Juno,
+    this is also used for the MHU payload when passing messages to and from the
+    SCP.
 
 *   On FVP, BL1 is originally sitting in the Trusted ROM at address `0x0`. On
     Juno, BL1 resides in flash memory at address `0x0BEC0000`. BL1 read-write


### PR DESCRIPTION
Since commit 804040d106, the Juno port has moved from per-CPU mailboxes
to a single shared one. This patch updates an out-dated reference to
the former per-CPU mailboxes mechanism in the Firmware Design.
