### PR TITLE
Fix gpio includes of mt8173 platform to avoid collision.

### DIFF
--- a/plat/mediatek/mt8173/drivers/gpio/gpio.c
+++ b/plat/mediatek/mt8173/drivers/gpio/gpio.c
@@ -28,10 +28,10 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 #include <debug.h>
-#include <gpio.h>
 #include <mmio.h>
 #include <mt8173_def.h>
 #include <pmic_wrap_init.h>
+#include "gpio.h"
 
 enum {
 	MAX_GPIO_REG_BITS = 16,

--- a/plat/mediatek/mt8173/plat_pm.c
+++ b/plat/mediatek/mt8173/plat_pm.c
@@ -36,7 +36,6 @@
 #include <console.h>
 #include <debug.h>
 #include <errno.h>
-#include <gpio.h>
 #include <mcucfg.h>
 #include <mmio.h>
 #include <mt8173_def.h>
@@ -49,6 +48,7 @@
 #include <spm_hotplug.h>
 #include <spm_mcdi.h>
 #include <spm_suspend.h>
+#include "drivers/gpio/gpio.h"
 
 struct core_context {
 	unsigned long timer_data[8];


### PR DESCRIPTION
All files including plat/mediatek/mt8173/drivers/gpio/gpio.h were
using system includes instead of user includes, which may cause the
wrong version of the header to be included. Said includes have been
changed to user includes to make sure that the included file is the
wanted one.

Change-Id: I29bdfe96fbd9a7900875e2357bbb43f3ea431fa5