### PR TITLE
Fix potential deadlock in PL011 init function

### DIFF
--- a/drivers/arm/pl011/pl011_console.S
+++ b/drivers/arm/pl011/pl011_console.S
@@ -69,15 +69,6 @@ func console_core_init
 	mov	w4, #PL011_UARTCR_UARTEN
 	bic	w3, w3, w4
 	str	w3, [x0, #UARTCR]
-	/* Flush the transmit FIFO */
-	ldr	w3, [x0, #UARTLCR_H]
-	mov	w4, #PL011_UARTLCR_H_FEN
-	bic	w3, w3, w4
-	str	w3, [x0, #UARTLCR_H]
-	/* Wait for the end of Tx of current character */
-busy_loop:
-	ldr	w3, [x0, #UARTFR]
-	tbnz	w3, #PL011_UARTFR_BUSY_BIT, busy_loop
 	/* Program the baudrate */
 	/* Divisor =  (Uart clock * 4) / baudrate */
 	lsl	w1, w1, #2


### PR DESCRIPTION
The PL011 initialization function disables the UART, flushes the FIFO
and waits for the current character to be transmitted before applying
the configuration and enabling the UART. This waiting might result in
a deadlock if the FIFO is disabled while another CPU is printing a
message since the flush of FIFO will never finish.

This patch fixes the problem by removing the flush operation and the
loop for last character completion from the initialization function.
The UART is disabled, configured and enabled again.

Change-Id: I1ca0b6bd9f352c12856f10f174a9f6eaca3ab4ea