### PR TITLE
Make cpu operations warning a VERBOSE print

### DIFF
--- a/include/common/debug.h
+++ b/include/common/debug.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2016, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -31,8 +31,6 @@
 #ifndef __DEBUG_H__
 #define __DEBUG_H__
 
-#include <stdio.h>
-
 /* The log output macros print output to the console. These macros produce
  * compiled log output only if the LOG_LEVEL defined in the makefile (or the
  * make command line) is greater or equal than the level required for that
@@ -49,6 +47,8 @@
 #define LOG_LEVEL_INFO			40
 #define LOG_LEVEL_VERBOSE		50
 
+#ifndef __ASSEMBLY__
+#include <stdio.h>
 
 #if LOG_LEVEL >= LOG_LEVEL_NOTICE
 # define NOTICE(...)	tf_printf("NOTICE:  " __VA_ARGS__)
@@ -86,4 +86,5 @@ void __dead2 do_panic(void);
 
 void tf_printf(const char *fmt, ...) __printflike(1, 2);
 
+#endif /* __ASSEMBLY__ */
 #endif /* __DEBUG_H__ */

--- a/lib/cpus/aarch64/cortex_a53.S
+++ b/lib/cpus/aarch64/cortex_a53.S
@@ -32,6 +32,7 @@
 #include <bl_common.h>
 #include <cortex_a53.h>
 #include <cpu_macros.S>
+#include <debug.h>
 #include <plat_macros.S>
 
 	/* ---------------------------------------------
@@ -73,7 +74,7 @@ func errata_a53_826319_wa
 	 */
 	cmp	x0, #2
 	b.ls	apply_826319
-#if DEBUG
+#if LOG_LEVEL >= LOG_LEVEL_VERBOSE
 	b	print_revision_warning
 #else
 	ret
@@ -109,7 +110,7 @@ func a53_disable_non_temporal_hint
 	 */
 	cmp	x0, #3
 	b.ls	disable_hint
-#if DEBUG
+#if LOG_LEVEL >= LOG_LEVEL_VERBOSE
 	b	print_revision_warning
 #else
 	ret

--- a/lib/cpus/aarch64/cortex_a57.S
+++ b/lib/cpus/aarch64/cortex_a57.S
@@ -33,6 +33,7 @@
 #include <bl_common.h>
 #include <cortex_a57.h>
 #include <cpu_macros.S>
+#include <debug.h>
 #include <plat_macros.S>
 
 	/* ---------------------------------------------
@@ -99,7 +100,7 @@ func errata_a57_806969_wa
 	 * Compare x0 against revision r0p0
 	 */
 	cbz	x0, apply_806969
-#if DEBUG
+#if LOG_LEVEL >= LOG_LEVEL_VERBOSE
 	b	print_revision_warning
 #else
 	ret
@@ -125,7 +126,7 @@ func errata_a57_813420_wa
 	 * Compare x0 against revision r0p0
 	 */
 	cbz	x0, apply_813420
-#if DEBUG
+#if LOG_LEVEL >= LOG_LEVEL_VERBOSE
 	b	print_revision_warning
 #else
 	ret
@@ -154,7 +155,7 @@ func a57_disable_ldnp_overread
 	 */
 	cmp	x0, #0x12
 	b.ls	disable_hint
-#if DEBUG
+#if LOG_LEVEL >= LOG_LEVEL_VERBOSE
 	b	print_revision_warning
 #else
 	ret

--- a/lib/cpus/aarch64/cpu_helpers.S
+++ b/lib/cpus/aarch64/cpu_helpers.S
@@ -35,6 +35,7 @@
 #if IMAGE_BL31
 #include <cpu_data.h>
 #endif
+#include <debug.h>
 
  /* Reset fn is needed in BL at reset vector */
 #if IMAGE_BL1 || IMAGE_BL31
@@ -204,10 +205,10 @@ error_exit:
 	ret
 endfunc get_cpu_ops_ptr
 
-#if DEBUG
-.section .rodata.rev_warn_str, "aS"
-rev_warn_str:
-	.asciz "Warning: Skipping CPU specific reset operation for non-matching CPU revision number.\n"
+#if LOG_LEVEL >= LOG_LEVEL_VERBOSE
+.section .rodata.rev_verbose_str, "aS"
+rev_verbose_str:
+	.asciz "VERBOSE: Skipping CPU specific reset operation for non-matching CPU revision number.\n"
 
 	/*
 	 * This function prints the above warning message to the crash console.
@@ -224,7 +225,7 @@ func print_revision_warning
 	/* Check if the console is initialized */
 	cbz	x0, 1f
 	/* The console is initialized */
-	adr	x4, rev_warn_str
+	adr	x4, rev_verbose_str
 	bl	asm_print_str
 1:
 	ret	x5


### PR DESCRIPTION
The assembler helper function `print_revision_warning` is used when a
CPU specific operation is enabled in the debug build (e.g. an errata
workaround) but doesn't apply to the executing CPU's revision/part number.
However, in some cases the system integrator may want a single binary to
support multiple platforms with different IP versions, only some of which
contain a specific erratum.  In this case, the warning can be emitted very
frequently when CPUs are being powered on/off.

This patch modifies this warning print behaviour so that it is emitted only
when LOG_LEVEL >= LOG_LEVEL_VERBOSE. The `debug.h` header file now contains
guard macros so that it can be included in assembly code.

Change-Id: Ic6e7a07f128dcdb8498a5bfdae920a8feeea1345