### PR TITLE
fix compiler warning in psci_set_req_local_pwr_state

### DIFF
--- a/services/std_svc/psci/psci_common.c
+++ b/services/std_svc/psci/psci_common.c
@@ -217,6 +217,8 @@ static void psci_set_req_local_pwr_state(unsigned int pwrlvl,
 					 plat_local_state_t req_pwr_state)
 {
 	assert(pwrlvl > PSCI_CPU_PWR_LVL);
+	assert(pwrlvl <= PSCI_MAX_PWR_LVL);
+
 	psci_req_local_pwr_states[pwrlvl - 1][cpu_idx] = req_pwr_state;
 }
 


### PR DESCRIPTION
add missing assert to range check input parameter.
This fixes a warning emitted by gcc5.1 compiler.

Fixes arm-software/tf-issues#379

Signed-off-by: Mathieu Rondonneau <mathieu.rondonneau@broadcom.com>
Signed-off-by: Scott Branden <scott.branden@broadcom.com>