### PR TITLE
rockchip: fixes for the required

### DIFF
--- a/plat/rockchip/rk3368/include/platform_def.h
+++ b/plat/rockchip/rk3368/include/platform_def.h
@@ -101,7 +101,7 @@
 /*
  * Put BL3-1 at the top of the Trusted RAM
  */
-#define BL31_BASE		(TZRAM_BASE + 0x8000)
+#define BL31_BASE		(TZRAM_BASE + 0x10000)
 #define BL31_LIMIT	(TZRAM_BASE + TZRAM_SIZE)
 
 /*******************************************************************************

--- a/plat/rockchip/rk3399/include/platform_def.h
+++ b/plat/rockchip/rk3399/include/platform_def.h
@@ -101,7 +101,7 @@
 /*
  * Put BL3-1 at the top of the Trusted RAM
  */
-#define BL31_BASE		(TZRAM_BASE + 0x8000)
+#define BL31_BASE		(TZRAM_BASE + 0x10000)
 #define BL31_LIMIT	(TZRAM_BASE + TZRAM_SIZE)
 
 /*******************************************************************************

--- a/plat/rockchip/rk3399/rk3399_def.h
+++ b/plat/rockchip/rk3399/rk3399_def.h
@@ -79,7 +79,7 @@
 #define RK3399_UART2_BASE	(0xff1a0000)
 #define RK3399_UART2_SIZE	SIZE_K(64)
 
-#define RK3399_BAUDRATE		(1500000)
+#define RK3399_BAUDRATE		(115200)
 #define RK3399_UART_CLOCK	(24000000)
 
 /******************************************************************************


### PR DESCRIPTION
This patch has the following change for rk3399.

* Set the uart to 115200 since the loader decide to set
  uart baud to 115200Hz. So the ATF also should set uart baud to 115200.

* We need ensure the bl31 base is greater than 4KB since there are have
  the shared mem for coreboot.(Note: the previous vesion was tested with uboot)

Otherwise, we will happen the exception crash since the ddr area won't
to work from the shared ram address in some cases.

For example, the exception crash:
CBFS: Found @ offset 19c80 size 24074
exception _sync_sp_el0
ELR = 0x0000000000008000
ESR = 0x0000000002000000
SPSR = 0x600003cc
FAR = 0xffffffff00000000
SP = 0x00000000ff8ed230
...
X29 = 0x00000000ff8c1fc0
X30 = 0x000000000030e3b0
exception death

Change-Id: I8bc557c6bcaf6804d2a313b38667d3e2517881d7
Signed-off-by: Caesar Wang <wxt@rock-chips.com>