### PR TITLE
Fix computation of L1 bitmask in the translation table lib (v2)

### DIFF
--- a/lib/xlat_tables/xlat_tables_common.c
+++ b/lib/xlat_tables/xlat_tables_common.c
@@ -284,8 +284,9 @@ static mmap_region_t *init_xlation_table_inner(mmap_region_t *mm,
 	unsigned level_size_shift = L1_XLAT_ADDRESS_SHIFT - (level - 1) *
 						XLAT_TABLE_ENTRIES_SHIFT;
 	unsigned level_size = 1 << level_size_shift;
-	unsigned long long level_index_mask = XLAT_TABLE_ENTRIES_MASK <<
-							level_size_shift;
+	unsigned long long level_index_mask =
+		((unsigned long long) XLAT_TABLE_ENTRIES_MASK)
+		<< level_size_shift;
 
 	assert(level > 0 && level <= 3);
 


### PR DESCRIPTION
This patch fixes the computation of the bitmask used to isolate
the level 1 field of a virtual address. The whole computation needs
to work on 64-bit values to produce the correct bitmask value.
XLAT_TABLE_ENTRIES_MASK being a C constant, it is a 32-bit value
so it needs to be extended to a 64-bit value before it takes part
in any other computation.

This patch fixes this bug by casting XLAT_TABLE_ENTRIES_MASK as
an unsigned long long.

Note that this bug doesn't manifest itself in practice because
address spaces larger than 39 bits are not yet supported in the
Trusted Firmware.
