### PR TITLE
Allow dynamic overriding of ROTPK verification

### DIFF
--- a/docs/porting-guide.md
+++ b/docs/porting-guide.md
@@ -631,10 +631,19 @@ In case the function returns a hash of the key:
         digest            OCTET STRING
     }
 
-The function returns 0 on success. Any other value means the ROTPK could not be
-retrieved from the platform. The function also reports extra information related
-to the ROTPK in the flags parameter.
+The function returns 0 on success. Any other value is treated as error by the
+Trusted Board Boot. The function also reports extra information related
+to the ROTPK in the flags parameter:
 
+    ROTPK_IS_HASH      : Indicates that the ROTPK returned by the platform is a
+                         hash.
+    ROTPK_NOT_DEPLOYED : This allows the platform to skip certificate ROTPK
+                         verification while the platform ROTPK is not deployed.
+                         When this flag is set, the function does not need to
+                         return a platform ROTPK, and the authentication
+                         framework uses the ROTPK in the certificate without
+                         verifying it against the platform value. This flag
+                         must not be used in a deployed production environment.
 
 ### Function: plat_get_nv_ctr()
 

--- a/include/plat/common/platform.h
+++ b/include/plat/common/platform.h
@@ -49,6 +49,9 @@ struct image_desc;
  * plat_get_rotpk_info() flags
  ******************************************************************************/
 #define ROTPK_IS_HASH			(1 << 0)
+/* Flag used to skip verification of the certificate ROTPK while the platform
+   ROTPK is not deployed */
+#define ROTPK_NOT_DEPLOYED		(1 << 1)
 
 /*******************************************************************************
  * Function declarations


### PR DESCRIPTION
A production ROM with TBB enabled must have the ability to boot test software
before a real ROTPK is deployed (e.g. manufacturing mode). Previously the
function plat_get_rotpk_info() must return a valid ROTPK for TBB to succeed.
This patch adds an additional bit `ROTPK_NOT_DEPLOYED` in the output `flags`
parameter from plat_get_rotpk_info(). If this bit is set, then the ROTPK
in certificate is used without verifying against the platform value.

Fixes ARM-software/tf-issues#381

Change-Id: Icbbffab6bff8ed76b72431ee21337f550d8fdbbb