### PR TITLE
Derive stack alignment from CACHE_WRITEBACK_GRANULE

### DIFF
--- a/include/common/asm_macros.S
+++ b/include/common/asm_macros.S
@@ -148,17 +148,33 @@
 #endif
 
 	/*
+	 * Helper assembler macro to count trailing zeros. The output is
+	 * populated in the `TZ_COUNT` symbol.
+	 */
+	.macro count_tz _value, _tz_count
+	.if \_value
+	  count_tz "(\_value >> 1)", "(\_tz_count + 1)"
+	.else
+	  .equ TZ_COUNT, (\_tz_count - 1)
+	.endif
+	.endm
+
+	/*
 	 * This macro declares an array of 1 or more stacks, properly
 	 * aligned and in the requested section
 	 */
-#define STACK_ALIGN	6
+#define DEFAULT_STACK_ALIGN	(1 << 6)   /* In case the caller doesnt provide alignment */
 
-	.macro declare_stack _name, _section, _size, _count
-	.if ((\_size & ((1 << STACK_ALIGN) - 1)) <> 0)
+	.macro declare_stack _name, _section, _size, _count, _align=DEFAULT_STACK_ALIGN
+	count_tz \_align, 0
+	.if (\_align - (1 << TZ_COUNT))
+	  .error "Incorrect stack alignment specified (Must be a power of 2)."
+	.endif
+	.if ((\_size & ((1 << TZ_COUNT) - 1)) <> 0)
 	  .error "Stack size not correctly aligned"
 	.endif
 	.section    \_section, "aw", %nobits
-	.align STACK_ALIGN
+	.align TZ_COUNT
 	\_name:
 	.space ((\_count) * (\_size)), 0
 	.endm

--- a/plat/common/aarch64/platform_mp_stack.S
+++ b/plat/common/aarch64/platform_mp_stack.S
@@ -193,4 +193,5 @@ endfunc plat_set_my_stack
 	 * -----------------------------------------------------
 	 */
 declare_stack platform_normal_stacks, tzfw_normal_stacks, \
-		PLATFORM_STACK_SIZE, PLATFORM_CORE_COUNT
+		PLATFORM_STACK_SIZE, PLATFORM_CORE_COUNT, \
+		CACHE_WRITEBACK_GRANULE

--- a/plat/common/aarch64/platform_up_stack.S
+++ b/plat/common/aarch64/platform_up_stack.S
@@ -99,4 +99,4 @@ endfunc_deprecated platform_set_stack
 	 * -----------------------------------------------------
 	 */
 declare_stack platform_normal_stacks, tzfw_normal_stacks, \
-		PLATFORM_STACK_SIZE, 1
+		PLATFORM_STACK_SIZE, 1, CACHE_WRITEBACK_GRANULE


### PR DESCRIPTION
The per-cpu stacks should be aligned to the cache-line size and
the `declare_stack` helper in asm_macros.S macro assumed a
cache-line size of 64 bytes. The platform defines the cache-line
size via CACHE_WRITEBACK_GRANULE macro. This patch modifies
`declare_stack` helper macro to derive stack alignment from the
platform defined macro.

Change-Id: I1e1b00fc8806ecc88190ed169f4c8d3dd25fe95b