### PR TITLE
ARM plat: add build option to unlock access to non-secure timer

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -456,6 +456,12 @@ map is explained in the [Firmware Design].
     Trusted Watchdog may be disabled at build time for testing or development
     purposes.
 
+*   `ARM_CONFIG_CNTACR`: boolean option to unlock access to the CNTBase<N>
+    frame registers by setting the CNTCTLBase.CNTACR<N> register bits. The
+    frame number <N> is defined by 'PLAT_ARM_NSTIMER_FRAME_ID', which should
+    match the frame used by the Non-Secure image (normally the Linux kernel).
+    Default is true (access to the frame is allowed).
+
 #### ARM CSS platform specific build options
 
 *   `CSS_DETECT_PRE_1_7_0_SCP`: Boolean flag to detect SCP version

--- a/plat/arm/common/aarch64/arm_common.c
+++ b/plat/arm/common/aarch64/arm_common.c
@@ -151,10 +151,12 @@ void arm_configure_sys_timer(void)
 {
 	unsigned int reg_val;
 
+#if ARM_CONFIG_CNTACR
 	reg_val = (1 << CNTACR_RPCT_SHIFT) | (1 << CNTACR_RVCT_SHIFT);
 	reg_val |= (1 << CNTACR_RFRQ_SHIFT) | (1 << CNTACR_RVOFF_SHIFT);
 	reg_val |= (1 << CNTACR_RWVT_SHIFT) | (1 << CNTACR_RWPT_SHIFT);
 	mmio_write_32(ARM_SYS_TIMCTL_BASE + CNTACR_BASE(PLAT_ARM_NSTIMER_FRAME_ID), reg_val);
+#endif /* ARM_CONFIG_CNTACR */
 
 	reg_val = (1 << CNTNSAR_NS_SHIFT(PLAT_ARM_NSTIMER_FRAME_ID));
 	mmio_write_32(ARM_SYS_TIMCTL_BASE + CNTNSAR, reg_val);

--- a/plat/arm/common/arm_common.mk
+++ b/plat/arm/common/arm_common.mk
@@ -72,6 +72,11 @@ endif
 $(eval $(call assert_boolean,ARM_DISABLE_TRUSTED_WDOG))
 $(eval $(call add_define,ARM_DISABLE_TRUSTED_WDOG))
 
+# Process ARM_CONFIG_CNTACR
+ARM_CONFIG_CNTACR		:=	1
+$(eval $(call assert_boolean,ARM_CONFIG_CNTACR))
+$(eval $(call add_define,ARM_CONFIG_CNTACR))
+
 PLAT_INCLUDES		+=	-Iinclude/common/tbbr				\
 				-Iinclude/plat/arm/common			\
 				-Iinclude/plat/arm/common/aarch64


### PR DESCRIPTION
Currently, Trusted Firmware on ARM platforms unlocks access to the
timer frame registers that will be used by the Non-Secure world. This
unlock operation should be done by the Non-Secure software itself,
instead of relying on secure firmware settings.

This patch adds a new ARM specific build option 'ARM_CONFIG_CNTACR'
to unlock access to the timer frame by setting the corresponding
bits in the CNTACR<N> register. The frame id <N> is defined by
'PLAT_ARM_NSTIMER_FRAME_ID'. Default value is true (unlock timer
access).

Documentation updated accordingly.

Fixes ARM-software/tf-issues#170

Change-Id: Id9d606efd781e43bc581868cd2e5f9c8905bdbf6