### PR TITLE
Doc: Fix the path to the xlat lib

### DIFF
--- a/docs/porting-guide.md
+++ b/docs/porting-guide.md
@@ -76,8 +76,8 @@ either mandatory or optional.
 A platform port must enable the Memory Management Unit (MMU) as well as the
 instruction and data caches for each BL stage. Setting up the translation
 tables is the responsibility of the platform port because memory maps differ
-across platforms. A memory translation library (see `lib/aarch64/xlat_tables.c`)
-is provided to help in this setup. Note that although this library supports
+across platforms. A memory translation library (see `lib/xlat_tables/`) is
+provided to help in this setup. Note that although this library supports
 non-identity mappings, this is intended only for re-mapping peripheral physical
 addresses and allows platforms with high I/O addresses to reduce their virtual
 address space. All other addresses corresponding to code and data must currently


### PR DESCRIPTION
The translation table library code has moved from lib/aarch64/ to
lib/xlat_tables/ since commit 3ca9928df but the Porting Guide still
points to the old location. This patch fixes this issue.
