### PR TITLE
Fix a syntax error in plat/arm/common/aarch64/arm_common.c

### DIFF
--- a/plat/arm/common/aarch64/arm_common.c
+++ b/plat/arm/common/aarch64/arm_common.c
@@ -176,7 +176,7 @@ const mmap_region_t *plat_arm_get_mmap(void)
 #if ERROR_DEPRECATED
 unsigned int plat_get_syscnt_freq2(void)
 {
-	unsigned int counter_base_frequency
+	unsigned int counter_base_frequency;
 #else
 unsigned long long plat_get_syscnt_freq(void)
 {


### PR DESCRIPTION
Building TF with ERROR_DEPRECATED=1 fails because of a missing
semi-column. This patch fixes this syntax error.
