### PR TITLE
Rationalise MMU and Page table related constants on ARM platforms

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -481,6 +481,13 @@ map is explained in the [Firmware Design].
     match the frame used by the Non-Secure image (normally the Linux kernel).
     Default is true (access to the frame is allowed).
 
+*   `ARM_BOARD_OPTIMISE_MMAP`: Boolean option to enable or disable optimisation
+    of page table and MMU related macros `PLAT_ARM_MMAP_ENTRIES` and
+    `MAX_XLAT_TABLES`. By default this flag is 0, which means it uses the
+    default unoptimised values for these macros. ARM development platforms
+    that wish to optimise memory usage for page tables need to set this flag to 1
+    and must override the related macros.
+
 #### ARM CSS platform specific build options
 
 *   `CSS_DETECT_PRE_1_7_0_SCP`: Boolean flag to detect SCP version

--- a/include/plat/arm/board/common/board_arm_def.h
+++ b/include/plat/arm/board/common/board_arm_def.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2016, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -60,80 +60,28 @@
 #endif
 
 /*
+ * The constants below are not optimised for memory usage. Platforms that wish
+ * to optimise these constants should set `ARM_BOARD_OPTIMISE_MMAP` to 1 and
+ * provide there own values.
+ */
+#if !ARM_BOARD_OPTIMISE_MMAP
+/*
  * PLAT_ARM_MMAP_ENTRIES depends on the number of entries in the
  * plat_arm_mmap array defined for each BL stage.
+ *
+ * Provide relatively optimised values for the runtime images (BL31 and BL32).
+ * Optimisation is less important for the other, transient boot images so a
+ * common, maximum value is used across these images.
  */
-#if IMAGE_BL1
-# if PLAT_fvp
-#  if TRUSTED_BOARD_BOOT
-#   define PLAT_ARM_MMAP_ENTRIES	8
-#  else
-#   define PLAT_ARM_MMAP_ENTRIES	7
-#  endif	/* TRUSTED_BOARD_BOOT */
-# else
-#  if TRUSTED_BOARD_BOOT
-#   define PLAT_ARM_MMAP_ENTRIES	7
-#  else
-#   define PLAT_ARM_MMAP_ENTRIES	6
-#  endif	/* TRUSTED_BOARD_BOOT */
-# endif		/* PLAT_ */
-#endif
-#if IMAGE_BL2
-# if PLAT_fvp
-#  define PLAT_ARM_MMAP_ENTRIES		9
-# else
-#  define PLAT_ARM_MMAP_ENTRIES		8
-# endif
-#endif
-#if IMAGE_BL2U
-# if PLAT_fvp
-#  define PLAT_ARM_MMAP_ENTRIES		3
-# else
-#  define PLAT_ARM_MMAP_ENTRIES		4
-#endif
-#endif
-#if IMAGE_BL31
-#define PLAT_ARM_MMAP_ENTRIES		5
-#endif
-#if IMAGE_BL32
-#define PLAT_ARM_MMAP_ENTRIES		4
+#if IMAGE_BL31 || IMAGE_BL32
+# define PLAT_ARM_MMAP_ENTRIES		6
+# define MAX_XLAT_TABLES		3
+#else
+# define PLAT_ARM_MMAP_ENTRIES		9
+# define MAX_XLAT_TABLES		4
 #endif
 
-/*
- * Platform specific page table and MMU setup constants
- */
-#if IMAGE_BL1
-# if TRUSTED_BOARD_BOOT
-#  define MAX_XLAT_TABLES		4
-# else
-#  if PLAT_juno
-#   define MAX_XLAT_TABLES		2
-#  else
-#   define MAX_XLAT_TABLES		3
-#  endif /* PLAT_ */
-# endif	/* TRUSTED_BOARD_BOOT */
-#elif IMAGE_BL2
-# if PLAT_juno
-#  define MAX_XLAT_TABLES		3
-# else
-#  define MAX_XLAT_TABLES		4
-# endif /* PLAT_ */
-#elif IMAGE_BL2U
-# if PLAT_juno
-#  define MAX_XLAT_TABLES		3
-# else
-#  define MAX_XLAT_TABLES		4
-# endif /* PLAT_ */
-#elif IMAGE_BL31
-# define MAX_XLAT_TABLES		2
-#elif IMAGE_BL32
-# if ARM_TSP_RAM_LOCATION_ID == ARM_DRAM_ID
-#  define MAX_XLAT_TABLES		3
-# else
-#  define MAX_XLAT_TABLES		2
-# endif
-#endif
-
+#endif /* ARM_BOARD_OPTIMISE_MMAP */
 
 #define MAX_IO_DEVICES			3
 #define MAX_IO_HANDLES			4

--- a/plat/arm/board/common/board_common.mk
+++ b/plat/arm/board/common/board_common.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2015-2016, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -54,3 +54,10 @@ ifneq (${TRUSTED_BOARD_BOOT},0)
     BL1_SOURCES		+=	plat/arm/board/common/board_arm_trusted_boot.c
     BL2_SOURCES		+=	plat/arm/board/common/board_arm_trusted_boot.c
 endif
+
+# This flag controls whether memory usage needs to be optimised
+ARM_BOARD_OPTIMISE_MMAP	?=	0
+
+# Process flags
+$(eval $(call assert_boolean,ARM_BOARD_OPTIMISE_MMAP))
+$(eval $(call add_define,ARM_BOARD_OPTIMISE_MMAP))

--- a/plat/arm/board/juno/include/platform_def.h
+++ b/plat/arm/board/juno/include/platform_def.h
@@ -70,6 +70,41 @@
 #define PLAT_ARM_TRUSTED_ROM_SIZE	0x00010000
 #endif /* TRUSTED_BOARD_BOOT */
 
+/*
+ * If ARM_BOARD_OPTIMISE_MMAP=0 then Juno uses the default, unoptimised values
+ * defined for ARM development platforms.
+ */
+#if ARM_BOARD_OPTIMISE_MMAP
+/*
+ * PLAT_ARM_MMAP_ENTRIES depends on the number of entries in the
+ * plat_arm_mmap array defined for each BL stage.
+ */
+#if IMAGE_BL1
+# define PLAT_ARM_MMAP_ENTRIES		7
+# define MAX_XLAT_TABLES		4
+#endif
+
+#if IMAGE_BL2
+# define PLAT_ARM_MMAP_ENTRIES		8
+# define MAX_XLAT_TABLES		3
+#endif
+
+#if IMAGE_BL2U
+# define PLAT_ARM_MMAP_ENTRIES		4
+# define MAX_XLAT_TABLES		3
+#endif
+
+#if IMAGE_BL31
+# define PLAT_ARM_MMAP_ENTRIES		5
+# define MAX_XLAT_TABLES		2
+#endif
+
+#if IMAGE_BL32
+# define PLAT_ARM_MMAP_ENTRIES		4
+# define MAX_XLAT_TABLES		3
+#endif
+
+#endif /* ARM_BOARD_OPTIMISE_MMAP */
 
 /* CCI related constants */
 #define PLAT_ARM_CCI_BASE		0x2c090000

--- a/plat/arm/board/juno/platform.mk
+++ b/plat/arm/board/juno/platform.mk
@@ -67,15 +67,18 @@ BL31_SOURCES		+=	lib/cpus/aarch64/cortex_a53.S		\
 				${JUNO_SECURITY_SOURCES}
 
 # Enable workarounds for selected Cortex-A57 erratas.
-ERRATA_A57_806969	:=	0
-ERRATA_A57_813420	:=	1
+ERRATA_A57_806969		:=	0
+ERRATA_A57_813420		:=	1
 
 # Enable option to skip L1 data cache flush during the Cortex-A57 cluster
 # power down sequence
 SKIP_A57_L1_FLUSH_PWR_DWN	:=	 1
 
 # Disable the PSCI platform compatibility layer
-ENABLE_PLAT_COMPAT	:= 	0
+ENABLE_PLAT_COMPAT		:= 	0
+
+# Enable memory map related constants optimisation
+ARM_BOARD_OPTIMISE_MMAP		:=	1
 
 include plat/arm/board/common/board_css.mk
 include plat/arm/common/arm_common.mk


### PR DESCRIPTION
`board_arm_def.h` contains multiple definitions of
`PLAT_ARM_MMAP_ENTRIES` and `MAX_XLAT_TABLES` that are optimised for
memory usage depending upon the chosen build configuration. To ease
maintenance of these constants, this patch replaces their multiple
definitions with a single set of definitions that will work on all ARM
platforms.

Platforms can override the defaults with optimal values by enabling the
`ARM_BOARD_OPTIMISE_MMAP` build option. An example has been provided in
the Juno ADP port.

Additionally, `PLAT_ARM_MMAP_ENTRIES` is increased by one to accomodate
future ARM platforms.

Change-Id: I5ba6490fdd1e118cc9cc2d988ad7e9c38492b6f0