### PR TITLE
fip_create: Fix exit status for missing output filename (2)

### DIFF
--- a/tools/fip_create/fip_create.c
+++ b/tools/fip_create/fip_create.c
@@ -811,7 +811,7 @@ int main(int argc, char **argv)
 	if (fip_filename == NULL) {
 		printf("ERROR: Missing FIP filename\n");
 		print_usage();
-		return 0;
+		return EINVAL;
 	}
 
 	/* Unpack images from FIP always takes precedence over packaging. In


### PR DESCRIPTION
Not sure whether I should submit against `integration` or `master` so I've done both, just reject whichever is wrong.