### PR TITLE
ARM platforms: Define common image sizes

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -465,12 +465,13 @@ map is explained in the [Firmware Design].
     match the frame used by the Non-Secure image (normally the Linux kernel).
     Default is true (access to the frame is allowed).
 
-*   `ARM_BOARD_OPTIMISE_MMAP`: Boolean option to enable or disable optimisation
-    of page table and MMU related macros `PLAT_ARM_MMAP_ENTRIES` and
-    `MAX_XLAT_TABLES`. By default this flag is 0, which means it uses the
-    default unoptimised values for these macros. ARM development platforms
-    that wish to optimise memory usage for page tables need to set this flag to 1
-    and must override the related macros.
+*   `ARM_BOARD_OPTIMISE_MEM`: Boolean option to enable or disable optimisation
+    of the memory reserved for each image. This affects the maximum size of each
+    BL image as well as the number of allocated memory regions and translation
+    tables. By default this flag is 0, which means it uses the default
+    unoptimised values for these macros. ARM development platforms that wish to
+    optimise memory usage need to set this flag to 1 and must override the
+    related macros.
 
 *   'ARM_BL31_IN_DRAM': Boolean option to select loading of BL31 in TZC secured
     DRAM. By default, BL31 is in the secure SRAM. Set this flag to 1 to load

--- a/include/plat/arm/board/common/board_arm_def.h
+++ b/include/plat/arm/board/common/board_arm_def.h
@@ -61,10 +61,10 @@
 
 /*
  * The constants below are not optimised for memory usage. Platforms that wish
- * to optimise these constants should set `ARM_BOARD_OPTIMISE_MMAP` to 1 and
+ * to optimise these constants should set `ARM_BOARD_OPTIMISE_MEM` to 1 and
  * provide there own values.
  */
-#if !ARM_BOARD_OPTIMISE_MMAP
+#if !ARM_BOARD_OPTIMISE_MEM
 /*
  * PLAT_ARM_MMAP_ENTRIES depends on the number of entries in the
  * plat_arm_mmap array defined for each BL stage.
@@ -81,7 +81,29 @@
 # define MAX_XLAT_TABLES		5
 #endif
 
-#endif /* ARM_BOARD_OPTIMISE_MMAP */
+/*
+ * PLAT_ARM_MAX_BL1_RW_SIZE is calculated using the current BL1 RW debug size
+ * plus a little space for growth.
+ */
+#define PLAT_ARM_MAX_BL1_RW_SIZE	0xA000
+
+/*
+ * PLAT_ARM_MAX_BL2_SIZE is calculated using the current BL2 debug size plus a
+ * little space for growth.
+ */
+#if TRUSTED_BOARD_BOOT
+# define PLAT_ARM_MAX_BL2_SIZE		0x1D000
+#else
+# define PLAT_ARM_MAX_BL2_SIZE		0xF000
+#endif
+
+/*
+ * PLAT_ARM_MAX_BL31_SIZE is calculated using the current BL31 debug size plus a
+ * little space for growth.
+ */
+#define PLAT_ARM_MAX_BL31_SIZE		0x1D000
+
+#endif /* ARM_BOARD_OPTIMISE_MEM */
 
 #define MAX_IO_DEVICES			3
 #define MAX_IO_HANDLES			4

--- a/plat/arm/board/common/board_common.mk
+++ b/plat/arm/board/common/board_common.mk
@@ -61,8 +61,8 @@ ifneq (${TRUSTED_BOARD_BOOT},0)
 endif
 
 # This flag controls whether memory usage needs to be optimised
-ARM_BOARD_OPTIMISE_MMAP	?=	0
+ARM_BOARD_OPTIMISE_MEM	?=	0
 
 # Process flags
-$(eval $(call assert_boolean,ARM_BOARD_OPTIMISE_MMAP))
-$(eval $(call add_define,ARM_BOARD_OPTIMISE_MMAP))
+$(eval $(call assert_boolean,ARM_BOARD_OPTIMISE_MEM))
+$(eval $(call add_define,ARM_BOARD_OPTIMISE_MEM))

--- a/plat/arm/board/fvp/include/platform_def.h
+++ b/plat/arm/board/fvp/include/platform_def.h
@@ -146,26 +146,4 @@
 
 #define PLAT_ARM_G0_IRQS		ARM_G0_IRQS
 
-/*
- * PLAT_ARM_MAX_BL1_RW_SIZE is calculated using the current BL1 RW debug size
- * plus a little space for growth.
- */
-#define PLAT_ARM_MAX_BL1_RW_SIZE	0xA000
-
-/*
- * PLAT_ARM_MAX_BL2_SIZE is calculated using the current BL2 debug size plus a
- * little space for growth.
- */
-#if TRUSTED_BOARD_BOOT
-# define PLAT_ARM_MAX_BL2_SIZE		0x1D000
-#else
-# define PLAT_ARM_MAX_BL2_SIZE		0xC000
-#endif
-
-/*
- * PLAT_ARM_MAX_BL31_SIZE is calculated using the current BL31 debug size plus a
- * little space for growth.
- */
-#define PLAT_ARM_MAX_BL31_SIZE		0x1D000
-
 #endif /* __PLATFORM_DEF_H__ */

--- a/plat/arm/board/juno/include/platform_def.h
+++ b/plat/arm/board/juno/include/platform_def.h
@@ -74,10 +74,10 @@
 #endif /* TRUSTED_BOARD_BOOT */
 
 /*
- * If ARM_BOARD_OPTIMISE_MMAP=0 then Juno uses the default, unoptimised values
+ * If ARM_BOARD_OPTIMISE_MEM=0 then Juno uses the default, unoptimised values
  * defined for ARM development platforms.
  */
-#if ARM_BOARD_OPTIMISE_MMAP
+#if ARM_BOARD_OPTIMISE_MEM
 /*
  * PLAT_ARM_MMAP_ENTRIES depends on the number of entries in the
  * plat_arm_mmap array defined for each BL stage.
@@ -107,7 +107,33 @@
 # define MAX_XLAT_TABLES		3
 #endif
 
-#endif /* ARM_BOARD_OPTIMISE_MMAP */
+/*
+ * PLAT_ARM_MAX_BL1_RW_SIZE is calculated using the current BL1 RW debug size
+ * plus a little space for growth.
+ */
+#if TRUSTED_BOARD_BOOT
+# define PLAT_ARM_MAX_BL1_RW_SIZE	0x9000
+#else
+# define PLAT_ARM_MAX_BL1_RW_SIZE	0x6000
+#endif
+
+/*
+ * PLAT_ARM_MAX_BL2_SIZE is calculated using the current BL2 debug size plus a
+ * little space for growth.
+ */
+#if TRUSTED_BOARD_BOOT
+# define PLAT_ARM_MAX_BL2_SIZE		0x1D000
+#else
+# define PLAT_ARM_MAX_BL2_SIZE		0xC000
+#endif
+
+/*
+ * PLAT_ARM_MAX_BL31_SIZE is calculated using the current BL31 debug size plus a
+ * little space for growth.
+ */
+#define PLAT_ARM_MAX_BL31_SIZE		0x1D000
+
+#endif /* ARM_BOARD_OPTIMISE_MEM */
 
 /* CCI related constants */
 #define PLAT_ARM_CCI_BASE		0x2c090000
@@ -182,31 +208,5 @@
 
 /* CSS SoC NIC-400 Global Programmers View (GPV) */
 #define PLAT_SOC_CSS_NIC400_BASE	0x2a000000
-
-/*
- * PLAT_ARM_MAX_BL1_RW_SIZE is calculated using the current BL1 RW debug size
- * plus a little space for growth.
- */
-#if TRUSTED_BOARD_BOOT
-# define PLAT_ARM_MAX_BL1_RW_SIZE	0x9000
-#else
-# define PLAT_ARM_MAX_BL1_RW_SIZE	0x6000
-#endif
-
-/*
- * PLAT_ARM_MAX_BL2_SIZE is calculated using the current BL2 debug size plus a
- * little space for growth.
- */
-#if TRUSTED_BOARD_BOOT
-# define PLAT_ARM_MAX_BL2_SIZE		0x1D000
-#else
-# define PLAT_ARM_MAX_BL2_SIZE		0xC000
-#endif
-
-/*
- * PLAT_ARM_MAX_BL31_SIZE is calculated using the current BL31 debug size plus a
- * little space for growth.
- */
-#define PLAT_ARM_MAX_BL31_SIZE		0x1D000
 
 #endif /* __PLATFORM_DEF_H__ */

--- a/plat/arm/board/juno/platform.mk
+++ b/plat/arm/board/juno/platform.mk
@@ -79,7 +79,7 @@ SKIP_A57_L1_FLUSH_PWR_DWN	:=	 1
 ENABLE_PLAT_COMPAT		:= 	0
 
 # Enable memory map related constants optimisation
-ARM_BOARD_OPTIMISE_MMAP		:=	1
+ARM_BOARD_OPTIMISE_MEM		:=	1
 
 include plat/arm/board/common/board_css.mk
 include plat/arm/common/arm_common.mk


### PR DESCRIPTION
Compile option `ARM_BOARD_OPTIMISE_MMAP` has been renamed to
`ARM_BOARD_OPTIMISE_MEM` because it now applies not only to defines
related to the translation tables but to the image size as well.

The defines `PLAT_ARM_MAX_BL1_RW_SIZE`, `PLAT_ARM_MAX_BL2_SIZE` and
`PLAT_ARM_MAX_BL31_SIZE` have been moved to the file board_arm_def.h.
This way, ARM platforms no longer have to set their own values if
`ARM_BOARD_OPTIMISE_MEM=0` and they can specify optimized values
otherwise. The common sizes have been set to the highest values used
for any of the current build configurations.

This is needed because in some build configurations some images are
running out of space. This way there is a common set of values known
to work for all of them and it can be optimized for each particular
platform if needed.

The space reserved for BL2 when `TRUSTED_BOARD_BOOT=0` has been
increased. This is needed because when memory optimisations are
disabled the values for Juno of `PLAT_ARM_MMAP_ENTRIES` and
`MAX_XLAT_TABLES` are higher. If in this situation the code is
compiled in debug mode and with "-O0", the code won't fit.

Change-Id: I70a3d8d3a0b0cad1d6b602c01a7ea334776e718e