### PR TITLE
zynqmp: Make UART selectable

### DIFF
--- a/docs/plat/xilinx-zynqmp.md
+++ b/docs/plat/xilinx-zynqmp.md
@@ -26,6 +26,10 @@ make ERROR_DEPRECATED=1 RESET_TO_BL31=1 CROSS_COMPILE=aarch64-none-elf- PLAT=zyn
 *   `ZYNQMP_BL32_MEM_BASE`: Specifies the base address of the bl32 binary.
 *   `ZYNQMP_BL32_MEM_SIZE`: Specifies the size of the memory region of the bl32 binary.
 
+*   `ZYNQMP_CONSOLE`: Select the console driver. Options:
+    -   `cadence`, `cadence0`: Cadence UART 0
+    -   `cadence1`           : Cadence UART 1
+
 # FSBL->ATF Parameter Passing
 The FSBL populates a data structure with image information for the ATF. The ATF
 uses that data to hand off to the loaded images. The address of the handoff data

--- a/make_helpers/build_macros.mk
+++ b/make_helpers/build_macros.mk
@@ -68,6 +68,13 @@ define add_define
     DEFINES			+=	-D$(1)$(if $(value $(1)),=$(value $(1)),)
 endef
 
+# Convenience function for adding build definitions
+# $(eval $(call add_define_val,FOO,BAR)) will have:
+# -DFOO=BAR
+define add_define_val
+    DEFINES			+=	-D$(1)=$(2)
+endef
+
 # Convenience function for verifying option has a boolean value
 # $(eval $(call assert_boolean,FOO)) will assert FOO is 0 or 1
 define assert_boolean

--- a/plat/xilinx/zynqmp/bl31_zynqmp_setup.c
+++ b/plat/xilinx/zynqmp/bl31_zynqmp_setup.c
@@ -96,7 +96,7 @@ void bl31_early_platform_setup(bl31_params_t *from_bl2,
 			       void *plat_params_from_bl2)
 {
 	/* Initialize the console to provide early debug support */
-	console_init(ZYNQMP_UART0_BASE, zynqmp_get_uart_clk(),
+	console_init(ZYNQMP_UART_BASE, zynqmp_get_uart_clk(),
 		     ZYNQMP_UART_BAUDRATE);
 
 	/* Initialize the platform config for future decision making */

--- a/plat/xilinx/zynqmp/platform.mk
+++ b/plat/xilinx/zynqmp/platform.mk
@@ -53,6 +53,9 @@ ifdef ZYNQMP_BL32_MEM_BASE
     $(eval $(call add_define,ZYNQMP_BL32_MEM_SIZE))
 endif
 
+ZYNQMP_CONSOLE	?=	cadence
+$(eval $(call add_define_val,ZYNQMP_CONSOLE,ZYNQMP_CONSOLE_ID_${ZYNQMP_CONSOLE}))
+
 PLAT_INCLUDES		:=	-Iinclude/plat/arm/common/			\
 				-Iinclude/plat/arm/common/aarch64/		\
 				-Iplat/xilinx/zynqmp/include/			\

--- a/plat/xilinx/zynqmp/tsp/tsp_plat_setup.c
+++ b/plat/xilinx/zynqmp/tsp/tsp_plat_setup.c
@@ -68,7 +68,7 @@ void tsp_early_platform_setup(void)
 	 * Initialize a different console than already in use to display
 	 * messages from TSP
 	 */
-	console_init(ZYNQMP_UART0_BASE, zynqmp_get_uart_clk(),
+	console_init(ZYNQMP_UART_BASE, zynqmp_get_uart_clk(),
 		     ZYNQMP_UART_BAUDRATE);
 
 	/* Initialize the platform config for future decision making */

--- a/plat/xilinx/zynqmp/zynqmp_def.h
+++ b/plat/xilinx/zynqmp/zynqmp_def.h
@@ -33,6 +33,13 @@
 
 #include <common_def.h>
 
+#define ZYNQMP_CONSOLE_ID_cadence	1
+#define ZYNQMP_CONSOLE_ID_cadence0	1
+#define ZYNQMP_CONSOLE_ID_cadence1	2
+#define ZYNQMP_CONSOLE_ID_dcc		3
+
+#define ZYNQMP_CONSOLE_IS(con)	(ZYNQMP_CONSOLE_ID_ ## con == ZYNQMP_CONSOLE)
+
 /* Firmware Image Package */
 #define ZYNQMP_PRIMARY_CPU		0
 
@@ -141,7 +148,15 @@
 #define ZYNQMP_UART0_BASE		0xFF000000
 #define ZYNQMP_UART1_BASE		0xFF001000
 
-#define PLAT_ARM_CRASH_UART_BASE	ZYNQMP_UART0_BASE
+#if ZYNQMP_CONSOLE_IS(cadence)
+# define ZYNQMP_UART_BASE	ZYNQMP_UART0_BASE
+#elif ZYNQMP_CONSOLE_IS(cadence1)
+# define ZYNQMP_UART_BASE	ZYNQMP_UART1_BASE
+#else
+# error "invalid ZYNQMP_CONSOLE"
+#endif
+
+#define PLAT_ARM_CRASH_UART_BASE	ZYNQMP_UART_BASE
 /* impossible to call C routine how it is done now - hardcode any value */
 #define	PLAT_ARM_CRASH_UART_CLK_IN_HZ	100000000 /* FIXME */
 


### PR DESCRIPTION
Add a zynqmp-specific config option, ZYNQMP_CONSOLE, to select a UART device.