### PR TITLE
Update doc links in the porting guide

### DIFF
--- a/docs/porting-guide.md
+++ b/docs/porting-guide.md
@@ -1986,8 +1986,8 @@ amount of open resources per driver.
 _Copyright (c) 2013-2015, ARM Limited and Contributors. All rights reserved._
 
 
-[ARM GIC Architecture Specification 2.0]: http://arminfo.emea.arm.com/help/topic/com.arm.doc.ihi0048b/IHI0048B_gic_architecture_specification.pdf
-[ARM GIC Architecture Specification 3.0]: http://arminfo.emea.arm.com/help/topic/com.arm.doc.ihi0069a/IHI0069A_gic_architecture_specification.pdf
+[ARM GIC Architecture Specification 2.0]: http://infocenter.arm.com/help/topic/com.arm.doc.ihi0048b/index.html
+[ARM GIC Architecture Specification 3.0]: http://infocenter.arm.com/help/topic/com.arm.doc.ihi0069b/index.html
 [IMF Design Guide]:                       interrupt-framework-design.md
 [User Guide]:                             user-guide.md
 [FreeBSD]:                                http://www.freebsd.org


### PR DESCRIPTION
GIC v2 and v3 specification references in the porting guide
should refer to publically visible links, not ARM internal links.

Change-Id: Ib47c8adda6a03581f23bcaed72d71c08c7dd9fb1
Signed-off-by: Yuping Luo <yuping.luo@arm.com>