### PR TITLE
include/common/asm_macros: update to build with GAS 2.26

### DIFF
--- a/include/common/asm_macros.S
+++ b/include/common/asm_macros.S
@@ -75,7 +75,7 @@
 	 */
 	.macro vector_base  label
 	.section .vectors, "ax"
-	.align 11, 0
+	.align 11
 	\label:
 	.endm
 
@@ -88,7 +88,7 @@
 	 */
 	.macro vector_entry  label
 	.section .vectors, "ax"
-	.align 7, 0
+	.align 7
 	\label:
 	.endm
 


### PR DESCRIPTION
GNU Binutils v2.26 no longer builds arm-trusted-firmware.  It fails
with the error "Error: non-constant expression in ".if" statement"

The issue is described here:
https://www.mail-archive.com/linaro-toolchain%40lists.linaro.org/msg05689.html

Because the 2nd value in the align directive is the padding byte, by
changing '.align 11, 0' and '.align 7,0' to just 'align 11' and
'align 7', all that gets changed is the padding. Using GAS 2.26
and looking in the manuals back to GAS 2.15, the padding changes
from 0x00000000 to the value for nop (0xd403201f), which seems
appropriate anyway.

https://sourceware.org/binutils/docs-2.26/as/Align.html#Align

This issue is affecting the coreboot toolchain, which has been updated
to binutils 2.26, and cannot be reverted to 2.25 as other platforms
require the updated version.

Signed-off-by: Martin Roth <martinroth@chromium.org>