### PR TITLE
Fix style check and remove markdown files from it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,10 +112,10 @@ CHECK_IGNORE		:=	--ignore COMPLEX_MACRO \
 				--ignore GIT_COMMIT_ID
 CHECKPATCH_ARGS		:=	--no-tree --no-signoff ${CHECK_IGNORE}
 CHECKCODE_ARGS		:=	--no-patch --no-tree --no-signoff ${CHECK_IGNORE}
-# Do not check the coding style on C library files
+# Do not check the coding style on C library files or documentation files
 INCLUDE_DIRS_TO_CHECK	:=	$(sort $(filter-out include/stdlib, $(wildcard include/*)))
 LIB_DIRS_TO_CHECK	:=	$(sort $(filter-out lib/stdlib, $(wildcard lib/*)))
-ROOT_DIRS_TO_CHECK	:=	$(sort $(filter-out lib include, $(wildcard *)))
+ROOT_DIRS_TO_CHECK	:=	$(sort $(filter-out lib include docs %.md, $(wildcard *)))
 CHECK_PATHS		:=	${ROOT_DIRS_TO_CHECK} ${INCLUDE_DIRS_TO_CHECK} ${LIB_DIRS_TO_CHECK}
 
 

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ CHECKCODE_ARGS		:=	--no-patch --no-tree --no-signoff ${CHECK_IGNORE}
 # Do not check the coding style on C library files
 INCLUDE_DIRS_TO_CHECK	:=	$(sort $(filter-out include/stdlib, $(wildcard include/*)))
 LIB_DIRS_TO_CHECK	:=	$(sort $(filter-out lib/stdlib, $(wildcard lib/*)))
-ROOT_DIRS_TO_CHECK	:=	$(sort $(filter-out lib include, $(wildcard *))))
+ROOT_DIRS_TO_CHECK	:=	$(sort $(filter-out lib include, $(wildcard *)))
 CHECK_PATHS		:=	${ROOT_DIRS_TO_CHECK} ${INCLUDE_DIRS_TO_CHECK} ${LIB_DIRS_TO_CHECK}
 
 


### PR DESCRIPTION
Fixed coding style check target of the Makefile. Prevent it from checking documentation files.