### PR TITLE
Support for gpio reset v1

### DIFF
--- a/drivers/gpio/gpio.c
+++ b/drivers/gpio/gpio.c
@@ -80,6 +80,16 @@ void gpio_set_value(int gpio, int value)
 	ops->set_value(gpio, value);
 }
 
+void gpio_set_pull(int gpio, int pull)
+{
+	assert(ops);
+	assert(ops->set_pull != 0);
+	assert((pull == PULLNONE) || (pull == PULLUP) || (pull == PULLDOWN));
+	assert(gpio >= 0);
+
+	ops->set_pull(gpio, pull);
+}
+
 /*
  * Initialize the gpio. The fields in the provided gpio
  * ops pointer must be valid.

--- a/include/drivers/gpio.h
+++ b/include/drivers/gpio.h
@@ -37,17 +37,25 @@
 #define GPIO_LEVEL_LOW		0
 #define GPIO_LEVEL_HIGH		1
 
+enum {
+	PULLNONE = 0,
+	PULLUP,
+	PULLDOWN
+};
+
 typedef struct gpio_ops {
 	int (*get_direction)(int gpio);
 	void (*set_direction)(int gpio, int direction);
 	int (*get_value)(int gpio);
 	void (*set_value)(int gpio, int value);
+	void (*set_pull)(int gpio, int pull);
 } gpio_ops_t;
 
 int gpio_get_direction(int gpio);
 void gpio_set_direction(int gpio, int direction);
 int gpio_get_value(int gpio);
 void gpio_set_value(int gpio, int value);
+void gpio_set_pull(int gpio, int pull);
 void gpio_init(const gpio_ops_t *ops);
 
 #endif	/* __GPIO_H__ */

--- a/plat/rockchip/common/bl31_plat_setup.c
+++ b/plat/rockchip/common/bl31_plat_setup.c
@@ -119,6 +119,9 @@ void bl31_early_platform_setup(bl31_params_t *from_bl2,
 	 * Copy the code into pmusram.
 	 */
 	plat_rockchip_pmusram_prepare();
+
+	/* there may have some board sepcific message need to initialize */
+	params_early_setup(plat_params_from_bl2);
 }
 
 /*******************************************************************************

--- a/plat/rockchip/common/include/plat_params.h
+++ b/plat/rockchip/common/include/plat_params.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * Neither the name of ARM nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __PLAT_PARAMS_H__
+#define __PLAT_PARAMS_H__
+
+#include <stdint.h>
+
+/*
+ * We defined several plat parameter structs for BL2 to pass platform related
+ * parameters to Rockchip BL31 platform code.  All plat parameters start with
+ * a common header, which has a type field to indicate the parameter type, and
+ * a next pointer points to next parameter. If the parameter is the last one in
+ * the list, next pointer will points to NULL.  After the header comes the
+ * variable-sized members that describe the parameter. The picture below shows
+ * how the parameters are kept in memory.
+ *
+ * head of list  ---> +----------------+ --+
+ *                    |      type      |   |
+ *                    +----------------+   |--> struct bl31_plat_param
+ *               +----|      next      |   |
+ *               |    +----------------+ --+
+ *               |    | parameter data |
+ *               |    +----------------+
+ *               |
+ *               +--> +----------------+ --+
+ *                    |      type      |   |
+ *                    +----------------+   |--> struct bl31_plat_param
+ *           NULL <---|      next      |   |
+ *                    +----------------+ --+
+ *                    | parameter data |
+ *                    +----------------+
+ *
+ * Note: The SCTLR_EL3.A bit (Alignment fault check enable) of ARM TF is set,
+ * so be sure each parameter struct starts on 64-bit aligned address. If not,
+ * alignment fault will occur during accessing its data member.
+ */
+
+/* param type */
+enum {
+	PARAM_NONE = 0,
+	PARAM_RESET,
+	PARAM_POWEROFF,
+};
+
+struct gpio_info {
+	uint8_t polarity;
+	uint8_t direction;
+	uint8_t pull_mode;
+	uint32_t index;
+};
+
+/* common header for all plat parameter type */
+struct bl31_plat_param {
+	uint64_t type;
+	void *next;
+};
+
+struct bl31_gpio_param {
+	struct bl31_plat_param h;
+	struct gpio_info gpio;
+};
+
+#endif /* __PLAT_PARAMS_H__ */

--- a/plat/rockchip/common/include/plat_private.h
+++ b/plat/rockchip/common/include/plat_private.h
@@ -97,6 +97,8 @@ void plat_cci_disable(void);
 
 void plat_delay_timer_init(void);
 
+void params_early_setup(void *plat_params_from_bl2);
+
 void plat_rockchip_gic_driver_init(void);
 void plat_rockchip_gic_init(void);
 void plat_rockchip_gic_cpuif_enable(void);
@@ -110,6 +112,8 @@ void plat_setup_rockchip_pm_ops(struct rockchip_pm_ops_cb *ops);
 
 void platform_cpu_warmboot(void);
 
+void *plat_get_rockchip_gpio_reset(void);
+void *plat_get_rockchip_gpio_poweroff(void);
 void plat_rockchip_gpio_init(void);
 
 extern const unsigned char rockchip_power_domain_tree_desc[];

--- a/plat/rockchip/common/include/plat_private.h
+++ b/plat/rockchip/common/include/plat_private.h
@@ -110,6 +110,8 @@ void plat_setup_rockchip_pm_ops(struct rockchip_pm_ops_cb *ops);
 
 void platform_cpu_warmboot(void);
 
+void plat_rockchip_gpio_init(void);
+
 extern const unsigned char rockchip_power_domain_tree_desc[];
 
 extern void *pmu_cpuson_entrypoint_start;

--- a/plat/rockchip/common/params_setup.c
+++ b/plat/rockchip/common/params_setup.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * Neither the name of ARM nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <arm_gic.h>
+#include <assert.h>
+#include <bl_common.h>
+#include <console.h>
+#include <debug.h>
+#include <mmio.h>
+#include <platform.h>
+#include <plat_params.h>
+#include <plat_private.h>
+#include <string.h>
+#include <gpio.h>
+
+static struct bl31_plat_param *bl31_params_head;
+static struct bl31_gpio_param param_reset;
+static struct bl31_gpio_param param_poweroff;
+static struct gpio_info *rst_gpio = NULL;
+static struct gpio_info *poweroff_gpio = NULL;
+
+void *plat_get_rockchip_gpio_reset(void)
+{
+	return rst_gpio;
+}
+
+void *plat_get_rockchip_gpio_poweroff(void)
+{
+	return poweroff_gpio;
+}
+
+void params_early_setup(void *plat_param_from_bl2)
+{
+	struct bl31_plat_param *param;
+	struct bl31_plat_param *bl2_param;
+	struct bl31_gpio_param *gpio_param;
+
+	/* keep plat parameters for later processing if need */
+	bl2_param = (struct bl31_plat_param *)plat_param_from_bl2;
+	while (bl2_param) {
+		switch (bl2_param->type) {
+		case PARAM_RESET:
+			param = (struct bl31_plat_param *)&param_reset;
+			memcpy((void *)param, (void *)bl2_param,
+				sizeof(struct bl31_gpio_param));
+			gpio_param = (struct bl31_gpio_param *)param;
+			rst_gpio = &gpio_param->gpio;
+			break;
+		case PARAM_POWEROFF:
+			param = (struct bl31_plat_param *)&param_poweroff;
+			memcpy((void *)param, (void *)bl2_param,
+				sizeof(struct bl31_gpio_param));
+			gpio_param = (struct bl31_gpio_param *)param;
+			poweroff_gpio = &gpio_param->gpio;
+			break;
+		default:
+			NOTICE("not expected type found\n");
+			return; /* don't continue if unexpected type found */
+		}
+		param->next = bl31_params_head;
+		bl31_params_head = param;
+		bl2_param = bl2_param->next;
+	}
+}

--- a/plat/rockchip/common/plat_pm.c
+++ b/plat/rockchip/common/plat_pm.c
@@ -253,6 +253,16 @@ static void __dead2 rockchip_system_reset(void)
 }
 
 /*******************************************************************************
+ * RockChip handlers to power off the system
+ ******************************************************************************/
+static void __dead2 rockchip_system_poweroff(void)
+{
+	assert(rockchip_ops && rockchip_ops->system_off);
+
+	rockchip_ops->system_off();
+}
+
+/*******************************************************************************
  * Export the platform handlers via plat_rockchip_psci_pm_ops. The rockchip
  * standard
  * platform layer will take care of registering the handlers with PSCI.
@@ -265,6 +275,7 @@ const plat_psci_ops_t plat_rockchip_psci_pm_ops = {
 	.pwr_domain_on_finish = rockchip_pwr_domain_on_finish,
 	.pwr_domain_suspend_finish = rockchip_pwr_domain_suspend_finish,
 	.system_reset = rockchip_system_reset,
+	.system_off = rockchip_system_poweroff,
 	.validate_power_state = rockchip_validate_power_state,
 	.get_sys_suspend_power_state = rockchip_get_sys_suspend_power_state
 };

--- a/plat/rockchip/rk3399/drivers/gpio/rk3399_gpio.c
+++ b/plat/rockchip/rk3399/drivers/gpio/rk3399_gpio.c
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * Neither the name of ARM nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <assert.h>
+#include <debug.h>
+#include <delay_timer.h>
+#include <errno.h>
+#include <gpio.h>
+#include <mmio.h>
+#include <platform.h>
+#include <platform_def.h>
+#include <plat_private.h>
+#include <soc.h>
+
+uint32_t gpio_port[] = {
+	GPIO0_BASE,
+	GPIO1_BASE,
+	GPIO2_BASE,
+	GPIO3_BASE,
+	GPIO4_BASE,
+};
+
+#define SWPORTA_DR	0x00
+#define SWPORTA_DDR	0x04
+#define EXT_PORTA	0x50
+
+#define PMU_GPIO_PORT0	0
+#define PMU_GPIO_PORT1	1
+
+#define PMU_GRF_GPIO0A_P	0x40
+#define GRF_GPIO2A_P		0xe040
+#define GPIO_P_MASK		0x03
+
+/*
+ * gpio clock disabled when not operate
+ * so need to enable gpio clock before operate gpio
+ * after setting, need to disable gpio clock
+ * gate 1: disable clock; 0: enable clock
+ */
+static void gpio_clk(int gpio, uint32_t gate)
+{
+	uint32_t port = gpio / 32;
+
+	assert(port < 5);
+
+	switch (port) {
+	case 0:
+		mmio_write_32(PMUCRU_BASE + CRU_PMU_CLKGATE_CON(1),
+			      BITS_WITH_WMASK(gate, CLK_GATE_MASK,
+					      PCLK_GPIO0_GATE_SHIFT));
+		break;
+	case 1:
+		mmio_write_32(PMUCRU_BASE + CRU_PMU_CLKGATE_CON(1),
+			      BITS_WITH_WMASK(gate, CLK_GATE_MASK,
+					      PCLK_GPIO1_GATE_SHIFT));
+		break;
+	case 2:
+		mmio_write_32(CRU_BASE + CRU_CLKGATE_CON(31),
+			      BITS_WITH_WMASK(gate, CLK_GATE_MASK,
+					      PCLK_GPIO2_GATE_SHIFT));
+		break;
+	case 3:
+		mmio_write_32(CRU_BASE + CRU_CLKGATE_CON(31),
+			      BITS_WITH_WMASK(gate, CLK_GATE_MASK,
+					      PCLK_GPIO3_GATE_SHIFT));
+
+		break;
+	case 4:
+		mmio_write_32(CRU_BASE + CRU_CLKGATE_CON(31),
+			      BITS_WITH_WMASK(gate, CLK_GATE_MASK,
+					      PCLK_GPIO4_GATE_SHIFT));
+		break;
+	default:
+		break;
+	}
+}
+
+static void set_pull(int gpio, int pull)
+{
+	uint32_t port = gpio / 32;
+	uint32_t num = gpio % 32;
+	uint32_t bank = num / 8;
+	uint32_t id = num % 8;
+
+	assert((port < 5) && (num < 32));
+
+	gpio_clk(gpio, 0);
+
+	/*
+	 * in gpio0a, gpio0b, gpio2c, gpio2d,
+	 * 00: Z
+	 * 01: pull down
+	 * 10: Z
+	 * 11: pull up
+	 * different with other gpio, so need to correct it
+	 */
+	if (((port == 0) && (bank < 2)) || ((port == 2) && (bank > 2))) {
+		if (pull == PULLUP)
+			pull = 3;
+		else if (pull == PULLDOWN)
+			pull = 1;
+		else
+			pull = 0;
+	}
+
+	if (port == PMU_GPIO_PORT0 || port == PMU_GPIO_PORT1) {
+		mmio_write_32(PMUGRF_BASE + PMU_GRF_GPIO0A_P +
+			      port * 16 + bank * 4,
+			      BITS_WITH_WMASK(pull, GPIO_P_MASK, id * 2));
+	} else {
+		mmio_write_32(GRF_BASE + GRF_GPIO2A_P +
+			      (port - 2) * 16 + bank * 4,
+			      BITS_WITH_WMASK(pull, GPIO_P_MASK, id * 2));
+	}
+	gpio_clk(gpio, 1);
+}
+
+static void set_direction(int gpio, int direction)
+{
+	uint32_t port = gpio / 32;
+	uint32_t num = gpio % 32;
+
+	assert((port < 5) && (num < 32));
+
+	gpio_clk(gpio, 0);
+
+	/*
+	 * in gpio.h
+	 * #define GPIO_DIR_OUT	0
+	 * #define GPIO_DIR_IN	1
+	 * but rk3399 gpio direction 1: output, 0: input
+	 * so need to revert direction value
+	 */
+	mmio_setbits_32(gpio_port[port] + SWPORTA_DDR, !direction << num);
+	gpio_clk(gpio, 1);
+}
+
+static int get_direction(int gpio)
+{
+	uint32_t port = gpio / 32;
+	uint32_t num = gpio % 32;
+	int direction;
+
+	assert((port < 5) && (num < 32));
+
+	gpio_clk(gpio, 0);
+
+	/*
+	 * in gpio.h
+	 * #define GPIO_DIR_OUT	0
+	 * #define GPIO_DIR_IN	1
+	 * but rk3399 gpio direction 1: output, 0: input
+	 * so need to revert direction value
+	 */
+	direction = !((mmio_read_32(gpio_port[port] +
+				    SWPORTA_DDR) >> num) & 0x1);
+	gpio_clk(gpio, 1);
+
+	return direction;
+}
+
+static int get_value(int gpio)
+{
+	uint32_t port = gpio / 32;
+	uint32_t num = gpio % 32;
+	int value;
+
+	assert((port < 5) && (num < 32));
+
+	gpio_clk(gpio, 0);
+	value = (mmio_read_32(gpio_port[port] + EXT_PORTA) >> num) & 0x1;
+	gpio_clk(gpio, 1);
+
+	return value;
+}
+
+static void set_value(int gpio, int value)
+{
+	uint32_t port = gpio / 32;
+	uint32_t num = gpio % 32;
+
+	assert((port < 5) && (num < 32));
+
+	gpio_clk(gpio, 0);
+	mmio_clrsetbits_32(gpio_port[port] + SWPORTA_DR, 1 << num,
+							 !!value << num);
+	gpio_clk(gpio, 0);
+}
+
+const gpio_ops_t rk3399_gpio_ops = {
+	.get_direction = get_direction,
+	.set_direction = set_direction,
+	.get_value = get_value,
+	.set_value = set_value,
+	.set_pull = set_pull,
+};
+
+void plat_rockchip_gpio_init(void)
+{
+	gpio_init(&rk3399_gpio_ops);
+}

--- a/plat/rockchip/rk3399/drivers/pmu/pmu.c
+++ b/plat/rockchip/rk3399/drivers/pmu/pmu.c
@@ -34,9 +34,11 @@
 #include <debug.h>
 #include <delay_timer.h>
 #include <errno.h>
+#include <gpio.h>
 #include <mmio.h>
 #include <platform.h>
 #include <platform_def.h>
+#include <plat_params.h>
 #include <plat_private.h>
 #include <rk3399_def.h>
 #include <pmu_sram.h>
@@ -384,6 +386,23 @@ static int sys_pwr_domain_resume(void)
 	return 0;
 }
 
+void __dead2 soc_soft_reset(void)
+{
+	struct gpio_info *rst_gpio;
+
+	rst_gpio = (struct gpio_info *)plat_get_rockchip_gpio_reset();
+
+	if (rst_gpio) {
+		gpio_set_direction(rst_gpio->index, GPIO_DIR_OUT);
+		gpio_set_value(rst_gpio->index, rst_gpio->polarity);
+	} else {
+		soc_global_soft_reset();
+	}
+
+	while (1)
+	;
+}
+
 static struct rockchip_pm_ops_cb pm_ops = {
 	.cores_pwr_dm_on = cores_pwr_domain_on,
 	.cores_pwr_dm_off = cores_pwr_domain_off,
@@ -392,7 +411,7 @@ static struct rockchip_pm_ops_cb pm_ops = {
 	.cores_pwr_dm_resume = cores_pwr_domain_resume,
 	.sys_pwr_dm_suspend = sys_pwr_domain_suspend,
 	.sys_pwr_dm_resume = sys_pwr_domain_resume,
-	.sys_gbl_soft_reset = soc_global_soft_reset,
+	.sys_gbl_soft_reset = soc_soft_reset,
 };
 
 void plat_rockchip_pmu_init(void)

--- a/plat/rockchip/rk3399/drivers/pmu/pmu.h
+++ b/plat/rockchip/rk3399/drivers/pmu/pmu.h
@@ -810,6 +810,8 @@ enum pmu_core_pwr_st {
 
 #define PMUGRF_GPIO1A_IOMUX	0x10
 #define AP_PWROFF		0x0a
+#define GPIO1A6_IOMUX		BITS_WITH_WMASK(0, 3, 12)
+#define TSADC_INT_PIN		38
 #define CORES_PM_DISABLE	0x0
 
 #define PD_CTR_LOOP		500

--- a/plat/rockchip/rk3399/drivers/soc/soc.c
+++ b/plat/rockchip/rk3399/drivers/soc/soc.c
@@ -57,7 +57,18 @@ const mmap_region_t plat_rk_mmap[] = {
 			MT_DEVICE | MT_RW | MT_SECURE),
 	MAP_REGION_FLAT(PMUGRF_BASE, PMUGRF_SIZE,
 			MT_DEVICE | MT_RW | MT_SECURE),
-
+	MAP_REGION_FLAT(GPIO0_BASE, GPIO0_SIZE,
+			MT_DEVICE | MT_RW | MT_SECURE),
+	MAP_REGION_FLAT(GPIO1_BASE, GPIO1_SIZE,
+			MT_DEVICE | MT_RW | MT_SECURE),
+	MAP_REGION_FLAT(GPIO2_BASE, GPIO2_SIZE,
+			MT_DEVICE | MT_RW | MT_SECURE),
+	MAP_REGION_FLAT(GPIO3_BASE, GPIO3_SIZE,
+			MT_DEVICE | MT_RW | MT_SECURE),
+	MAP_REGION_FLAT(GPIO4_BASE, GPIO4_SIZE,
+			MT_DEVICE | MT_RW | MT_SECURE),
+	MAP_REGION_FLAT(GRF_BASE, GRF_SIZE,
+			MT_DEVICE | MT_RW | MT_SECURE),
 	{ 0 }
 };
 
@@ -349,4 +360,5 @@ void plat_rockchip_soc_init(void)
 	dma_secure_cfg(0);
 	sgrf_init();
 	soc_global_soft_reset_init();
+	plat_rockchip_gpio_init();
 }

--- a/plat/rockchip/rk3399/drivers/soc/soc.h
+++ b/plat/rockchip/rk3399/drivers/soc/soc.h
@@ -72,6 +72,8 @@
 #define REG_SIZE			0x04
 #define REG_SOC_WMSK			0xffff0000
 
+#define CLK_GATE_MASK			0x01
+
 enum plls_id {
 	ALPLL_ID = 0,
 	ABPLL_ID,
@@ -152,6 +154,11 @@ struct deepsleep_data_s {
 #define CRU_GLB_SRST_FST	0x0500
 #define CRU_GLB_SRST_SND	0x0504
 
+#define CRU_CLKGATE_CON(n)	(0x300 + n * 4)
+#define PCLK_GPIO2_GATE_SHIFT	3
+#define PCLK_GPIO3_GATE_SHIFT	4
+#define PCLK_GPIO4_GATE_SHIFT	5
+
 /**************************************************
  * pmu cru reg, offset
  **************************************************/
@@ -166,6 +173,10 @@ struct deepsleep_data_s {
 
 #define CRU_PMU_FIRST_SFTRST_MSK	(0x3 << 2)
 #define CRU_PMU_FIRST_SFTRST_EN		0x0
+
+#define CRU_PMU_CLKGATE_CON(n)		(0x100 + n * 4)
+#define PCLK_GPIO0_GATE_SHIFT		3
+#define PCLK_GPIO1_GATE_SHIFT		4
 
 /**************************************************
  * sgrf reg, offset

--- a/plat/rockchip/rk3399/include/platform_def.h
+++ b/plat/rockchip/rk3399/include/platform_def.h
@@ -109,7 +109,7 @@
  ******************************************************************************/
 #define ADDR_SPACE_SIZE		(1ull << 32)
 #define MAX_XLAT_TABLES		20
-#define MAX_MMAP_REGIONS	16
+#define MAX_MMAP_REGIONS	20
 
 /*******************************************************************************
  * Declarations and constants to access the mailboxes safely. Each mailbox is

--- a/plat/rockchip/rk3399/platform.mk
+++ b/plat/rockchip/rk3399/platform.mk
@@ -63,6 +63,7 @@ BL31_SOURCES            +=      ${RK_GIC_SOURCES}                               
                                 plat/common/aarch64/platform_mp_stack.S         \
                                 ${RK_PLAT_COMMON}/aarch64/plat_helpers.S        \
                                 ${RK_PLAT_COMMON}/bl31_plat_setup.c             \
+                                ${RK_PLAT_COMMON}/params_setup.c                \
                                 ${RK_PLAT_COMMON}/pmusram/pmu_sram_cpus_on.S	\
 				${RK_PLAT_COMMON}/pmusram/pmu_sram.c		\
                                 ${RK_PLAT_COMMON}/plat_delay_timer.c            \

--- a/plat/rockchip/rk3399/platform.mk
+++ b/plat/rockchip/rk3399/platform.mk
@@ -57,6 +57,7 @@ BL31_SOURCES            +=      ${RK_GIC_SOURCES}                               
                                 drivers/console/console.S                       \
                                 drivers/ti/uart/16550_console.S                 \
                                 drivers/delay_timer/delay_timer.c               \
+				drivers/gpio/gpio.c				\
                                 lib/cpus/aarch64/cortex_a53.S                   \
                                 lib/cpus/aarch64/cortex_a72.S                   \
                                 plat/common/aarch64/platform_mp_stack.S         \
@@ -67,7 +68,8 @@ BL31_SOURCES            +=      ${RK_GIC_SOURCES}                               
                                 ${RK_PLAT_COMMON}/plat_delay_timer.c            \
                                 ${RK_PLAT_COMMON}/plat_pm.c                     \
                                 ${RK_PLAT_COMMON}/plat_topology.c               \
-                                ${RK_PLAT_COMMON}/aarch64/platform_common.c        \
+                                ${RK_PLAT_COMMON}/aarch64/platform_common.c	\
+                                ${RK_PLAT_SOC}/drivers/gpio/rk3399_gpio.c	\
                                 ${RK_PLAT_SOC}/drivers/pmu/pmu.c                \
                                 ${RK_PLAT_SOC}/drivers/soc/soc.c
 

--- a/plat/rockchip/rk3399/rk3399_def.h
+++ b/plat/rockchip/rk3399/rk3399_def.h
@@ -64,6 +64,24 @@
 #define PMUGRF_BASE		0xff320000
 #define PMUGRF_SIZE		SIZE_K(64)
 
+#define GPIO0_BASE		0xff720000
+#define GPIO0_SIZE		SIZE_K(64)
+
+#define GPIO1_BASE		0xff730000
+#define GPIO1_SIZE		SIZE_K(64)
+
+#define GPIO2_BASE		0xff780000
+#define GPIO2_SIZE		SIZE_K(32)
+
+#define GPIO3_BASE		0xff788000
+#define GPIO3_SIZE		SIZE_K(32)
+
+#define GPIO4_BASE		0xff790000
+#define GPIO4_SIZE		SIZE_K(32)
+
+#define GRF_BASE		0xff770000
+#define GRF_SIZE		SIZE_K(64)
+
 /*
  * include i2c pmu/audio, pwm0-3 rkpwm0-3 uart_dbg,mailbox scr
  * 0xff650000 -0xff6c0000


### PR DESCRIPTION
Add the gpio configure to complete the system off/reset soc.


In order to properly reboot, the AP should not use the standar dreboot methods.  We need to use "AP_EC_WARM_RESET_REQ" .

The reason for this is that the reset method won't reset the TPM.

That means:
* I think the ARM Trusted Firmware is in charge of rebooting the machine, even when the kernel is running (PSCI is used to call ATF).  That means the firmware needs to do this.

* Also if the firmware sees that a Hardware Watchdog Reset happened it should log (using the event log) and then do a GPIO-based reset so that the TPM gets rebooted.