### PR TITLE
Remove non-ASCII character from comment

### DIFF
--- a/plat/arm/css/common/css_scpi.h
+++ b/plat/arm/css/common/css_scpi.h
@@ -45,7 +45,7 @@ typedef struct {
 	uint32_t set		: 1;
 	/* Sender ID to match a reply. The value is sender specific. */
 	uint32_t sender		: 8;
-	/* Size of the payload in bytes (0 – 511) */
+	/* Size of the payload in bytes (0 - 511) */
 	uint32_t size		: 9;
 	uint32_t reserved	: 7;
 	/*


### PR DESCRIPTION
Replaced a long dash in a comment by the ASCII character '-'. Support
for multibyte character in the source character set is not enforced by
the C99 standard. To maximize compatibility with C processing tools
(e.g. compilers or static code analysis tools), they should be removed.

Change-Id: Ie318e380d3b44755109f042a76ebfd2229f42ae3