### PR TITLE
Rename BL33_BASE and make it work with RESET_TO_BL31

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,9 +316,9 @@ include lib/cpus/cpu-ops.mk
 ################################################################################
 
 ifdef EL3_PAYLOAD_BASE
-        ifdef BL33_BASE
-                $(warning "BL33_BASE and EL3_PAYLOAD_BASE are incompatible \
-                build options. EL3_PAYLOAD_BASE has priority.")
+        ifdef PRELOADED_BL33_BASE
+                $(warning "PRELOADED_BL33_BASE and EL3_PAYLOAD_BASE are \
+                incompatible build options. EL3_PAYLOAD_BASE has priority.")
         endif
 endif
 
@@ -327,9 +327,10 @@ ifeq (${NEED_BL33},yes)
                 $(warning "BL33 image is not needed when option \
                 BL33_PAYLOAD_BASE is used and won't be added to the FIP file.")
         endif
-        ifdef BL33_BASE
-                $(warning "BL33 image is not needed when option BL33_BASE is \
-                used and won't be added to the FIP file.")
+        ifdef PRELOADED_BL33_BASE
+                $(warning "BL33 image is not needed when option \
+                PRELOADED_BL33_BASE is used and won't be added to the FIP \
+                file.")
         endif
 endif
 
@@ -352,7 +353,7 @@ ifdef BL2_SOURCES
                 # in the FIP file.
                 NEED_BL33		:=	no
         else
-                ifdef BL33_BASE
+                ifdef PRELOADED_BL33_BASE
                         # If booting a BL33 preloaded image there is no need of
                         # another one in the FIP file.
                         NEED_BL33		:=	no
@@ -444,10 +445,10 @@ $(eval $(call add_define,PL011_GENERIC_UART))
 ifdef EL3_PAYLOAD_BASE
         $(eval $(call add_define,EL3_PAYLOAD_BASE))
 else
-        # Define the BL33_BASE flag only if it is provided and EL3_PAYLOAD_BASE
-        # is not defined, as it has priority.
-        ifdef BL33_BASE
-                $(eval $(call add_define,BL33_BASE))
+        # Define the PRELOADED_BL33_BASE flag only if it is provided and
+        # EL3_PAYLOAD_BASE is not defined, as it has priority.
+        ifdef PRELOADED_BL33_BASE
+                $(eval $(call add_define,PRELOADED_BL33_BASE))
         endif
 endif
 

--- a/bl2/bl2_main.c
+++ b/bl2/bl2_main.c
@@ -169,7 +169,7 @@ static int load_bl32(bl31_params_t *bl2_to_bl31_params)
 	return e;
 }
 
-#ifndef BL33_BASE
+#ifndef PRELOADED_BL33_BASE
 /*******************************************************************************
  * Load the BL33 image.
  * The bl2_to_bl31_params param will be updated with the relevant BL33
@@ -200,7 +200,7 @@ static int load_bl33(bl31_params_t *bl2_to_bl31_params)
 
 	return e;
 }
-#endif /* BL33_BASE */
+#endif /* PRELOADED_BL33_BASE */
 
 #endif /* EL3_PAYLOAD_BASE */
 
@@ -277,13 +277,13 @@ void bl2_main(void)
 		}
 	}
 
-#ifdef BL33_BASE
+#ifdef PRELOADED_BL33_BASE
 	/*
 	 * In this case, don't load the BL33 image as it's already loaded in
 	 * memory. Update BL33 entrypoint information.
 	 */
 	INFO("BL2: Populating the entrypoint info for the preloaded BL33\n");
-	bl2_to_bl31_params->bl33_ep_info->pc = BL33_BASE;
+	bl2_to_bl31_params->bl33_ep_info->pc = PRELOADED_BL33_BASE;
 	bl2_plat_set_bl33_ep_info(NULL, bl2_to_bl31_params->bl33_ep_info);
 #else
 	e = load_bl33(bl2_to_bl31_params);
@@ -291,7 +291,7 @@ void bl2_main(void)
 		ERROR("Failed to load BL33 (%i)\n", e);
 		plat_error_handler(e);
 	}
-#endif /* BL33_BASE */
+#endif /* PRELOADED_BL33_BASE */
 
 #endif /* EL3_PAYLOAD_BASE */
 

--- a/docs/porting-guide.md
+++ b/docs/porting-guide.md
@@ -1242,8 +1242,8 @@ BL33 image. The meminfo provided by this is used by load_image() to
 validate whether the BL33 image can be loaded with in the given
 memory from the given base.
 
-This function isn't needed if either `BL33_BASE` or `EL3_PAYLOAD_BASE` build
-options are used.
+This function isn't needed if either `PRELOADED_BL33_BASE` or `EL3_PAYLOAD_BASE`
+build options are used.
 
 ### Function : bl2_plat_flush_bl31_params() [mandatory]
 
@@ -1267,8 +1267,8 @@ entrypoint of that image, which BL31 uses to jump to it.
 
 BL2 is responsible for loading the normal world BL33 image (e.g. UEFI).
 
-This function isn't needed if either `BL33_BASE` or `EL3_PAYLOAD_BASE` build
-options are used.
+This function isn't needed if either `PRELOADED_BL33_BASE` or `EL3_PAYLOAD_BASE`
+build options are used.
 
 
 3.3 FWU Boot Loader Stage 2 (BL2U)
@@ -1973,8 +1973,8 @@ build system.
     By default, this flag is defined `yes` by the build system and `BL33`
     build option should be supplied as a build option. The platform has the
     option of excluding the BL33 image in the `fip` image by defining this flag
-    to `no`. If any of the options `EL3_PAYLOAD_BASE` or `BL33_BASE` are used,
-    this flag will be set to `no` automatically.
+    to `no`. If any of the options `EL3_PAYLOAD_BASE` or `PRELOADED_BL33_BASE`
+    are used, this flag will be set to `no` automatically.
 
 5.  C Library
 -------------

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -408,11 +408,11 @@ performed.
     payload. Please refer to the "Booting an EL3 payload" section for more
     details.
 
-*   `BL33_BASE`: This option enables booting a preloaded BL33 image instead of
-    the normal boot flow. When defined, it must specify the entry point address
-    for the preloaded BL33 image. This option is incompatible with
+*   `PRELOADED_BL33_BASE`: This option enables booting a preloaded BL33 image
+    instead of the normal boot flow. When defined, it must specify the entry
+    point address for the preloaded BL33 image. This option is incompatible with
     `EL3_PAYLOAD_BASE`. If both are defined, `EL3_PAYLOAD_BASE` has priority
-    over `BL33_BASE`.
+    over `PRELOADED_BL33_BASE`.
 
 *   `PL011_GENERIC_UART`: Boolean option to indicate the PL011 driver that
     the underlying hardware is not a full PL011 UART but a minimally compliant
@@ -998,13 +998,13 @@ code and improve performance in a development environment. When secure world
 cold boot is complete, Trusted Firmware simply jumps to a BL33 base address
 provided at build time.
 
-For this option to be used, the `BL33_BASE` build option has to be used when
-compiling the Trusted Firmware. For example, the following command will create
-a FIP without a BL33 and prepare to jump to a BL33 image loaded at address
-0x80000000:
+For this option to be used, the `PRELOADED_BL33_BASE` build option has to be
+used when compiling the Trusted Firmware. For example, the following command
+will create a FIP without a BL33 and prepare to jump to a BL33 image loaded at
+address 0x80000000:
 
     CROSS_COMPILE=<path-to>/bin/aarch64-linux-gnu- \
-    make BL33_BASE=0x80000000 PLAT=fvp all fip
+    make PRELOADED_BL33_BASE=0x80000000 PLAT=fvp all fip
 
 #### Boot of a preloaded bootwrapped kernel image on Base FVP
 
@@ -1026,8 +1026,8 @@ following command:
 The `-a cluster0.cpu0=<bootwrapped-kernel.elf>` option loads the ELF file. It
 also sets the PC register to the ELF entry point address, which is not the
 desired behaviour, so the `--start cluster0.cpu0=0x0` option forces the PC back
-to 0x0 (the BL1 entry point address) on CPU #0. The `BL33_BASE` define used when
-compiling the FIP must match the ELF entry point.
+to 0x0 (the BL1 entry point address) on CPU #0. The `PRELOADED_BL33_BASE` define
+used when compiling the FIP must match the ELF entry point.
 
 #### Boot of a preloaded bootwrapped kernel image on Juno
 

--- a/plat/arm/common/arm_bl31_setup.c
+++ b/plat/arm/common/arm_bl31_setup.c
@@ -142,11 +142,11 @@ void arm_bl31_early_platform_setup(bl31_params_t *from_bl2,
 	 * Tell BL31 where the non-trusted software image
 	 * is located and the entry state information
 	 */
-#ifdef BL33_BASE
-	bl33_image_ep_info.pc = BL33_BASE;
+#ifdef PRELOADED_BL33_BASE
+	bl33_image_ep_info.pc = PRELOADED_BL33_BASE;
 #else
 	bl33_image_ep_info.pc = plat_get_ns_image_entrypoint();
-#endif
+#endif /* PRELOADED_BL33_BASE */
 	bl33_image_ep_info.spsr = arm_get_spsr_for_bl33_entry();
 	SET_SECURITY_STATE(bl33_image_ep_info.h.attr, NON_SECURE);
 

--- a/plat/arm/common/arm_bl31_setup.c
+++ b/plat/arm/common/arm_bl31_setup.c
@@ -142,7 +142,11 @@ void arm_bl31_early_platform_setup(bl31_params_t *from_bl2,
 	 * Tell BL31 where the non-trusted software image
 	 * is located and the entry state information
 	 */
+#ifdef BL33_BASE
+	bl33_image_ep_info.pc = BL33_BASE;
+#else
 	bl33_image_ep_info.pc = plat_get_ns_image_entrypoint();
+#endif
 	bl33_image_ep_info.spsr = arm_get_spsr_for_bl33_entry();
 	SET_SECURITY_STATE(bl33_image_ep_info.h.attr, NON_SECURE);
 


### PR DESCRIPTION
- Fixed boot when both BL33_BASE and RESET_TO_BL31 are used.

- BL33_BASE build option renamed to PRELOADED_BL33_BASE to avoid confusion with other options with similar name.

NOTE: PLATFORMS USING BUILD OPTION `BL33_BASE` MUST CHANGE TO THE NEW
BUILD OPTION `PRELOADED_BL33_BASE`.