### PR TITLE
Enable asynchronous abort exceptions during boot

### DIFF
--- a/bl1/aarch64/bl1_arch_setup.c
+++ b/bl1/aarch64/bl1_arch_setup.c
@@ -38,7 +38,7 @@
 void bl1_arch_setup(void)
 {
 	/* Set the next EL to be AArch64 */
-	write_scr_el3(SCR_RES1_BITS | SCR_RW_BIT);
+	write_scr_el3(read_scr_el3() | SCR_RW_BIT);
 }
 
 /*******************************************************************************

--- a/bl31/aarch64/bl31_arch_setup.c
+++ b/bl31/aarch64/bl31_arch_setup.c
@@ -43,9 +43,6 @@
  ******************************************************************************/
 void bl31_arch_setup(void)
 {
-	/* Set the RES1 bits in the SCR_EL3 */
-	write_scr_el3(SCR_RES1_BITS);
-
 	/* Program the counter frequency */
 	write_cntfrq_el0(plat_get_syscnt_freq());
 

--- a/bl31/aarch64/crash_reporting.S
+++ b/bl31/aarch64/crash_reporting.S
@@ -70,7 +70,8 @@ non_el3_sys_regs:
 		"tpidrro_el0", "dacr32_el2", "ifsr32_el2", "par_el1",\
 		"mpidr_el1", "afsr0_el1", "afsr1_el1", "contextidr_el1",\
 		"vbar_el1", "cntp_ctl_el0", "cntp_cval_el0", "cntv_ctl_el0",\
-		"cntv_cval_el0", "cntkctl_el1", "fpexc32_el2", "sp_el0", ""
+		"cntv_cval_el0", "cntkctl_el1", "fpexc32_el2", "sp_el0",\
+		"isr_el1", ""
 
 panic_msg:
 	.asciz "PANIC in EL3 at x30 = 0x"
@@ -338,6 +339,7 @@ func do_crash_reporting
 	mrs	x8, cntkctl_el1
 	mrs	x9, fpexc32_el2
 	mrs	x10, sp_el0
+	mrs	x11, isr_el1
 	bl	str_in_crash_buf_print
 
 	/* Get the cpu specific registers to report */

--- a/common/context_mgmt.c
+++ b/common/context_mgmt.c
@@ -111,6 +111,11 @@ static void cm_init_context_common(cpu_context_t *ctx, const entry_point_info_t 
 	if (EP_GET_ST(ep->h.attr))
 		scr_el3 |= SCR_ST_BIT;
 
+#ifndef HANDLE_EA_EL3_FIRST
+	/* Explicitly stop to trap aborts from lower exception levels. */
+	scr_el3 &= ~SCR_EA_BIT;
+#endif
+
 #if IMAGE_BL31
 	/*
 	 * IRQ/FIQ bits only need setting if interrupt routing

--- a/docs/firmware-design.md
+++ b/docs/firmware-design.md
@@ -174,8 +174,9 @@ BL1 performs minimal architectural initialization as follows.
         `SCTLR_EL3.A` and `SCTLR_EL3.SA` bits. Exception endianness is set to
         little-endian by clearing the `SCTLR_EL3.EE` bit.
 
-    -  `SCR_EL3`. The register width of the next lower exception level is set to
-        AArch64 by setting the `SCR.RW` bit.
+    -  `SCR_EL3`. The register width of the next lower exception level is set
+        to AArch64 by setting the `SCR.RW` bit. The `SCR.EA` bit is set to trap
+        both External Aborts and SError Interrupts in EL3.
 
     -   `CPTR_EL3`. Accesses to the `CPACR_EL1` register from EL1 or EL2, or the
         `CPTR_EL2` register from EL2 are configured to not trap to EL3 by

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -439,6 +439,9 @@ performed.
     where applicable). Defaults to a string that contains the time and date of
     the compilation.
 
+*   `HANDLE_EA_EL3_FIRST`: When defined External Aborts and SError Interrupts
+    will be always trapped in EL3 i.e. in BL31 at runtime.
+
 #### ARM development platform specific build options
 
 *   `ARM_TSP_RAM_LOCATION`: location of the TSP binary. Options:

--- a/include/common/el3_common_macros.S
+++ b/include/common/el3_common_macros.S
@@ -70,8 +70,15 @@
 	isb
 
 	/* ---------------------------------------------------------------------
-	 * Enable the SError interrupt now that the exception vectors have been
-	 * setup.
+	 * Early set RES1 bits in SCR_EL3. Set EA bit as well to catch both
+	 * External Aborts and SError Interrupts in EL3.
+	 * ---------------------------------------------------------------------
+	 */
+	mov	x0, #(SCR_RES1_BITS | SCR_EA_BIT)
+	msr	scr_el3, x0
+	/* ---------------------------------------------------------------------
+	 * Enable External Aborts and SError Interrupts now that the exception
+	 * vectors have been setup.
 	 * ---------------------------------------------------------------------
 	 */
 	msr	daifclr, #DAIF_ABT_BIT

--- a/include/lib/aarch64/arch.h
+++ b/include/lib/aarch64/arch.h
@@ -186,6 +186,11 @@
 #define HCR_IMO_BIT		(1 << 4)
 #define HCR_FMO_BIT		(1 << 3)
 
+/* ISR definitions */
+#define ISR_A_SHIFT		8
+#define ISR_I_SHIFT		7
+#define ISR_F_SHIFT		6
+
 /* CNTHCTL_EL2 definitions */
 #define EVNTEN_BIT		(1 << 2)
 #define EL1PCEN_BIT		(1 << 1)

--- a/include/lib/aarch64/arch_helpers.h
+++ b/include/lib/aarch64/arch_helpers.h
@@ -168,15 +168,6 @@ void disable_mmu_icache_el3(void);
 DEFINE_SYSREG_WRITE_CONST_FUNC(daifset)
 DEFINE_SYSREG_WRITE_CONST_FUNC(daifclr)
 
-#define enable_irq()			write_daifclr(DAIF_IRQ_BIT)
-#define enable_fiq()			write_daifclr(DAIF_FIQ_BIT)
-#define enable_serror()			write_daifclr(DAIF_ABT_BIT)
-#define enable_debug_exceptions()	write_daifclr(DAIF_DBG_BIT)
-#define disable_irq()			write_daifset(DAIF_IRQ_BIT)
-#define disable_fiq()			write_daifset(DAIF_FIQ_BIT)
-#define disable_serror()		write_daifset(DAIF_ABT_BIT)
-#define disable_debug_exceptions()	write_daifset(DAIF_DBG_BIT)
-
 DEFINE_SYSREG_READ_FUNC(par_el1)
 DEFINE_SYSREG_READ_FUNC(id_pfr1_el1)
 DEFINE_SYSREG_READ_FUNC(id_aa64pfr0_el1)


### PR DESCRIPTION
On r0p2 revision and above revision, despite what is stated in ARM DDI0500D TRM
Cortex A53 r0p2 SCR_EL3 description in Table 4-77, asynchronous exceptions
generated by the code running in EL3 are not taken in EL3 when SCR_EL3[EA] is
zero.
DDI0487A.b Architecture Reference Manual does not reflect the actual
behaviour of r0p2.

DDI0487A.e Architecture Reference Manual D7.2.80 SCR_EL3 description depicts
the observed behaviour.

Fixes arm-software/tf-issues#368

Signed-off-by: Gerald Lejeune <gerald.lejeune@st.com>