### PR TITLE
rockchip: rk3399: fixes for the required

### DIFF
--- a/plat/rockchip/rk3399/include/platform_def.h
+++ b/plat/rockchip/rk3399/include/platform_def.h
@@ -92,7 +92,7 @@
  * Platform memory map related constants
  ******************************************************************************/
 /* TF txet, ro, rw, Size: 512KB */
-#define TZRAM_BASE		(0x0)
+#define TZRAM_BASE		(0x500000)
 #define TZRAM_SIZE		(0x80000)
 
 /*******************************************************************************

--- a/plat/rockchip/rk3399/rk3399_def.h
+++ b/plat/rockchip/rk3399/rk3399_def.h
@@ -79,7 +79,7 @@
 #define RK3399_UART2_BASE	(0xff1a0000)
 #define RK3399_UART2_SIZE	SIZE_K(64)
 
-#define RK3399_BAUDRATE		(1500000)
+#define RK3399_BAUDRATE		(115200)
 #define RK3399_UART_CLOCK	(24000000)
 
 /******************************************************************************


### PR DESCRIPTION
This patch has the following change for rk3399.

* We have to set the uart to 115200 since the loader decide to set
uart baud to 115200Hz.

* The ATF set the uart baud to 115200, and
changed the sram base for coreboot required.

Otherwise, we will happen the exception crash since the ddr area won't
to work from the zero sram base address in some cases.

For example, the exception crash:
CBFS: Found @ offset 19c80 size 24074
exception _sync_sp_el0
ELR = 0x0000000000008000
ESR = 0x0000000002000000
SPSR = 0x600003cc
FAR = 0xffffffff00000000
SP = 0x00000000ff8ed230
...
X29 = 0x00000000ff8c1fc0
X30 = 0x000000000030e3b0
exception death

Change-Id: I8bc557c6bcaf6804d2a313b38667d3e2517881d7
Signed-off-by: Caesar Wang <wxt@rock-chips.com>