### PR TITLE
Replace fip_create with fiptool

### DIFF
--- a/tools/cert_create/src/main.c
+++ b/tools/cert_create/src/main.c
@@ -428,9 +428,11 @@ int main(int argc, char *argv[])
 			 */
 			switch (ext->type) {
 			case EXT_TYPE_NVCOUNTER:
-				nvctr = atoi(ext->arg);
-				CHECK_NULL(cert_ext, ext_new_nvcounter(ext_nid,
+				if (ext->arg) {
+					nvctr = atoi(ext->arg);
+					CHECK_NULL(cert_ext, ext_new_nvcounter(ext_nid,
 						EXT_CRIT, nvctr));
+				}
 				break;
 			case EXT_TYPE_HASH:
 				if (ext->arg == NULL) {


### PR DESCRIPTION
fiptool provides a more consistent and intuitive interface compared to
the fip_create program.  It serves as a better base to build on more
features in the future.

fiptool supports various subcommands.  Below are the currently
supported subcommands:

1) info   - List the images contained in a FIP file.
2) pack   - Update or create a new FIP file.
3) unpack - Extract a selected set or all the images from a FIP file.
4) remove - Remove images from a FIP file.  This is a new command that
    was not present in fip_create.

Each of these subcommands has various options associated.  For more
information run fiptool help <subcommand>.

A compatibility script that emulates the basic functionality of
fip_create is provided.  Existing scripts might or might not work with
the compatibility script.  Users are strongly encouraged to migrate to
fiptool.

Fixes ARM-Software/tf-issues#87
Fixes ARM-Software/tf-issues#108
Fixes ARM-Software/tf-issues#361