### PR TITLE
Enable SCR_EL3.SIF bit

### DIFF
--- a/docs/firmware-design.md
+++ b/docs/firmware-design.md
@@ -176,7 +176,9 @@ BL1 performs minimal architectural initialization as follows.
 
     -  `SCR_EL3`. The register width of the next lower exception level is set
         to AArch64 by setting the `SCR.RW` bit. The `SCR.EA` bit is set to trap
-        both External Aborts and SError Interrupts in EL3.
+        both External Aborts and SError Interrupts in EL3. The `SCR.SIF` bit is
+        also set to disable instruction fetches from Non-secure memory when in
+        secure state.
 
     -   `CPTR_EL3`. Accesses to the `CPACR_EL1` register from EL1 or EL2, or the
         `CPTR_EL2` register from EL2 are configured to not trap to EL3 by

--- a/include/common/el3_common_macros.S
+++ b/include/common/el3_common_macros.S
@@ -70,11 +70,12 @@
 	isb
 
 	/* ---------------------------------------------------------------------
-	 * Early set RES1 bits in SCR_EL3. Set EA bit as well to catch both
-	 * External Aborts and SError Interrupts in EL3.
+	 * Early set RES1 bits in SCR_EL3. Set EA bit to catch both
+	 * External Aborts and SError Interrupts in EL3 and also the SIF bit
+	 * to disable instruction fetches from Non-secure memory.
 	 * ---------------------------------------------------------------------
 	 */
-	mov	x0, #(SCR_RES1_BITS | SCR_EA_BIT)
+	mov	x0, #(SCR_RES1_BITS | SCR_EA_BIT | SCR_SIF_BIT)
 	msr	scr_el3, x0
 	/* ---------------------------------------------------------------------
 	 * Enable External Aborts and SError Interrupts now that the exception


### PR DESCRIPTION
This patch enables the SCR_EL3.SIF (Secure Instruction Fetch) bit in BL1 and
BL31 common architectural setup code. When in secure state, this disables
instruction fetches from Non-secure memory.

NOTE: THIS COULD BREAK PLATFORMS THAT HAVE SECURE WORLD CODE EXECUTING FROM
NON-SECURE MEMORY, BUT THIS IS CONSIDERED UNLIKELY AND IS A SERIOUS SECURITY
RISK.

Fixes ARM-Software/tf-issues#372

Change-Id: I684e84b8d523c3b246e9a5fabfa085b6405df319