### PR TITLE
Add runtime support of trusted_board_boot

### DIFF
--- a/drivers/auth/auth_mod.c
+++ b/drivers/auth/auth_mod.c
@@ -307,8 +307,12 @@ int auth_mod_verify_img(unsigned int img_id,
 					img_desc, img_ptr, img_len);
 			break;
 		case AUTH_METHOD_SIG:
-			rc = auth_signature(&auth_method->param.sig,
-					img_desc, img_ptr, img_len);
+			if (plat_is_trusted_boot()) {
+				rc = auth_signature(&auth_method->param.sig,
+						img_desc, img_ptr, img_len);
+			} else {
+				rc = 0;
+			}
 			break;
 		default:
 			/* Unknown authentication method */

--- a/include/plat/common/platform.h
+++ b/include/plat/common/platform.h
@@ -249,6 +249,7 @@ void bl32_plat_enable_mmu(uint32_t flags);
  ******************************************************************************/
 int plat_get_rotpk_info(void *cookie, void **key_ptr, unsigned int *key_len,
 			unsigned int *flags);
+int plat_is_trusted_boot(void);
 
 #if ENABLE_PLAT_COMPAT
 /*

--- a/plat/arm/board/common/board_arm_trusted_boot.c
+++ b/plat/arm/board/common/board_arm_trusted_boot.c
@@ -36,6 +36,7 @@
 
 /* Weak definition may be overridden in specific platform */
 #pragma weak plat_match_rotpk
+#pragma weak plat_is_trusted_boot
 
 /* SHA256 algorithm */
 #define SHA256_BYTES			32
@@ -148,3 +149,7 @@ int plat_get_rotpk_info(void *cookie, void **key_ptr, unsigned int *key_len,
 	return 0;
 }
 
+int plat_is_trusted_boot(void)
+{
+	return TRUSTED_BOARD_BOOT;
+}


### PR DESCRIPTION
Introduce plat_is_trusted_boot to determine if signature checks
should be done on image or not.

The plat_is_trusted_boot can be implemented on a per platform basis.

Fixes ARM-software/tf-issues#381

Signed-off-by: Scott Branden <scott.branden@broadcom.com>