### PR TITLE
Use unsigned long long instead of uintptr_t in TZC400/DMC500 drivers

### DIFF
--- a/drivers/arm/tzc/tzc400.c
+++ b/drivers/arm/tzc/tzc400.c
@@ -191,8 +191,8 @@ void tzc400_configure_region0(tzc_region_attributes_t sec_attr,
  */
 void tzc400_configure_region(unsigned int filters,
 			  int region,
-			  uintptr_t region_base,
-			  uintptr_t region_top,
+			  unsigned long long region_base,
+			  unsigned long long region_top,
 			  tzc_region_attributes_t sec_attr,
 			  unsigned int nsaid_permissions)
 {

--- a/drivers/arm/tzc/tzc_common_private.c
+++ b/drivers/arm/tzc/tzc_common_private.c
@@ -42,42 +42,42 @@
 
 #define DEFINE_TZC_COMMON_WRITE_REGION_BASE(fn_name, macro_name)	\
 	static inline void _tzc##fn_name##_write_region_base(		\
-						uintptr_t base,		\
-						int region_no,		\
-						uintptr_t region_base)	\
+					uintptr_t base,			\
+					int region_no,			\
+					unsigned long long region_base)	\
 	{								\
 		mmio_write_32(base +					\
 			TZC_REGION_OFFSET(				\
 				TZC_##macro_name##_REGION_SIZE,		\
 				region_no) +				\
-				TZC_##macro_name##_REGION_BASE_LOW_0_OFFSET,	\
-			(unsigned int)region_base);			\
+			TZC_##macro_name##_REGION_BASE_LOW_0_OFFSET,	\
+			(uint32_t)region_base);				\
 		mmio_write_32(base +					\
 			TZC_REGION_OFFSET(				\
 				TZC_##macro_name##_REGION_SIZE,		\
 				region_no) +				\
 			TZC_##macro_name##_REGION_BASE_HIGH_0_OFFSET,	\
-			(unsigned int)(region_base >> 32));		\
+			(uint32_t)(region_base >> 32));			\
 	}
 
 #define DEFINE_TZC_COMMON_WRITE_REGION_TOP(fn_name, macro_name)		\
 	static inline void _tzc##fn_name##_write_region_top(		\
-						uintptr_t base,		\
-						int region_no,		\
-						uintptr_t region_top)	\
+					uintptr_t base,			\
+					int region_no,			\
+					unsigned long long region_top)	\
 	{								\
 		mmio_write_32(base +					\
 			TZC_REGION_OFFSET				\
 				(TZC_##macro_name##_REGION_SIZE,	\
 				region_no) +				\
 			TZC_##macro_name##_REGION_TOP_LOW_0_OFFSET,	\
-			(unsigned int)region_top);			\
+			(uint32_t)region_top);			\
 		mmio_write_32(base +					\
 			TZC_REGION_OFFSET(				\
 				TZC_##macro_name##_REGION_SIZE,		\
 				region_no) +				\
 			TZC_##macro_name##_REGION_TOP_HIGH_0_OFFSET,	\
-			(unsigned int)(region_top >> 32));		\
+			(uint32_t)(region_top >> 32));		\
 	}
 
 #define DEFINE_TZC_COMMON_WRITE_REGION_ATTRIBUTES(fn_name, macro_name)	\
@@ -146,8 +146,8 @@
 	void _tzc##fn_name##_configure_region(uintptr_t base,		\
 				unsigned int filters,			\
 				int region_no,				\
-				uintptr_t region_base,			\
-				uintptr_t region_top,			\
+				unsigned long long region_base,		\
+				unsigned long long region_top,		\
 				tzc_region_attributes_t sec_attr,	\
 				unsigned int nsaid_permissions)	\
 	{								\
@@ -155,8 +155,8 @@
 		VERBOSE("TrustZone : Configuring region "		\
 			"(TZC Interface Base: %p, region_no = %d)"	\
 			"...\n", (void *)base, region_no);		\
-		VERBOSE("TrustZone : ... base = %p, top = %p,"		\
-			"\n", (void *)region_base, (void *)region_top);\
+		VERBOSE("TrustZone : ... base = %llx, top = %llx,"	\
+			"\n", region_base, region_top);\
 		VERBOSE("TrustZone : ... sec_attr = 0x%x,"		\
 			" ns_devs = 0x%x)\n",				\
 			sec_attr, nsaid_permissions);			\

--- a/drivers/arm/tzc/tzc_dmc500.c
+++ b/drivers/arm/tzc/tzc_dmc500.c
@@ -196,8 +196,8 @@ void tzc_dmc500_configure_region0(tzc_region_attributes_t sec_attr,
  * for this region (see comment for that function).
  */
 void tzc_dmc500_configure_region(int region_no,
-			uintptr_t region_base,
-			uintptr_t region_top,
+			unsigned long long region_base,
+			unsigned long long region_top,
 			tzc_region_attributes_t sec_attr,
 			unsigned int nsaid_permissions)
 {

--- a/include/drivers/arm/tzc400.h
+++ b/include/drivers/arm/tzc400.h
@@ -139,8 +139,8 @@ void tzc400_configure_region0(tzc_region_attributes_t sec_attr,
 			   unsigned int ns_device_access);
 void tzc400_configure_region(unsigned int filters,
 			  int region,
-			  uintptr_t region_base,
-			  uintptr_t region_top,
+			  unsigned long long region_base,
+			  unsigned long long region_top,
 			  tzc_region_attributes_t sec_attr,
 			  unsigned int ns_device_access);
 void tzc400_set_action(tzc_action_t action);
@@ -157,8 +157,8 @@ static inline void tzc_configure_region0(
 static inline void tzc_configure_region(
 			  unsigned int filters,
 			  int region,
-			  uintptr_t region_base,
-			  uintptr_t region_top,
+			  unsigned long long region_base,
+			  unsigned long long region_top,
 			  tzc_region_attributes_t sec_attr,
 			  unsigned int ns_device_access) __deprecated;
 static inline void tzc_set_action(tzc_action_t action) __deprecated;
@@ -180,8 +180,8 @@ static inline void tzc_configure_region0(
 static inline void tzc_configure_region(
 			  unsigned int filters,
 			  int region,
-			  uintptr_t region_base,
-			  uintptr_t region_top,
+			  unsigned long long region_base,
+			  unsigned long long region_top,
 			  tzc_region_attributes_t sec_attr,
 			  unsigned int ns_device_access)
 {

--- a/include/drivers/arm/tzc_dmc500.h
+++ b/include/drivers/arm/tzc_dmc500.h
@@ -160,8 +160,8 @@ void tzc_dmc500_driver_init(const tzc_dmc500_driver_data_t *plat_driver_data);
 void tzc_dmc500_configure_region0(tzc_region_attributes_t sec_attr,
 				unsigned int nsaid_permissions);
 void tzc_dmc500_configure_region(int region_no,
-				uintptr_t region_base,
-				uintptr_t region_top,
+				unsigned long long region_base,
+				unsigned long long region_top,
 				tzc_region_attributes_t sec_attr,
 				unsigned int nsaid_permissions);
 void tzc_dmc500_set_action(tzc_action_t action);


### PR DESCRIPTION
Currently the `tzc400_configure_region` and `tzc_dmc500_configure_region`
functions uses uintptr_t as the data type for `region_top` and `region_base`
variables, which will be converted to 32/64 bits for AArch32/AArch64
respectively. But the expectation is to keep these addresses at least 64 bit.

This patch modifies the data types to make it at least 64 bit by using
unsigned long long instead of uintptr_t for the `region_top` and
`region_base` variables. It also modifies the associated macros
`_tzc##fn_name##_write_region_xxx` accordingly.

Change-Id: I4e3c6a8a39ad04205cf0f3bda336c3970b15a28b