### PR TITLE
PSCI: Resolve GCC static analysis false positive

### DIFF
--- a/services/std_svc/psci/psci_common.c
+++ b/services/std_svc/psci/psci_common.c
@@ -393,6 +393,7 @@ void psci_do_state_coordination(unsigned int end_pwrlvl,
 	unsigned int start_idx, ncpus;
 	plat_local_state_t target_state, *req_states;
 
+	assert(end_pwrlvl <= PLAT_MAX_PWR_LVL);
 	parent_idx = psci_cpu_pd_nodes[cpu_idx].parent_node;
 
 	/* For level 0, the requested state will be equivalent


### PR DESCRIPTION
When BL31 is compiled at `-O3` optimization level using Linaro GCC 4.9
AArch64 toolchain, it reports the following error:

```
services/std_svc/psci/psci_common.c: In function 'psci_do_state_coordination':
services/std_svc/psci/psci_common.c:220:27: error: array subscript is above
array bounds [-Werror=array-bounds]
  psci_req_local_pwr_states[pwrlvl - 1][cpu_idx] = req_pwr_state;
                           ^
```

This error is a false positive and this patch resolves the error by asserting
the array bounds in `psci_do_state_coordination()`.

Fixes ARM-software/tf-issues#347

Change-Id: I3584ed7b2e28faf455b082cb3281d6e1d11d6495