### PR TITLE
std_svc: psci: introduce handler for system suspend

### DIFF
--- a/services/std_svc/psci/psci_main.c
+++ b/services/std_svc/psci/psci_main.c
@@ -147,7 +147,6 @@ int psci_cpu_suspend(unsigned int power_state,
 	return PSCI_E_SUCCESS;
 }
 
-
 int psci_system_suspend(uintptr_t entrypoint, u_register_t context_id)
 {
 	int rc;
@@ -173,16 +172,14 @@ int psci_system_suspend(uintptr_t entrypoint, u_register_t context_id)
 	assert(is_local_state_off(state_info.pwr_domain_state[PLAT_MAX_PWR_LVL]));
 
 	/*
-	 * Do what is needed to enter the system suspend state. This function
-	 * might return if the power down was abandoned for any reason, e.g.
-	 * arrival of an interrupt
+	 * Do what is needed to enter the system suspend state.
 	 */
-	psci_cpu_suspend_start(&ep,
-			    PLAT_MAX_PWR_LVL,
-			    &state_info,
-			    PSTATE_TYPE_POWERDOWN);
+	psci_system_suspend_start(&ep, &state_info);
 
-	return PSCI_E_SUCCESS;
+	/*
+	 * We should not return here upon exiting system suspend state.
+	 */
+	panic();
 }
 
 int psci_cpu_off(void)

--- a/services/std_svc/psci/psci_private.h
+++ b/services/std_svc/psci/psci_private.h
@@ -213,6 +213,8 @@ void psci_cpu_on_finish(unsigned int cpu_idx,
 int psci_do_cpu_off(unsigned int end_pwrlvl);
 
 /* Private exported functions from psci_suspend.c */
+void psci_system_suspend_start(entry_point_info_t *ep,
+			       psci_power_state_t *state_info);
 void psci_cpu_suspend_start(entry_point_info_t *ep,
 			unsigned int end_pwrlvl,
 			psci_power_state_t *state_info,


### PR DESCRIPTION
System Suspend needs to be executed on the last standing CPU and
psci_system_suspend() makes sure of that. The real problem with
the current code is that it acquires locks further into the CPU
suspend sequence even for the system suspend case. This seems
unnecessary and adds to the entry latency times.

This patch introduces a separate handler for the system suspend
case which does not acquire any locks and hence reduces the
entry time into the state.

Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>