### PR TITLE
gicv3: disable Group1 NonSecure interrupts during core powerdown

### DIFF
--- a/drivers/arm/gic/v3/gicv3_main.c
+++ b/drivers/arm/gic/v3/gicv3_main.c
@@ -280,9 +280,10 @@ void gicv3_cpuif_disable(unsigned int proc_num)
 	write_icc_igrpen0_el1(read_icc_igrpen0_el1() &
 			      ~IGRPEN1_EL1_ENABLE_G0_BIT);
 
-	/* Disable Group1 Secure interrupts */
+	/* Disable Group1 Secure and Non-Secure interrupts */
 	write_icc_igrpen1_el3(read_icc_igrpen1_el3() &
-			      ~IGRPEN1_EL3_ENABLE_G1S_BIT);
+			      ~(IGRPEN1_EL3_ENABLE_G1NS_BIT |
+			      IGRPEN1_EL3_ENABLE_G1S_BIT));
 
 	/* Synchronise accesses to group enable registers */
 	isb();


### PR DESCRIPTION
As per the GICv3 specification, to power down a processor using GICv3
and allow automatic power-on if an interrupt must be sent to a processor,
software must set Enable to zero for all interrupt groups(by writing to
GICC_CTLR or ICC_IGRPEN{0,1}_EL1/3 as appropriate.

Also, NonSecure EL1 software may not be aware of the CPU power state
details and fail to choose right states that require quiescing the CPU
interface. So it's preferred that the PSCI implementation handles it as
it is fully aware of the CPU power states.

This patch adds disabling of Group1 NonSecure interrupts during processor
power down along with Group0 and Group1 Secure interrupts so that all the
interrupt groups are handled at once as per specification.

Change-Id: Ib564d773c9c4c41f2ca9471451c030e3de75e641