### PR TITLE
Conditionally compile `plat_get_syscnt_freq()` in ARM standard platforms

### DIFF
--- a/plat/arm/common/aarch64/arm_common.c
+++ b/plat/arm/common/aarch64/arm_common.c
@@ -163,6 +163,7 @@ const mmap_region_t *plat_arm_get_mmap(void)
 	return plat_arm_mmap;
 }
 
+#ifdef ARM_SYS_CNTCTL_BASE
 unsigned long long plat_get_syscnt_freq(void)
 {
 	unsigned long long counter_base_frequency;
@@ -176,3 +177,4 @@ unsigned long long plat_get_syscnt_freq(void)
 
 	return counter_base_frequency;
 }
+#endif /* ARM_SYS_CNTCTL_BASE */


### PR DESCRIPTION
This patch puts the definition of `plat_get_syscnt_freq()`
under `#ifdef ARM_SYS_CNTCTL_BASE` in arm_common.c file.
This is the fix for compilation error introduced by commit-id
`749ade4`, for platforms that use arm_common.c but do not
provide a memory mapped interface to the generic counter.

Fixes ARM-software/tf-issues#395

Change-Id: I2f2b10bd9500fa15308541ccb15829306a76a745