### PR TITLE
Enable abort exception on Cortex A53 r0p2 and above

### DIFF
--- a/bl1/aarch64/bl1_arch_setup.c
+++ b/bl1/aarch64/bl1_arch_setup.c
@@ -38,7 +38,7 @@
 void bl1_arch_setup(void)
 {
 	/* Set the next EL to be AArch64 */
-	write_scr_el3(SCR_RES1_BITS | SCR_RW_BIT);
+	write_scr_el3(read_scr_el3() | SCR_RW_BIT);
 }
 
 /*******************************************************************************

--- a/bl31/aarch64/bl31_arch_setup.c
+++ b/bl31/aarch64/bl31_arch_setup.c
@@ -43,9 +43,6 @@
  ******************************************************************************/
 void bl31_arch_setup(void)
 {
-	/* Set the RES1 bits in the SCR_EL3 */
-	write_scr_el3(SCR_RES1_BITS);
-
 	/* Program the counter frequency */
 	write_cntfrq_el0(plat_get_syscnt_freq());
 

--- a/bl31/aarch64/crash_reporting.S
+++ b/bl31/aarch64/crash_reporting.S
@@ -70,7 +70,8 @@ non_el3_sys_regs:
 		"tpidrro_el0", "dacr32_el2", "ifsr32_el2", "par_el1",\
 		"mpidr_el1", "afsr0_el1", "afsr1_el1", "contextidr_el1",\
 		"vbar_el1", "cntp_ctl_el0", "cntp_cval_el0", "cntv_ctl_el0",\
-		"cntv_cval_el0", "cntkctl_el1", "fpexc32_el2", "sp_el0", ""
+		"cntv_cval_el0", "cntkctl_el1", "fpexc32_el2", "sp_el0",\
+		"isr_el1", ""
 
 panic_msg:
 	.asciz "PANIC in EL3 at x30 = 0x"
@@ -338,6 +339,7 @@ func do_crash_reporting
 	mrs	x8, cntkctl_el1
 	mrs	x9, fpexc32_el2
 	mrs	x10, sp_el0
+	mrs	x11, isr_el1
 	bl	str_in_crash_buf_print
 
 	/* Get the cpu specific registers to report */

--- a/common/context_mgmt.c
+++ b/common/context_mgmt.c
@@ -100,7 +100,7 @@ static void cm_init_context_common(cpu_context_t *ctx, const entry_point_info_t 
 	 */
 	scr_el3 = read_scr();
 	scr_el3 &= ~(SCR_NS_BIT | SCR_RW_BIT | SCR_FIQ_BIT | SCR_IRQ_BIT |
-			SCR_ST_BIT | SCR_HCE_BIT);
+		     SCR_ST_BIT | SCR_HCE_BIT);
 
 	if (security_state != SECURE)
 		scr_el3 |= SCR_NS_BIT;
@@ -110,6 +110,11 @@ static void cm_init_context_common(cpu_context_t *ctx, const entry_point_info_t 
 
 	if (EP_GET_ST(ep->h.attr))
 		scr_el3 |= SCR_ST_BIT;
+
+#ifndef HANDLE_EA_EL3_FIRST
+	/* Explicitly stop to trap aborts from lower exception levels. */
+	scr_el3 &= ~SCR_EA_BIT;
+#endif
 
 #if IMAGE_BL31
 	/*

--- a/include/common/el3_common_macros.S
+++ b/include/common/el3_common_macros.S
@@ -70,10 +70,12 @@
 	isb
 
 	/* ---------------------------------------------------------------------
-	 * Enable the SError interrupt now that the exception vectors have been
+	 * Enable the Abort interrupt now that the exception vectors have been
 	 * setup.
 	 * ---------------------------------------------------------------------
 	 */
+	mov	x0, #(SCR_RES1_BITS | SCR_EA_BIT)
+	msr	scr_el3, x0
 	msr	daifclr, #DAIF_ABT_BIT
 
 	/* ---------------------------------------------------------------------

--- a/include/lib/aarch64/arch.h
+++ b/include/lib/aarch64/arch.h
@@ -186,6 +186,11 @@
 #define HCR_IMO_BIT		(1 << 4)
 #define HCR_FMO_BIT		(1 << 3)
 
+/* ISR definitions */
+#define ISR_A_SHIFT		8
+#define ISR_I_SHIFT		7
+#define ISR_F_SHIFT		6
+
 /* CNTHCTL_EL2 definitions */
 #define EVNTEN_BIT		(1 << 2)
 #define EL1PCEN_BIT		(1 << 1)

--- a/include/lib/aarch64/arch_helpers.h
+++ b/include/lib/aarch64/arch_helpers.h
@@ -168,15 +168,6 @@ void disable_mmu_icache_el3(void);
 DEFINE_SYSREG_WRITE_CONST_FUNC(daifset)
 DEFINE_SYSREG_WRITE_CONST_FUNC(daifclr)
 
-#define enable_irq()			write_daifclr(DAIF_IRQ_BIT)
-#define enable_fiq()			write_daifclr(DAIF_FIQ_BIT)
-#define enable_serror()			write_daifclr(DAIF_ABT_BIT)
-#define enable_debug_exceptions()	write_daifclr(DAIF_DBG_BIT)
-#define disable_irq()			write_daifset(DAIF_IRQ_BIT)
-#define disable_fiq()			write_daifset(DAIF_FIQ_BIT)
-#define disable_serror()		write_daifset(DAIF_ABT_BIT)
-#define disable_debug_exceptions()	write_daifset(DAIF_DBG_BIT)
-
 DEFINE_SYSREG_READ_FUNC(par_el1)
 DEFINE_SYSREG_READ_FUNC(id_pfr1_el1)
 DEFINE_SYSREG_READ_FUNC(id_aa64pfr0_el1)


### PR DESCRIPTION
On p2 revision, despite what is stated in ARM DDI0500D TRM Cortex A53 r0p2
SCR_EL3 description in Table 4-77, asynchronous exceptions generated by the
code running in EL3 are not taken in EL3 when SCR_EL3[EA] is zero.
DDI0487A.b Architecture Reference Manual does not reflect the actual
behaviour of r0p2.

DDI0487A.e Architecture Reference Manual D7.2.80 SCR_EL3 description depicts
the observed behaviour.

fixes arm-software/tf-issues#368

Signed-off-by: Gerald Lejeune <gerald.lejeune@st.com>