### PR TITLE
Fix `cert_create` tool for Segmentation fault

### DIFF
--- a/tools/cert_create/src/main.c
+++ b/tools/cert_create/src/main.c
@@ -428,9 +428,11 @@ int main(int argc, char *argv[])
 			 */
 			switch (ext->type) {
 			case EXT_TYPE_NVCOUNTER:
-				nvctr = atoi(ext->arg);
-				CHECK_NULL(cert_ext, ext_new_nvcounter(ext_nid,
+				if (ext->arg) {
+					nvctr = atoi(ext->arg);
+					CHECK_NULL(cert_ext, ext_new_nvcounter(ext_nid,
 						EXT_CRIT, nvctr));
+				}
 				break;
 			case EXT_TYPE_HASH:
 				if (ext->arg == NULL) {


### PR DESCRIPTION
With the introduction of commit `96103d5a`, the Certificate
Generation tool is not able to generate FWU certificate and
while doing so it does segmentation fault.

This happens because it is now required to pass non-volatile
counter values to the `cert_create` tool from the command line
for creating the trusted firmware certificates.

But in case of creating FWU certificate these counter values are not
being passed to the tool and as a consequence the `cert_create` tool
try to use the NULL argument and errors out with Segmentation fault.

This patch fixes this issue by providing a check before using the
command line argument passed in the case of `EXT_TYPE_NVCOUNTER`
certificate extension.

Change-Id: Ie17d0c1502b52aaa8500f3659c2da2448ab0347a