### PR TITLE
Porting guide: Clarify API that don't follow AAPCS

### DIFF
--- a/docs/porting-guide.md
+++ b/docs/porting-guide.md
@@ -642,7 +642,8 @@ CPU-specific linear index into blocks of memory (for example while allocating
 per-CPU stacks). This function will be invoked very early in the
 initialization sequence which mandates that this function should be
 implemented in assembly and should not rely on the avalability of a C
-runtime environment.
+runtime environment. This function can clobber x0 - x8 and must preserve
+x9 - x29.
 
 This function plays a crucial role in the power domain topology framework in
 PSCI and details of this can be found in [Power Domain Topology Design].


### PR DESCRIPTION
This patch clarifies a porting API in the Porting Guide that do not
follow the ARM Architecture Program Calling Standards (AAPCS). The
list of registers that are allowed to be clobbered by this API has
been updated in the Porting Guide.

Fixes ARM-software/tf-issues#259

Change-Id: Ibf2adda2e1fb3e9b8f53d8a918d5998356eb8fce