### PR TITLE
Remove BL32_BASE when building without SPD for FVP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -424,6 +424,7 @@ $(eval $(call assert_boolean,PL011_GENERIC_UART))
 ################################################################################
 
 $(eval $(call add_define,PLAT_${PLAT}))
+$(eval $(call add_define,SPD_${SPD}))
 $(eval $(call add_define,NS_TIMER_SWITCH))
 $(eval $(call add_define,RESET_TO_BL31))
 $(eval $(call add_define,CTX_INCLUDE_FPREGS))

--- a/include/plat/arm/common/arm_def.h
+++ b/include/plat/arm/common/arm_def.h
@@ -321,6 +321,10 @@
 # error "Unsupported ARM_TSP_RAM_LOCATION_ID value"
 #endif
 
+#ifdef SPD_none
+#undef BL32_BASE
+#endif /* SPD_none */
+
 /*******************************************************************************
  * FWU Images: NS_BL1U, BL2U & NS_BL2U defines.
  ******************************************************************************/

--- a/plat/arm/common/arm_bl2_setup.c
+++ b/plat/arm/common/arm_bl2_setup.c
@@ -147,14 +147,14 @@ bl31_params_t *bl2_plat_get_bl31_params(void)
 		VERSION_1, 0);
 
 	/* Fill BL32 related information if it exists */
-#if BL32_BASE
+#ifdef BL32_BASE
 	bl2_to_bl31_params->bl32_ep_info = &bl31_params_mem.bl32_ep_info;
 	SET_PARAM_HEAD(bl2_to_bl31_params->bl32_ep_info, PARAM_EP,
 		VERSION_1, 0);
 	bl2_to_bl31_params->bl32_image_info = &bl31_params_mem.bl32_image_info;
 	SET_PARAM_HEAD(bl2_to_bl31_params->bl32_image_info, PARAM_IMAGE_BINARY,
 		VERSION_1, 0);
-#endif
+#endif /* BL32_BASE */
 
 	/* Fill BL33 related information */
 	bl2_to_bl31_params->bl33_ep_info = &bl31_params_mem.bl33_ep_info;
@@ -280,25 +280,12 @@ void bl2_plat_set_bl31_ep_info(image_info_t *bl31_image_info,
  * the entrypoint of BL32 and set SPSR and security state.
  * On ARM standard platforms we only set the security state of the entrypoint
  ******************************************************************************/
+#ifdef BL32_BASE
 void bl2_plat_set_bl32_ep_info(image_info_t *bl32_image_info,
 					entry_point_info_t *bl32_ep_info)
 {
 	SET_SECURITY_STATE(bl32_ep_info->h.attr, SECURE);
 	bl32_ep_info->spsr = arm_get_spsr_for_bl32_entry();
-}
-
-/*******************************************************************************
- * Before calling this function BL33 is loaded in memory and its entrypoint
- * is set by load_image. This is a placeholder for the platform to change
- * the entrypoint of BL33 and set SPSR and security state.
- * On ARM standard platforms we only set the security state of the entrypoint
- ******************************************************************************/
-void bl2_plat_set_bl33_ep_info(image_info_t *image,
-					entry_point_info_t *bl33_ep_info)
-{
-
-	SET_SECURITY_STATE(bl33_ep_info->h.attr, NON_SECURE);
-	bl33_ep_info->spsr = arm_get_spsr_for_bl33_entry();
 }
 
 /*******************************************************************************
@@ -316,7 +303,20 @@ void bl2_plat_get_bl32_meminfo(meminfo_t *bl32_meminfo)
 	bl32_meminfo->free_size =
 			(TSP_SEC_MEM_BASE + TSP_SEC_MEM_SIZE) - BL32_BASE;
 }
+#endif /* BL32_BASE */
 
+/*******************************************************************************
+ * Before calling this function BL33 is loaded in memory and its entrypoint
+ * is set by load_image. This is a placeholder for the platform to change
+ * the entrypoint of BL33 and set SPSR and security state.
+ * On ARM standard platforms we only set the security state of the entrypoint
+ ******************************************************************************/
+void bl2_plat_set_bl33_ep_info(image_info_t *image,
+					entry_point_info_t *bl33_ep_info)
+{
+	SET_SECURITY_STATE(bl33_ep_info->h.attr, NON_SECURE);
+	bl33_ep_info->spsr = arm_get_spsr_for_bl33_entry();
+}
 
 /*******************************************************************************
  * Populate the extents of memory available for loading BL33


### PR DESCRIPTION
Previously, when building TF without SPD support, BL2 tried to load a
BL32 image from the FIP and fails to find one, which resulted on
warning messages on the console. Even if there is a BL32 image in the
FIP it shouldn't be loaded because there is no way to transfer
control to the Secure Payload without SPD support.

The Makefile has been modified to pass a define of the form
SPD_${SPD} to the source code the same way it's done for PLAT. The
define SPD_none is then used to undefine BL32_BASE when BL32 is not
used to prevent BL2 from trying to load a BL32 image and failing,
thus removing the warning messages mentioned above.

Fixes ARM-software/tf-issues#287

Change-Id: Ifeb6f1c26935efb76afd353fea88e87ba09e9658