### PR TITLE
CSS: Add support to wake up the core from wfi in GICv3

### DIFF
--- a/plat/arm/css/common/css_pm.c
+++ b/plat/arm/css/common/css_pm.c
@@ -262,8 +262,14 @@ void css_cpu_standby(plat_local_state_t cpu_state)
 	assert(cpu_state == ARM_LOCAL_STATE_RET);
 
 	scr = read_scr_el3();
-	/* Enable PhysicalIRQ bit for NS world to wake the CPU */
-	write_scr_el3(scr | SCR_IRQ_BIT);
+	/*
+	 * Enable the Non secure interrupt to wake the CPU.
+	 * In GICv3 affinity routing mode, the non secure group1 interrupts use
+	 * the PhysicalFIQ at EL3 whereas in GICv2, it uses the PhysicalIRQ.
+	 * Enabling both the bits works for both GICv2 mode and GICv3 affinity
+	 * routing mode.
+	 */
+	write_scr_el3(scr | SCR_IRQ_BIT | SCR_FIQ_BIT);
 	isb();
 	dsb();
 	wfi();


### PR DESCRIPTION
In GICv3 mode, the non secure group1 interrupts are signalled via the
FIQ line in EL3. To support waking up from CPU_SUSPEND to standby on
these systems, EL3 should route FIQ to EL3 temporarily before wfi and
restore the original setting after resume. This patch makes this change
for the CSS platforms in the `css_cpu_standby` psci pm ops hook.

Change-Id: Ibf3295d16e2f08da490847c1457bc839e1bac144