### PR TITLE
cdefs.h: Use __deprecated__ instead of deprecated

### DIFF
--- a/include/stdlib/sys/cdefs.h
+++ b/include/stdlib/sys/cdefs.h
@@ -283,7 +283,7 @@
 
 #if __GNUC_PREREQ__(3, 1)
 #define	__noinline	__attribute__ ((__noinline__))
-#define	__deprecated	__attribute__ ((deprecated))
+#define	__deprecated	__attribute__ ((__deprecated__))
 #else
 #define	__noinline
 #define	__deprecated


### PR DESCRIPTION
Use the form with underscores to define the '__deprecated' macro to avoid
collisions with potentially defined macros, as suggested in gcc docs
(https://gcc.gnu.org/onlinedocs/gcc/Attribute-Syntax.html#Attribute-Syntax).

Signed-off-by: Soren Brinkmann <soren.brinkmann@xilinx.com>