### PR TITLE
pass r0-r6 as part of smc param

### DIFF
--- a/services/spd/opteed/opteed_main.c
+++ b/services/spd/opteed/opteed_main.c
@@ -265,6 +265,18 @@ uint64_t opteed_smc_handler(uint32_t smc_fid,
 		cm_el1_sysregs_context_restore(SECURE);
 		cm_set_next_eret_context(SECURE);
 
+		write_ctx_reg(get_gpregs_ctx(&optee_ctx->cpu_ctx),
+			      CTX_GPREG_X4,
+			      read_ctx_reg(get_gpregs_ctx(handle),
+					   CTX_GPREG_X4));
+		write_ctx_reg(get_gpregs_ctx(&optee_ctx->cpu_ctx),
+			      CTX_GPREG_X5,
+			      read_ctx_reg(get_gpregs_ctx(handle),
+					   CTX_GPREG_X5));
+		write_ctx_reg(get_gpregs_ctx(&optee_ctx->cpu_ctx),
+			      CTX_GPREG_X6,
+			      read_ctx_reg(get_gpregs_ctx(handle),
+					   CTX_GPREG_X6));
 		/* Propagate hypervisor client ID */
 		write_ctx_reg(get_gpregs_ctx(&optee_ctx->cpu_ctx),
 			      CTX_GPREG_X7,


### PR DESCRIPTION
In new communication protocol between optee os and linux driver,
r0-r6 registers are used. opteed need to copy these registers
as well when optee context registers are initialized.

Change-Id: Ifb47b73f847c61746cb58ea78411c1c71f208030
Signed-off-by: Ashutosh Singh <ashutosh.singh@arm.com>