### PR TITLE
Use tf_printf() for debug logs from xlat_tables.c

### DIFF
--- a/include/plat/arm/board/common/board_arm_def.h
+++ b/include/plat/arm/board/common/board_arm_def.h
@@ -39,9 +39,7 @@
  */
 
 /* Size of cacheable stacks */
-#if DEBUG_XLAT_TABLE
-# define PLATFORM_STACK_SIZE 0x800
-#elif IMAGE_BL1
+#if IMAGE_BL1
 #if TRUSTED_BOARD_BOOT
 # define PLATFORM_STACK_SIZE 0x1000
 #else

--- a/plat/mediatek/mt8173/include/platform_def.h
+++ b/plat/mediatek/mt8173/include/platform_def.h
@@ -31,7 +31,6 @@
 #ifndef __PLATFORM_DEF_H__
 #define __PLATFORM_DEF_H__
 
-#define DEBUG_XLAT_TABLE 0
 
 /*******************************************************************************
  * Platform binary types for linking
@@ -44,9 +43,7 @@
  ******************************************************************************/
 
 /* Size of cacheable stacks */
-#if DEBUG_XLAT_TABLE
-#define PLATFORM_STACK_SIZE 0x800
-#elif IMAGE_BL1
+#if IMAGE_BL1
 #define PLATFORM_STACK_SIZE 0x440
 #elif IMAGE_BL2
 #define PLATFORM_STACK_SIZE 0x400

--- a/plat/nvidia/tegra/include/platform_def.h
+++ b/plat/nvidia/tegra/include/platform_def.h
@@ -40,9 +40,7 @@
  ******************************************************************************/
 
 /* Size of cacheable stacks */
-#if DEBUG_XLAT_TABLE
-#define PLATFORM_STACK_SIZE 0x800
-#elif IMAGE_BL31
+#if IMAGE_BL31
 #define PLATFORM_STACK_SIZE 0x400
 #endif
 


### PR DESCRIPTION
The debug prints used to debug translation table setup in xlat_tables.c
used the `printf()` standard library function instead of the stack
optimized `tf_printf()` API. DEBUG_XLAT_TABLE option was used to enable
debug logs within xlat_tables.c and it configured a much larger stack
size for the platform in case it was enabled. This patch modifies these
debug prints within xlat_tables.c to use tf_printf() and modifies the format
specifiers to be compatible with tf_printf(). The debug prints are now enabled
if the VERBOSE prints are enabled in Trusted Firmware via LOG_LEVEL build
option.

The much larger stack size definition when DEBUG_XLAT_TABLE is defined
is no longer required and the platform ports are modified to remove this
stack size definition.

Change-Id: I2f7d77ea12a04b827fa15e2adc3125b1175e4c23