### PR TITLE
Move up to Base FVP version 7.6

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1032,10 +1032,10 @@ This version of the ARM Trusted Firmware has been tested on the following ARM
 FVPs (64-bit versions only).
 
 *   `Foundation_Platform` (Version 9.5, Build 9.5.40)
-*   `FVP_Base_AEMv8A-AEMv8A` (Version 7.2, Build 0.8.7202)
-*   `FVP_Base_Cortex-A57x4-A53x4` (Version 7.2, Build 0.8.7202)
-*   `FVP_Base_Cortex-A57x1-A53x1` (Version 7.2, Build 0.8.7202)
-*   `FVP_Base_Cortex-A57x2-A53x4` (Version 7.2, Build 0.8.7202)
+*   `FVP_Base_AEMv8A-AEMv8A` (Version 7.6, Build 0.8.7605)
+*   `FVP_Base_Cortex-A57x4-A53x4` (Version 7.6, Build 0.8.7605)
+*   `FVP_Base_Cortex-A57x1-A53x1` (Version 7.6, Build 0.8.7605)
+*   `FVP_Base_Cortex-A57x2-A53x4` (Version 7.6, Build 0.8.7605)
 
 NOTE: The build numbers quoted above are those reported by launching the FVP
 with the `--version` parameter. `Foundation_Platform` tarball for `--version`


### PR DESCRIPTION
This patch updates the User Guide to move up from version 7.2 to 7.6
of the Base FVP.
