### PR TITLE
Pl061 gpio v3

### DIFF
--- a/drivers/arm/pl061/pl061_gpio.c
+++ b/drivers/arm/pl061/pl061_gpio.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2014-2016, ARM Limited and Contributors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * Neither the name of ARM nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include <debug.h>
+#include <errno.h>
+#include <gpio.h>
+#include <mmio.h>
+#include <pl061_gpio.h>
+
+#define MAX_GPIO_DEVICES	32
+#define PL061_GPIO_DIR		0x400
+
+#define BIT(nr)			(1UL << (nr))
+
+struct pl061_gpio_device_t {
+	uintptr_t	reg_base[MAX_GPIO_DEVICES];
+	unsigned int	gpio_index[MAX_GPIO_DEVICES];
+	unsigned int	gpio_nums;
+	unsigned int	gpio_devs;
+};
+
+static struct pl061_gpio_device_t pl061_dev;
+
+static int pl061_get_reg_base(unsigned int gpio, uintptr_t *gpio_base)
+{
+	int i;
+
+	if (pl061_dev.gpio_nums > MAX_GPIO_DEVICES * GPIOS_PER_PL061)
+		return -EINVAL;
+	if (gpio >= pl061_dev.gpio_nums)
+		return -EINVAL;
+	if (gpio_base == NULL)
+		return -EINVAL;
+	for (i = 0; i < pl061_dev.gpio_devs; i++) {
+		if (gpio < pl061_dev.gpio_index[i])
+			return -ENOENT;
+		if (gpio >= pl061_dev.gpio_index[i] + GPIOS_PER_PL061)
+			continue;
+		*gpio_base = pl061_dev.reg_base[i];
+		return 0;
+	}
+	return -ENOENT;
+}
+
+static int pl061_get_direction(unsigned int gpio)
+{
+	uintptr_t base_addr;
+	unsigned int data, offset;
+
+	if (pl061_get_reg_base(gpio, &base_addr))
+		return -EINVAL;
+
+	offset = gpio % GPIOS_PER_PL061;
+	data = mmio_read_8(base_addr + PL061_GPIO_DIR);
+	if (data & BIT(offset))
+		return GPIO_DIR_OUT;
+	return GPIO_DIR_IN;
+}
+
+static int pl061_set_direction(unsigned int gpio, unsigned int direction)
+{
+	uintptr_t base_addr;
+	unsigned int data, offset;
+
+	if (pl061_get_reg_base(gpio, &base_addr))
+		return -EINVAL;
+
+	offset = gpio % GPIOS_PER_PL061;
+	if (direction == GPIO_DIR_OUT) {
+		data = mmio_read_8(base_addr + PL061_GPIO_DIR) | BIT(offset);
+		mmio_write_8(base_addr + PL061_GPIO_DIR, data);
+	} else {
+		data = mmio_read_8(base_addr + PL061_GPIO_DIR) & ~BIT(offset);
+		mmio_write_8(base_addr + PL061_GPIO_DIR, data);
+	}
+	return 0;
+}
+
+static int pl061_get_value(unsigned int gpio)
+{
+	uintptr_t base_addr;
+	unsigned int offset;
+
+	if (pl061_get_reg_base(gpio, &base_addr))
+		return -EINVAL;
+
+	offset = gpio % GPIOS_PER_PL061;
+	if (mmio_read_8(base_addr + BIT(offset + 2)))
+		return GPIO_LEVEL_HIGH;
+	return GPIO_LEVEL_LOW;
+}
+
+static int pl061_set_value(unsigned int gpio, unsigned int value)
+{
+	uintptr_t base_addr;
+	unsigned int offset;
+
+	if (pl061_get_reg_base(gpio, &base_addr))
+		return -EINVAL;
+
+	offset = gpio % GPIOS_PER_PL061;
+	if (value == GPIO_LEVEL_HIGH)
+		mmio_write_8(base_addr + BIT(offset + 2), BIT(offset));
+	else
+		mmio_write_8(base_addr + BIT(offset + 2), 0);
+	return 0;
+}
+
+static gpio_ops_t pl061_gpio_ops = {
+	.get_direction	= pl061_get_direction,
+	.set_direction	= pl061_set_direction,
+	.get_value	= pl061_get_value,
+	.set_value	= pl061_set_value,
+};
+
+
+/*
+ * Register the PL061 GPIO controller with a base address and the offset
+ * of start pin in this GPIO controller.
+ * This function is called after pl061_gpio_ops_init().
+ */
+int pl061_gpio_register(uintptr_t base_addr, unsigned int gpio_offset)
+{
+	int i;
+
+	assert ((pl061_dev.gpio_nums != 0) && (pl061_dev.gpio_devs != 0));
+
+	if (gpio_offset % GPIOS_PER_PL061) {
+		WARN("Fail to register PL061 GPIO with offset %d\n",
+		     gpio_offset);
+		return -EINVAL;
+	}
+
+	for (i = 0; i < pl061_dev.gpio_devs; i++) {
+		if (gpio_offset == pl061_dev.gpio_index[i]) {
+			pl061_dev.reg_base[i] = base_addr;
+			return 0;
+		}
+	}
+	return -EINVAL;
+}
+
+/*
+ * Initialize PL061 GPIO controller with the total GPIO numbers in SoC.
+ */
+int pl061_gpio_init(unsigned int gpio_nums)
+{
+	int gpio_devs, i;
+
+	assert(gpio_nums > 0);
+
+	if (gpio_nums > (MAX_GPIO_DEVICES * GPIOS_PER_PL061))
+		return -EINVAL;
+
+	gpio_devs = (gpio_nums + (GPIOS_PER_PL061 - 1)) / GPIOS_PER_PL061;
+	for (i = 0; i < gpio_devs; i++) {
+		pl061_dev.reg_base[i] = 0;
+		pl061_dev.gpio_index[i] = i * GPIOS_PER_PL061;
+	}
+	pl061_dev.gpio_nums = gpio_nums;
+	pl061_dev.gpio_devs = gpio_devs;
+
+	gpio_init(&pl061_gpio_ops);
+	return 0;
+}

--- a/drivers/gpio/gpio.c
+++ b/drivers/gpio/gpio.c
@@ -1,0 +1,87 @@
+/*
+ * GPIO -- General Purpose Input/Output
+ *
+ * Defines a simple and generic interface to access GPIO device.
+ *
+ * Copyright (c) 2014-2016, ARM Limited and Contributors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * Neither the name of ARM nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <gpio.h>
+
+/*
+ * The gpio implementation
+ */
+static const gpio_ops_t *ops;
+
+int gpio_get_direction(unsigned int gpio)
+{
+	assert(ops->get_direction != 0);
+
+	return ops->get_direction(gpio);
+}
+
+int gpio_set_direction(unsigned int gpio, unsigned int direction)
+{
+	assert(ops->set_direction != 0);
+	assert((direction == GPIO_DIR_OUT) || (direction == GPIO_DIR_IN));
+
+	return ops->set_direction(gpio, direction);
+}
+
+int gpio_get_value(unsigned int gpio)
+{
+	assert(ops->get_value != 0);
+
+	return ops->get_value(gpio);
+}
+
+int gpio_set_value(unsigned int gpio, unsigned int value)
+{
+	assert(ops->set_value != 0);
+	assert((value == GPIO_LEVEL_LOW) || (value == GPIO_LEVEL_HIGH));
+
+	return ops->set_value(gpio, value);
+}
+
+/*
+ * Initialize the gpio. The fields in the provided gpio
+ * ops pointer must be valid.
+ */
+void gpio_init(const gpio_ops_t *ops_ptr)
+{
+	assert(ops_ptr != 0  &&
+	       (ops_ptr->get_direction != 0) &&
+	       (ops_ptr->set_direction != 0) &&
+	       (ops_ptr->get_value != 0) &&
+	       (ops_ptr->set_value != 0));
+
+	ops = ops_ptr;
+}

--- a/include/drivers/arm/pl061_gpio.h
+++ b/include/drivers/arm/pl061_gpio.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2014-2016, ARM Limited and Contributors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * Neither the name of ARM nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __PL061_GPIO_H__
+#define __PL061_GPIO_H__
+
+#include <gpio.h>
+
+#define GPIOS_PER_PL061		8
+
+int pl061_gpio_register(uintptr_t base_addr, unsigned int gpio_offset);
+int pl061_gpio_init(unsigned int gpio_nums);
+
+#endif	/* __PL061_GPIO_H__ */

--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2014-2016, ARM Limited and Contributors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * Neither the name of ARM nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __GPIO_H__
+#define __GPIO_H__
+
+#include <stdint.h>
+
+#define GPIO_DIR_OUT		0
+#define GPIO_DIR_IN		1
+
+#define GPIO_LEVEL_LOW		0
+#define GPIO_LEVEL_HIGH		1
+
+typedef struct gpio_ops {
+	int (*get_direction)(unsigned int gpio);
+	int (*set_direction)(unsigned int gpio, unsigned int direction);
+	int (*get_value)(unsigned int gpio);
+	int (*set_value)(unsigned int gpio, unsigned int value);
+} gpio_ops_t;
+
+int gpio_get_direction(unsigned int gpio);
+int gpio_set_direction(unsigned int gpio, unsigned int direction);
+int gpio_get_value(unsigned int gpio);
+int gpio_set_value(unsigned int gpio, unsigned int value);
+void gpio_init(const gpio_ops_t *ops);
+
+#endif	/* __GPIO_H__ */


### PR DESCRIPTION
Implement gpio framework and PL061 gpio driver. ARM-software/tf-issues#351

Changelog:
v3:
1. Add more comments in gpio driver.
2. Add more assert in both gpio & pl061 driver.
3. Add get_direction() in gpio ops.

v2:
1. Update with the standard copyright text.
2. Replace "uint32_t" by "unsigned int" according to the rules in wiki.
