### PR TITLE
Improve debug assertion for runtime svc number

### DIFF
--- a/common/runtime_svc.c
+++ b/common/runtime_svc.c
@@ -87,7 +87,8 @@ void runtime_svc_init(void)
 	int rc = 0, index, start_idx, end_idx;
 
 	/* Assert the number of descriptors detected are less than maximum indices */
-	assert((RT_SVC_DECS_NUM >= 0) && (RT_SVC_DECS_NUM < MAX_RT_SVCS));
+	assert((RT_SVC_DESCS_END >= RT_SVC_DESCS_START) &&
+			(RT_SVC_DECS_NUM < MAX_RT_SVCS));
 
 	/* If no runtime services are implemented then simply bail out */
 	if (RT_SVC_DECS_NUM == 0)


### PR DESCRIPTION
This patch improves the debug assertion for runtime svc number
 - Remove useless comparison ensuring that the number of descriptors
   is a positive number. The variable is an unsigned integer so can't
   be negative.
 - Check that the end address of the descriptors is sane relative
   to the start address.

Change-Id: Iea7be6b34e33b8b1cbd394eb923cc834ea964831