### PR TITLE
Enable asynchronous abort exceptions

### DIFF
--- a/bl1/aarch64/bl1_arch_setup.c
+++ b/bl1/aarch64/bl1_arch_setup.c
@@ -38,7 +38,7 @@
 void bl1_arch_setup(void)
 {
 	/* Set the next EL to be AArch64 */
-	write_scr_el3(SCR_RES1_BITS | SCR_RW_BIT);
+	write_scr_el3(read_scr_el3() | SCR_RW_BIT);
 }
 
 /*******************************************************************************

--- a/bl1/aarch64/bl1_exceptions.S
+++ b/bl1/aarch64/bl1_exceptions.S
@@ -113,10 +113,13 @@ SErrorSPx:
 	 */
 	.align	7
 SynchronousExceptionA64:
-	/* Enable the SError interrupt */
-	msr	daifclr, #DAIF_ABT_BIT
-
 	str	x30, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_LR]
+
+	/*
+	 * Assume that BL2 did not left a pending abort.
+	 * Use a function to get rid of the vector size overflow.
+	 */
+	enable_abort	x30
 
 	/* Expect only SMC exceptions */
 	mrs	x30, esr_el3

--- a/bl31/aarch64/bl31_arch_setup.c
+++ b/bl31/aarch64/bl31_arch_setup.c
@@ -43,9 +43,6 @@
  ******************************************************************************/
 void bl31_arch_setup(void)
 {
-	/* Set the RES1 bits in the SCR_EL3 */
-	write_scr_el3(SCR_RES1_BITS);
-
 	/* Program the counter frequency */
 	write_cntfrq_el0(plat_get_syscnt_freq());
 

--- a/bl31/aarch64/crash_reporting.S
+++ b/bl31/aarch64/crash_reporting.S
@@ -352,6 +352,9 @@ func do_crash_reporting
 	/* Print the interconnect registers */
 	plat_print_interconnect_regs
 
+	/* Print the some platform registers */
+	plat_print_misc_regs
+
 	/* Done reporting */
 	b	crash_panic
 endfunc do_crash_reporting

--- a/bl31/aarch64/crash_reporting.S
+++ b/bl31/aarch64/crash_reporting.S
@@ -70,7 +70,8 @@ non_el3_sys_regs:
 		"tpidrro_el0", "dacr32_el2", "ifsr32_el2", "par_el1",\
 		"mpidr_el1", "afsr0_el1", "afsr1_el1", "contextidr_el1",\
 		"vbar_el1", "cntp_ctl_el0", "cntp_cval_el0", "cntv_ctl_el0",\
-		"cntv_cval_el0", "cntkctl_el1", "fpexc32_el2", "sp_el0", ""
+		"cntv_cval_el0", "cntkctl_el1", "fpexc32_el2", "sp_el0",\
+		"isr_el1", ""
 
 panic_msg:
 	.asciz "PANIC in EL3 at x30 = 0x"
@@ -338,6 +339,7 @@ func do_crash_reporting
 	mrs	x8, cntkctl_el1
 	mrs	x9, fpexc32_el2
 	mrs	x10, sp_el0
+	mrs	x11, isr_el1
 	bl	str_in_crash_buf_print
 
 	/* Get the cpu specific registers to report */

--- a/bl31/aarch64/runtime_exceptions.S
+++ b/bl31/aarch64/runtime_exceptions.S
@@ -43,9 +43,6 @@
 	 * -----------------------------------------------------
 	 */
 	.macro	handle_sync_exception
-	/* Enable the SError interrupt */
-	msr	daifclr, #DAIF_ABT_BIT
-
 	str	x30, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_LR]
 	mrs	x30, esr_el3
 	ubfx	x30, x30, #ESR_EC_SHIFT, #ESR_EC_LENGTH
@@ -72,9 +69,6 @@
 	 * -----------------------------------------------------
 	 */
 	.macro	handle_interrupt_exception label
-	/* Enable the SError interrupt */
-	msr	daifclr, #DAIF_ABT_BIT
-
 	str	x30, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_LR]
 	bl	save_gp_registers
 
@@ -85,6 +79,9 @@
 	mrs	x0, spsr_el3
 	mrs	x1, elr_el3
 	stp	x0, x1, [sp, #CTX_EL3STATE_OFFSET + CTX_SPSR_EL3]
+
+	/* Enable the Abort interrupt */
+	enable_abort	x0
 
 	/* Switch to the runtime stack i.e. SP_EL0 */
 	ldr	x2, [sp, #CTX_EL3STATE_OFFSET + CTX_RUNTIME_SP]
@@ -412,6 +409,9 @@ smc_handler64:
 	bfi	x7, x18, #0, #1
 
 	mov	sp, x12
+
+	/* Enable the Abort interrupt */
+	enable_abort	x10
 
 	/* -----------------------------------------------------
 	 * Call the Secure Monitor Call handler and then drop

--- a/common/context_mgmt.c
+++ b/common/context_mgmt.c
@@ -100,7 +100,7 @@ static void cm_init_context_common(cpu_context_t *ctx, const entry_point_info_t 
 	 */
 	scr_el3 = read_scr();
 	scr_el3 &= ~(SCR_NS_BIT | SCR_RW_BIT | SCR_FIQ_BIT | SCR_IRQ_BIT |
-			SCR_ST_BIT | SCR_HCE_BIT);
+		     SCR_ST_BIT | SCR_HCE_BIT);
 
 	if (security_state != SECURE)
 		scr_el3 |= SCR_NS_BIT;
@@ -110,6 +110,9 @@ static void cm_init_context_common(cpu_context_t *ctx, const entry_point_info_t 
 
 	if (EP_GET_ST(ep->h.attr))
 		scr_el3 |= SCR_ST_BIT;
+
+	/* Explicitly stop to trap aborts from lower exception levels. */
+	scr_el3 &= ~SCR_EA_BIT;
 
 #if IMAGE_BL31
 	/*

--- a/include/common/asm_macros.S
+++ b/include/common/asm_macros.S
@@ -123,6 +123,20 @@
 #endif
 
 	/*
+	 * Grab possible SError interrupts triggered by EL3 itself else they
+	 * will unexpectedly land in EL1.
+	 * If there was a pending Abort interrupt coming from lower exception
+	 * levels, it will be thrown here. ISR_EL1.A bit will denote it.
+	 * Maul one 64bit register.
+	 */
+	.macro enable_abort x0
+	msr	daifclr, #DAIF_ABT_BIT
+	mrs	\x0, scr_el3
+	orr	\x0, \x0, #SCR_EA_BIT
+	msr	scr_el3, \x0
+	.endm
+
+	/*
 	 * This macro declares an array of 1 or more stacks, properly
 	 * aligned and in the requested section
 	 */

--- a/include/common/el3_common_macros.S
+++ b/include/common/el3_common_macros.S
@@ -70,11 +70,19 @@
 	isb
 
 	/* ---------------------------------------------------------------------
-	 * Enable the SError interrupt now that the exception vectors have been
-	 * setup.
+	 * Early set the RES1 bits in the SCR_EL3 so that it could be modified
+	 * safely afterwards.
 	 * ---------------------------------------------------------------------
 	 */
-	msr	daifclr, #DAIF_ABT_BIT
+	mov	x0, #SCR_RES1_BITS
+	msr	scr_el3, x0
+
+	/* ---------------------------------------------------------------------
+	 * Enable the Abort interrupt now that the exception vectors have been
+	 * setup.
+	 * ---------------------------------------------------------------------
+ 	 */
+	enable_abort	x0
 
 	/* ---------------------------------------------------------------------
 	 * The initial state of the Architectural feature trap register

--- a/include/lib/aarch64/arch.h
+++ b/include/lib/aarch64/arch.h
@@ -186,6 +186,11 @@
 #define HCR_IMO_BIT		(1 << 4)
 #define HCR_FMO_BIT		(1 << 3)
 
+/* ISR definitions */
+#define ISR_A_SHIFT		8
+#define ISR_I_SHIFT		7
+#define ISR_F_SHIFT		6
+
 /* CNTHCTL_EL2 definitions */
 #define EVNTEN_BIT		(1 << 2)
 #define EL1PCEN_BIT		(1 << 1)

--- a/include/lib/aarch64/arch_helpers.h
+++ b/include/lib/aarch64/arch_helpers.h
@@ -168,15 +168,6 @@ void disable_mmu_icache_el3(void);
 DEFINE_SYSREG_WRITE_CONST_FUNC(daifset)
 DEFINE_SYSREG_WRITE_CONST_FUNC(daifclr)
 
-#define enable_irq()			write_daifclr(DAIF_IRQ_BIT)
-#define enable_fiq()			write_daifclr(DAIF_FIQ_BIT)
-#define enable_serror()			write_daifclr(DAIF_ABT_BIT)
-#define enable_debug_exceptions()	write_daifclr(DAIF_DBG_BIT)
-#define disable_irq()			write_daifset(DAIF_IRQ_BIT)
-#define disable_fiq()			write_daifset(DAIF_FIQ_BIT)
-#define disable_serror()		write_daifset(DAIF_ABT_BIT)
-#define disable_debug_exceptions()	write_daifset(DAIF_DBG_BIT)
-
 DEFINE_SYSREG_READ_FUNC(par_el1)
 DEFINE_SYSREG_READ_FUNC(id_pfr1_el1)
 DEFINE_SYSREG_READ_FUNC(id_aa64pfr0_el1)

--- a/plat/mediatek/mt8173/include/plat_macros.S
+++ b/plat/mediatek/mt8173/include/plat_macros.S
@@ -108,3 +108,14 @@ cci_iface_regs:
 	/* Store to the crash buf and print to console */
 	bl	str_in_crash_buf_print
 	.endm
+
+	/* ------------------------------------------------
+	 * The below macro prints out relevant platform
+	 * registers whenever an unhandled exception is
+	 * taken in BL3-1.
+	 * It's a stub here.
+	 * ------------------------------------------------
+	 */
+	.macro plat_print_misc_regs
+	nop
+	.endm

--- a/plat/nvidia/tegra/include/plat_macros.S
+++ b/plat/nvidia/tegra/include/plat_macros.S
@@ -91,4 +91,14 @@ spacer:
 	nop
 .endm
 
+/* ------------------------------------------------
+ * The below macro prints out relevant platform
+ * registers whenever an unhandled exception is
+ * taken in BL3-1.
+ * It's a stub here.
+ * ------------------------------------------------
+ */
+.macro plat_print_misc_regs
+	nop
+.endm
 #endif /* __PLAT_MACROS_S__ */


### PR DESCRIPTION
On r0p2 revision and above revision, despite what is stated in ARM DDI0500D TRM
Cortex A53 r0p2 SCR_EL3 description in Table 4-77, asynchronous exceptions
generated by the code running in EL3 are not taken in EL3 when SCR_EL3[EA] is
zero.
DDI0487A.b Architecture Reference Manual does not reflect the actual
behaviour of r0p2.

DDI0487A.e Architecture Reference Manual D7.2.80 SCR_EL3 description depicts
the observed behaviour.

Fixes arm-software/tf-issues#368

Signed-off-by: Gerald Lejeune <gerald.lejeune@st.com>