### PR TITLE
Modify return type of plat_get_ns_image_entrypoint()

### DIFF
--- a/docs/porting-guide.md
+++ b/docs/porting-guide.md
@@ -1259,7 +1259,7 @@ later Bootloader stages with MMU off
 ### Function : plat_get_ns_image_entrypoint() [mandatory]
 
     Argument : void
-    Return   : unsigned long
+    Return   : uintptr_t
 
 As previously described, BL2 is responsible for arranging for control to be
 passed to a normal world BL image through BL31. This function returns the

--- a/include/plat/common/platform.h
+++ b/include/plat/common/platform.h
@@ -60,7 +60,7 @@ uint64_t plat_get_syscnt_freq(void);
 int plat_get_image_source(unsigned int image_id,
 			uintptr_t *dev_handle,
 			uintptr_t *image_spec);
-unsigned long plat_get_ns_image_entrypoint(void);
+uintptr_t plat_get_ns_image_entrypoint(void);
 unsigned int plat_my_core_pos(void);
 int plat_core_pos_by_mpidr(u_register_t mpidr);
 

--- a/plat/arm/common/aarch64/arm_common.c
+++ b/plat/arm/common/aarch64/arm_common.c
@@ -93,7 +93,7 @@ DEFINE_CONFIGURE_MMU_EL(1)
 DEFINE_CONFIGURE_MMU_EL(3)
 
 
-unsigned long plat_get_ns_image_entrypoint(void)
+uintptr_t plat_get_ns_image_entrypoint(void)
 {
 	return PLAT_ARM_NS_IMAGE_OFFSET;
 }


### PR DESCRIPTION
This patch modifies the return type of the platform API
`plat_get_ns_image_entrypoint()` from `unsigned long` to
`uintptr_t` in accordance with the coding guidelines.

Change-Id: Icb4510ca98b706aa4d535fe27e203394184fb4ca