### PR TITLE
mt8173: Protect BL31 memory from non-secure access

### DIFF
--- a/plat/mediatek/mt8173/drivers/spm/spm.c
+++ b/plat/mediatek/mt8173/drivers/spm/spm.c
@@ -384,6 +384,10 @@ enum wake_reason_t spm_output_wake_reason(struct wake_status *wakesta)
 
 void spm_boot_init(void)
 {
+	/* set spm transaction to secure mode */
+	mmio_write_32(DEVAPC0_APC_CON, 0x0);
+	mmio_write_32(DEVAPC0_MAS_SEC_0, 0x200);
+
 	/* Only CPU0 is online during boot, initialize cpu online reserve bit */
 	mmio_write_32(SPM_PCM_RESERVE, 0xFE);
 	mmio_clrbits_32(AP_PLL_CON3, 0xFFFFF);

--- a/plat/mediatek/mt8173/include/mt8173_def.h
+++ b/plat/mediatek/mt8173/include/mt8173_def.h
@@ -40,11 +40,13 @@
 /* Register base address */
 #define IO_PHYS			(0x10000000)
 #define INFRACFG_AO_BASE	(IO_PHYS + 0x1000)
+#define SRAMROM_SEC_BASE	(IO_PHYS + 0x1800)
 #define PERI_CON_BASE		(IO_PHYS + 0x3000)
 #define GPIO_BASE		(IO_PHYS + 0x5000)
 #define SPM_BASE		(IO_PHYS + 0x6000)
 #define RGU_BASE		(IO_PHYS + 0x7000)
 #define PMIC_WRAP_BASE		(IO_PHYS + 0xD000)
+#define DEVAPC0_BASE		(IO_PHYS + 0xE000)
 #define MCUCFG_BASE		(IO_PHYS + 0x200000)
 #define APMIXED_BASE		(IO_PHYS + 0x209000)
 #define TRNG_BASE		(IO_PHYS + 0x20F000)
@@ -56,6 +58,14 @@
 #define MTK_DEV_RNG0_SIZE	0x400000
 #define MTK_DEV_RNG1_BASE	(IO_PHYS + 0x1000000)
 #define MTK_DEV_RNG1_SIZE	0x4000000
+
+/* SRAMROM related registers */
+#define SRAMROM_SEC_CTRL	(SRAMROM_SEC_BASE + 0x4)
+#define SRAMROM_SEC_ADDR	(SRAMROM_SEC_BASE + 0x8)
+
+/* DEVAPC0 related registers */
+#define DEVAPC0_MAS_SEC_0	(DEVAPC0_BASE + 0x500)
+#define DEVAPC0_APC_CON		(DEVAPC0_BASE + 0xF00)
 
 /*******************************************************************************
  * UART related constants


### PR DESCRIPTION
BL31 usually handles confidential stuff, its memory must not be
read/write accessible from non-secure world. This patch protects
the BL31 memory range from non-secure read/write access.

Change-Id: I442fb92b667bb2f9a62d471a90508b1ba4489911
Signed-off-by: Jimmy Huang <jimmy.huang@mediatek.com>