### PR TITLE
Add WFI in platform's unexpected error handlers

### DIFF
--- a/plat/arm/board/fvp/fvp_err.c
+++ b/plat/arm/board/fvp/fvp_err.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2016, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -28,6 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <arch_helpers.h>
 #include <board_arm_def.h>
 #include <debug.h>
 #include <errno.h>
@@ -61,5 +62,5 @@ void plat_error_handler(int err)
 
 	/* Loop until the watchdog resets the system */
 	for (;;)
-		;
+		wfi();
 }

--- a/plat/arm/board/juno/juno_err.c
+++ b/plat/arm/board/juno/juno_err.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2016, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -28,6 +28,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <arch_helpers.h>
 #include <errno.h>
 #include <v2m_def.h>
 
@@ -45,5 +46,5 @@ void plat_error_handler(int err)
 
 	/* Loop until the watchdog resets the system */
 	for (;;)
-		;
+		wfi();
 }

--- a/plat/common/aarch64/platform_helpers.S
+++ b/plat/common/aarch64/platform_helpers.S
@@ -130,6 +130,7 @@ endfunc bl1_plat_prepare_exit
 	 * -----------------------------------------------------
 	 */
 func plat_error_handler
+	wfi
 	b	plat_error_handler
 endfunc plat_error_handler
 
@@ -139,5 +140,6 @@ endfunc plat_error_handler
 	 * -----------------------------------------------------
 	 */
 func plat_panic_handler
+	wfi
 	b	plat_panic_handler
 endfunc plat_panic_handler


### PR DESCRIPTION
This patch adds a WFI instruction in the default implementations of
plat_error_handler() and plat_panic_handler(). This potentially reduces
power consumption by allowing the hardware to enter a low-power state.
The same change has been made to the FVP and Juno platform ports.
