### PR TITLE
GIC: Ensure SGIs and PPIs are Group0 before setup

### DIFF
--- a/drivers/arm/gic/arm_gic.c
+++ b/drivers/arm/gic/arm_gic.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2016, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -205,10 +205,14 @@ void arm_gic_pcpu_distif_setup(void)
 
 	assert(g_irq_sec_ptr);
 	sec_ppi_sgi_mask = 0;
+
+	/* Ensure all SGIs and PPIs are Group0 to begin with */
+	gicd_write_igroupr(g_gicd_base, 0, 0);
+
 	for (index = 0; index < g_num_irqs; index++) {
 		irq_num = g_irq_sec_ptr[index];
 		if (irq_num < MIN_SPI_ID) {
-			/* We have an SGI or a PPI. They are Group0 at reset */
+			/* We have an SGI or a PPI */
 			sec_ppi_sgi_mask |= 1U << irq_num;
 			gicd_set_ipriorityr(g_gicd_base, irq_num,
 				GIC_HIGHEST_SEC_PRIORITY);


### PR DESCRIPTION
The legacy GIC driver assumes that the SGIs and PPIs are Group0 during
initialization. This is true if the driver is the first one to initialize
the GIC hardware after reset. But in some cases, earlier BL stages could
have already initialized the GIC hardware which means that SGI and PPI
configuration are not the expected reset values causing assertion failure
in `gicd_set_ipriorityr()`. This patch explicitly resets the SGI and PPI
to Group0 prior to their initialization in the driver. The same patch is
not done in the GICv2-only driver because unlike in the legacy driver,
`gicd_set_ipriorityr()` of GICv2 driver doesn't enforce this policy and
the appropriate group is set irrespective of the initial value.

Fixes ARM-software/tf-issues#396

Change-Id: I521d35caa37470ce542c796c2ba99716e4763105