### PR TITLE
Add support to load BL31 in DRAM

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -495,6 +495,12 @@ map is explained in the [Firmware Design].
     that wish to optimise memory usage for page tables need to set this flag to 1
     and must override the related macros.
 
+*   'ARM_BL31_IN_DRAM': Boolean option to select loading of BL31 in TZC secured
+    DRAM. By default, BL31 is in the secure SRAM. Set this flag to 1 to load
+    BL31 in TZC secured DRAM. If TSP is present, then setting this option also
+    sets the TSP location to DRAM and ignores the `ARM_TSP_RAM_LOCATION` build
+    flag.
+
 #### ARM CSS platform specific build options
 
 *   `CSS_DETECT_PRE_1_7_0_SCP`: Boolean flag to detect SCP version

--- a/include/plat/arm/board/common/board_arm_def.h
+++ b/include/plat/arm/board/common/board_arm_def.h
@@ -75,10 +75,10 @@
  */
 #if IMAGE_BL31 || IMAGE_BL32
 # define PLAT_ARM_MMAP_ENTRIES		6
-# define MAX_XLAT_TABLES		3
-#else
-# define PLAT_ARM_MMAP_ENTRIES		9
 # define MAX_XLAT_TABLES		4
+#else
+# define PLAT_ARM_MMAP_ENTRIES		10
+# define MAX_XLAT_TABLES		5
 #endif
 
 #endif /* ARM_BOARD_OPTIMISE_MMAP */

--- a/plat/arm/board/fvp/aarch64/fvp_common.c
+++ b/plat/arm/board/fvp/aarch64/fvp_common.c
@@ -97,6 +97,9 @@ const mmap_region_t plat_arm_mmap[] = {
 	MAP_DEVICE2,
 	ARM_MAP_NS_DRAM1,
 	ARM_MAP_TSP_SEC_MEM,
+#if ARM_BL31_IN_DRAM
+	ARM_MAP_BL31_SEC_DRAM,
+#endif
 	{0}
 };
 #endif

--- a/plat/arm/board/fvp/include/platform_def.h
+++ b/plat/arm/board/fvp/include/platform_def.h
@@ -146,11 +146,7 @@
  * PLAT_ARM_MAX_BL1_RW_SIZE is calculated using the current BL1 RW debug size
  * plus a little space for growth.
  */
-#if TRUSTED_BOARD_BOOT
-# define PLAT_ARM_MAX_BL1_RW_SIZE	0x9000
-#else
-# define PLAT_ARM_MAX_BL1_RW_SIZE	0x6000
-#endif
+#define PLAT_ARM_MAX_BL1_RW_SIZE	0xA000
 
 /*
  * PLAT_ARM_MAX_BL2_SIZE is calculated using the current BL2 debug size plus a

--- a/plat/arm/common/arm_bl2_setup.c
+++ b/plat/arm/common/arm_bl2_setup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2016, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -96,11 +96,27 @@ static bl2_to_bl31_params_mem_t bl31_params_mem;
 #pragma weak bl2_plat_get_bl33_meminfo
 #pragma weak bl2_plat_set_bl33_ep_info
 
+#if ARM_BL31_IN_DRAM
+meminfo_t *bl2_plat_sec_mem_layout(void)
+{
+	static meminfo_t bl2_dram_layout
+		__aligned(CACHE_WRITEBACK_GRANULE) = {
+		.total_base = BL31_BASE,
+		.total_size = (ARM_AP_TZC_DRAM1_BASE +
+				ARM_AP_TZC_DRAM1_SIZE) - BL31_BASE,
+		.free_base = BL31_BASE,
+		.free_size = (ARM_AP_TZC_DRAM1_BASE +
+				ARM_AP_TZC_DRAM1_SIZE) - BL31_BASE
+	};
 
+	return &bl2_dram_layout;
+}
+#else
 meminfo_t *bl2_plat_sec_mem_layout(void)
 {
 	return &bl2_tzram_layout;
 }
+#endif
 
 /*******************************************************************************
  * This function assigns a pointer to the memory that the platform has kept

--- a/plat/arm/common/arm_common.mk
+++ b/plat/arm/common/arm_common.mk
@@ -77,6 +77,11 @@ ARM_CONFIG_CNTACR		:=	1
 $(eval $(call assert_boolean,ARM_CONFIG_CNTACR))
 $(eval $(call add_define,ARM_CONFIG_CNTACR))
 
+# Process ARM_BL31_IN_DRAM flag
+ARM_BL31_IN_DRAM		:=	0
+$(eval $(call assert_boolean,ARM_BL31_IN_DRAM))
+$(eval $(call add_define,ARM_BL31_IN_DRAM))
+
 PLAT_INCLUDES		+=	-Iinclude/common/tbbr				\
 				-Iinclude/plat/arm/common			\
 				-Iinclude/plat/arm/common/aarch64


### PR DESCRIPTION
This patch adds an option to the ARM common platforms to load BL31 in the
TZC secured DRAM instead of the default secure SRAM.

To enable this feature, set `ARM_BL31_IN_DRAM` to 1 in build options.
If TSP is present, then setting this option also sets the TSP location
to DRAM and ignores the `ARM_TSP_RAM_LOCATION` build flag.

To use this feature, BL2 platform code must map in the DRAM used by
BL31. The macro ARM_MAP_BL31_SEC_DRAM is provided for this purpose.
Currently, only the FVP BL2 platform code maps in this DRAM.

Change-Id: If5f7cc9deb569cfe68353a174d4caa48acd78d67