### PR TITLE
GICv3: Fix the GICD_IROUTER offset

### DIFF
--- a/drivers/arm/gic/v3/gicv3_private.h
+++ b/drivers/arm/gic/v3/gicv3_private.h
@@ -141,6 +141,7 @@ static inline unsigned int gicd_read_pidr2(uintptr_t base)
 
 static inline unsigned long long gicd_read_irouter(uintptr_t base, unsigned int id)
 {
+	assert(id >= MIN_SPI_ID);
 	return mmio_read_64(base + GICD_IROUTER + (id << 3));
 }
 
@@ -148,6 +149,7 @@ static inline void gicd_write_irouter(uintptr_t base,
 				      unsigned int id,
 				      unsigned long long affinity)
 {
+	assert(id >= MIN_SPI_ID);
 	mmio_write_64(base + GICD_IROUTER + (id << 3), affinity);
 }
 

--- a/include/drivers/arm/gicv3.h
+++ b/include/drivers/arm/gicv3.h
@@ -55,7 +55,11 @@
 #define GICD_SETSPI_SR		0x50
 #define GICD_CLRSPI_SR		0x50
 #define GICD_IGRPMODR		0xd00
-#define GICD_IROUTER		0x6100
+/*
+ * GICD_IROUTER<n> register is at 0x6000 + 8n, where n is the interrupt id and
+ * n >= 32, making the effective offset as 0x6100.
+ */
+#define GICD_IROUTER		0x6000
 #define GICD_PIDR2_GICV3	0xffe8
 
 #define IGRPMODR_SHIFT		5


### PR DESCRIPTION
This patch fixes the offset of GICD_IROUTER register defined in gicv3.h.
Although the GICv3 documention mentions that the offset for this register
is 0x6100-0x7FD8, the offset calculation for an interrupt id `n` is :

   0x6000 + 8n, where n >= 32

This requires the offset for GICD_IROUTER to be defined as 0x6000.

Fixes ARM-software/tf-issues#410

Change-Id: If9e91e30d946afe7f1f60fea4f065c7567093fa8