### PR TITLE
Add support for --plat-toc-flags

### DIFF
--- a/docs/firmware-design.md
+++ b/docs/firmware-design.md
@@ -1522,7 +1522,10 @@ ARM Trusted firmware.
 The ToC header has the following fields:
     `name`: The name of the ToC. This is currently used to validate the header.
     `serial_number`: A non-zero number provided by the creation tool
-    `flags`: Flags associated with this data. None are yet defined.
+    `flags`: Flags associated with this data.
+        Bits 0-31: Reserved
+        Bits 32-47: Platform defined
+        Bits 48-63: Reserved
 
 A ToC entry has the following fields:
     `uuid`: All files are referred to by a pre-defined Universally Unique

--- a/make_helpers/tbbr/tbbr_tools.mk
+++ b/make_helpers/tbbr/tbbr_tools.mk
@@ -41,6 +41,7 @@
 #   BL31: image filename (optional). Default is IMG_BIN(31)
 #   BL32: image filename (optional). Default is IMG_BIN(32)
 #   BL33: image filename (optional). Default is IMG_BIN(33)
+#   PLAT_TOC_FLAGS: 16-bit plat specific flags in toc (optional). Default is 0
 #
 # Build options added by this file:
 #
@@ -134,3 +135,6 @@ endif
 ifneq (${NS_BL2U},)
     $(eval $(call FWU_CERT_ADD_CMD_OPT,${NS_BL2U},--fwu,true))
 endif
+
+# Add the toc_flags to the FIP header (optional)
+$(if $(PLAT_TOC_FLAGS),$(eval $(call FIP_ADD_PAYLOAD,$(PLAT_TOC_FLAGS),--plat-toc-flags)))


### PR DESCRIPTION
Add a --plat-toc-flags option to the fip_create tool.
By defining PLAT_TOC_FLAGS a 16-bit field in the flags field of the
ToC header is populated.

Fixes ARM-software/tf-issues#361

Signed-off-by Scott Branden <scott.branden@broadcom.com>