### PR TITLE
opteed: assume aarch64 for optee

### DIFF
--- a/services/spd/opteed/opteed_main.c
+++ b/services/spd/opteed/opteed_main.c
@@ -148,7 +148,7 @@ int32_t opteed_setup(void)
 	 * state i.e whether AArch32 or AArch64. Assuming it's AArch32
 	 * for the time being.
 	 */
-	opteed_rw = OPTEE_AARCH32;
+	opteed_rw = OPTEE_AARCH64;
 	opteed_init_optee_ep_state(optee_ep_info,
 				opteed_rw,
 				optee_ep_info->pc,


### PR DESCRIPTION
OPTEE to execute in aarch64 bit mode, set it accordingly
when execution transitions from EL3 to EL1

Change-Id: I59f2f940bdc1aac10543045b006a137d107ec95f
Signed-off-by: Ashutosh Singh <ashutosh.singh@arm.com>