### PR TITLE
Move `plat_get_syscnt_freq()` to arm_common.c

### DIFF
--- a/include/plat/common/platform.h
+++ b/include/plat/common/platform.h
@@ -56,7 +56,7 @@ struct image_desc;
 /*******************************************************************************
  * Mandatory common functions
  ******************************************************************************/
-uint64_t plat_get_syscnt_freq(void);
+unsigned long long plat_get_syscnt_freq(void);
 int plat_get_image_source(unsigned int image_id,
 			uintptr_t *dev_handle,
 			uintptr_t *image_spec);

--- a/plat/arm/common/aarch64/arm_common.c
+++ b/plat/arm/common/aarch64/arm_common.c
@@ -29,6 +29,7 @@
  */
 #include <arch.h>
 #include <arch_helpers.h>
+#include <debug.h>
 #include <mmio.h>
 #include <plat_arm.h>
 #include <platform_def.h>
@@ -39,7 +40,7 @@ extern const mmap_region_t plat_arm_mmap[];
 /* Weak definitions may be overridden in specific ARM standard platform */
 #pragma weak plat_get_ns_image_entrypoint
 #pragma weak plat_arm_get_mmap
-
+#pragma weak plat_get_syscnt_freq
 
 /*******************************************************************************
  * Macro generating the code for the function setting up the pagetables as per
@@ -160,4 +161,18 @@ void arm_configure_sys_timer(void)
 const mmap_region_t *plat_arm_get_mmap(void)
 {
 	return plat_arm_mmap;
+}
+
+unsigned long long plat_get_syscnt_freq(void)
+{
+	unsigned long long counter_base_frequency;
+
+	/* Read the frequency from Frequency modes table */
+	counter_base_frequency = mmio_read_32(ARM_SYS_CNTCTL_BASE + CNTFID_OFF);
+
+	/* The first entry of the frequency modes table must not be 0 */
+	if (counter_base_frequency == 0)
+		panic();
+
+	return counter_base_frequency;
 }

--- a/plat/arm/common/arm_bl31_setup.c
+++ b/plat/arm/common/arm_bl31_setup.c
@@ -34,7 +34,6 @@
 #include <assert.h>
 #include <bl_common.h>
 #include <console.h>
-#include <debug.h>
 #include <mmio.h>
 #include <plat_arm.h>
 #include <platform.h>
@@ -76,7 +75,6 @@ static entry_point_info_t bl33_image_ep_info;
 #pragma weak bl31_platform_setup
 #pragma weak bl31_plat_arch_setup
 #pragma weak bl31_plat_get_next_image_ep_info
-#pragma weak plat_get_syscnt_freq
 
 
 /*******************************************************************************
@@ -267,18 +265,4 @@ void arm_bl31_plat_arch_setup(void)
 void bl31_plat_arch_setup(void)
 {
 	arm_bl31_plat_arch_setup();
-}
-
-uint64_t plat_get_syscnt_freq(void)
-{
-	uint64_t counter_base_frequency;
-
-	/* Read the frequency from Frequency modes table */
-	counter_base_frequency = mmio_read_32(ARM_SYS_CNTCTL_BASE + CNTFID_OFF);
-
-	/* The first entry of the frequency modes table must not be 0 */
-	if (counter_base_frequency == 0)
-		panic();
-
-	return counter_base_frequency;
 }

--- a/plat/mediatek/mt8173/aarch64/platform_common.c
+++ b/plat/mediatek/mt8173/aarch64/platform_common.c
@@ -84,7 +84,7 @@ const mmap_region_t plat_mmap[] = {
 /* Define EL3 variants of the function initialising the MMU */
 DEFINE_CONFIGURE_MMU_EL(3)
 
-uint64_t plat_get_syscnt_freq(void)
+unsigned long long plat_get_syscnt_freq(void)
 {
 	return SYS_COUNTER_FREQ_IN_TICKS;
 }

--- a/plat/nvidia/tegra/include/tegra_private.h
+++ b/plat/nvidia/tegra/include/tegra_private.h
@@ -52,7 +52,7 @@ int32_t tegra_soc_validate_power_state(unsigned int power_state,
 
 /* Declarations for plat_setup.c */
 const mmap_region_t *plat_get_mmio_map(void);
-uint64_t plat_get_syscnt_freq(void);
+unsigned long long plat_get_syscnt_freq(void);
 
 /* Declarations for plat_secondary.c */
 void plat_secondary_setup(void);

--- a/plat/nvidia/tegra/soc/t132/plat_setup.c
+++ b/plat/nvidia/tegra/soc/t132/plat_setup.c
@@ -74,7 +74,7 @@ const mmap_region_t *plat_get_mmio_map(void)
 	return tegra_mmap;
 }
 
-uint64_t plat_get_syscnt_freq(void)
+unsigned long long plat_get_syscnt_freq(void)
 {
 	return 12000000;
 }

--- a/plat/nvidia/tegra/soc/t210/plat_setup.c
+++ b/plat/nvidia/tegra/soc/t210/plat_setup.c
@@ -80,7 +80,7 @@ const mmap_region_t *plat_get_mmio_map(void)
 /*******************************************************************************
  * Handler to get the System Counter Frequency
  ******************************************************************************/
-uint64_t plat_get_syscnt_freq(void)
+unsigned long long plat_get_syscnt_freq(void)
 {
 	return 19200000;
 }

--- a/plat/rockchip/common/aarch64/platform_common.c
+++ b/plat/rockchip/common/aarch64/platform_common.c
@@ -75,7 +75,7 @@ static const int cci_map[] = {
 /* Define EL3 variants of the function initialising the MMU */
 DEFINE_CONFIGURE_MMU_EL(3)
 
-uint64_t plat_get_syscnt_freq(void)
+unsigned long long plat_get_syscnt_freq(void)
 {
 	return SYS_COUNTER_FREQ_IN_TICKS;
 }

--- a/plat/xilinx/zynqmp/aarch64/zynqmp_common.c
+++ b/plat/xilinx/zynqmp/aarch64/zynqmp_common.c
@@ -297,9 +297,9 @@ void zynqmp_config_setup(void)
 	mmio_write_32(IOU_SCNTRS_CONTROL, IOU_SCNTRS_CONTROL_EN);
 }
 
-uint64_t plat_get_syscnt_freq(void)
+unsigned long long plat_get_syscnt_freq(void)
 {
-	uint64_t counter_base_frequency;
+	unsigned long long counter_base_frequency;
 
 	/* FIXME: Read the frequency from Frequency modes table */
 	counter_base_frequency = zynqmp_get_system_timer_freq();


### PR DESCRIPTION
This patch moves the definition for `plat_get_syscnt_freq()`
from arm_bl31_setup.c to arm_common.c. This could be useful
in case a delay timer needs to be installed based on the
generic timer in other BLs.
This patch also modifies the return type for this function
from `uint64_t` to `unsigned long long` within ARM and other
platform files.

Change-Id: Iccdfa811948e660d4fdcaae60ad1d700e4eda80d