### PR TITLE
Remove looping around `plat_report_exception`

### DIFF
--- a/bl1/aarch64/bl1_exceptions.S
+++ b/bl1/aarch64/bl1_exceptions.S
@@ -49,25 +49,25 @@ vector_base bl1_exceptions
 vector_entry SynchronousExceptionSP0
 	mov	x0, #SYNC_EXCEPTION_SP_EL0
 	bl	plat_report_exception
-	b	SynchronousExceptionSP0
+	bl	plat_panic_handler
 	check_vector_size SynchronousExceptionSP0
 
 vector_entry IrqSP0
 	mov	x0, #IRQ_SP_EL0
 	bl	plat_report_exception
-	b	IrqSP0
+	bl	plat_panic_handler
 	check_vector_size IrqSP0
 
 vector_entry FiqSP0
 	mov	x0, #FIQ_SP_EL0
 	bl	plat_report_exception
-	b	FiqSP0
+	bl	plat_panic_handler
 	check_vector_size FiqSP0
 
 vector_entry SErrorSP0
 	mov	x0, #SERROR_SP_EL0
 	bl	plat_report_exception
-	b	SErrorSP0
+	bl	plat_panic_handler
 	check_vector_size SErrorSP0
 
 	/* -----------------------------------------------------
@@ -77,25 +77,25 @@ vector_entry SErrorSP0
 vector_entry SynchronousExceptionSPx
 	mov	x0, #SYNC_EXCEPTION_SP_ELX
 	bl	plat_report_exception
-	b	SynchronousExceptionSPx
+	bl	plat_panic_handler
 	check_vector_size SynchronousExceptionSPx
 
 vector_entry IrqSPx
 	mov	x0, #IRQ_SP_ELX
 	bl	plat_report_exception
-	b	IrqSPx
+	bl	plat_panic_handler
 	check_vector_size IrqSPx
 
 vector_entry FiqSPx
 	mov	x0, #FIQ_SP_ELX
 	bl	plat_report_exception
-	b	FiqSPx
+	bl	plat_panic_handler
 	check_vector_size FiqSPx
 
 vector_entry SErrorSPx
 	mov	x0, #SERROR_SP_ELX
 	bl	plat_report_exception
-	b	SErrorSPx
+	bl	plat_panic_handler
 	check_vector_size SErrorSPx
 
 	/* -----------------------------------------------------
@@ -120,19 +120,19 @@ vector_entry SynchronousExceptionA64
 vector_entry IrqA64
 	mov	x0, #IRQ_AARCH64
 	bl	plat_report_exception
-	b	IrqA64
+	bl	plat_panic_handler
 	check_vector_size IrqA64
 
 vector_entry FiqA64
 	mov	x0, #FIQ_AARCH64
 	bl	plat_report_exception
-	b	FiqA64
+	bl	plat_panic_handler
 	check_vector_size FiqA64
 
 vector_entry SErrorA64
 	mov	x0, #SERROR_AARCH64
 	bl	plat_report_exception
-	b   	SErrorA64
+	bl	plat_panic_handler
 	check_vector_size SErrorA64
 
 	/* -----------------------------------------------------
@@ -142,25 +142,25 @@ vector_entry SErrorA64
 vector_entry SynchronousExceptionA32
 	mov	x0, #SYNC_EXCEPTION_AARCH32
 	bl	plat_report_exception
-	b	SynchronousExceptionA32
+	bl	plat_panic_handler
 	check_vector_size SynchronousExceptionA32
 
 vector_entry IrqA32
 	mov	x0, #IRQ_AARCH32
 	bl	plat_report_exception
-	b	IrqA32
+	bl	plat_panic_handler
 	check_vector_size IrqA32
 
 vector_entry FiqA32
 	mov	x0, #FIQ_AARCH32
 	bl	plat_report_exception
-	b	FiqA32
+	bl	plat_panic_handler
 	check_vector_size FiqA32
 
 vector_entry SErrorA32
 	mov	x0, #SERROR_AARCH32
 	bl	plat_report_exception
-	b	SErrorA32
+	bl	plat_panic_handler
 	check_vector_size SErrorA32
 
 
@@ -231,8 +231,7 @@ endfunc smc_handler64
 unexpected_sync_exception:
 	mov	x0, #SYNC_EXCEPTION_AARCH64
 	bl	plat_report_exception
-	wfi
-	b	unexpected_sync_exception
+	bl	plat_panic_handler
 
 	/* -----------------------------------------------------
 	 * Save Secure/Normal world context and jump to

--- a/common/aarch64/early_exceptions.S
+++ b/common/aarch64/early_exceptions.S
@@ -47,25 +47,25 @@ vector_base early_exceptions
 vector_entry SynchronousExceptionSP0
 	mov	x0, #SYNC_EXCEPTION_SP_EL0
 	bl	plat_report_exception
-	b	SynchronousExceptionSP0
+	bl	plat_panic_handler
 	check_vector_size SynchronousExceptionSP0
 
 vector_entry IrqSP0
 	mov	x0, #IRQ_SP_EL0
 	bl	plat_report_exception
-	b	IrqSP0
+	bl	plat_panic_handler
 	check_vector_size IrqSP0
 
 vector_entry FiqSP0
 	mov	x0, #FIQ_SP_EL0
 	bl	plat_report_exception
-	b	FiqSP0
+	bl	plat_panic_handler
 	check_vector_size FiqSP0
 
 vector_entry SErrorSP0
 	mov	x0, #SERROR_SP_EL0
 	bl	plat_report_exception
-	b	SErrorSP0
+	bl	plat_panic_handler
 	check_vector_size SErrorSP0
 
 	/* -----------------------------------------------------
@@ -75,25 +75,25 @@ vector_entry SErrorSP0
 vector_entry SynchronousExceptionSPx
 	mov	x0, #SYNC_EXCEPTION_SP_ELX
 	bl	plat_report_exception
-	b	SynchronousExceptionSPx
+	bl	plat_panic_handler
 	check_vector_size SynchronousExceptionSPx
 
 vector_entry IrqSPx
 	mov	x0, #IRQ_SP_ELX
 	bl	plat_report_exception
-	b	IrqSPx
+	bl	plat_panic_handler
 	check_vector_size IrqSPx
 
 vector_entry FiqSPx
 	mov	x0, #FIQ_SP_ELX
 	bl	plat_report_exception
-	b	FiqSPx
+	bl	plat_panic_handler
 	check_vector_size FiqSPx
 
 vector_entry SErrorSPx
 	mov	x0, #SERROR_SP_ELX
 	bl	plat_report_exception
-	b	SErrorSPx
+	bl	plat_panic_handler
 	check_vector_size SErrorSPx
 
 	/* -----------------------------------------------------
@@ -103,25 +103,25 @@ vector_entry SErrorSPx
 vector_entry SynchronousExceptionA64
 	mov	x0, #SYNC_EXCEPTION_AARCH64
 	bl	plat_report_exception
-	b	SynchronousExceptionA64
+	bl	plat_panic_handler
 	check_vector_size SynchronousExceptionA64
 
 vector_entry IrqA64
 	mov	x0, #IRQ_AARCH64
 	bl	plat_report_exception
-	b	IrqA64
+	bl	plat_panic_handler
 	check_vector_size IrqA64
 
 vector_entry FiqA64
 	mov	x0, #FIQ_AARCH64
 	bl	plat_report_exception
-	b	FiqA64
+	bl	plat_panic_handler
 	check_vector_size FiqA64
 
 vector_entry SErrorA64
 	mov	x0, #SERROR_AARCH64
 	bl	plat_report_exception
-	b   	SErrorA64
+	bl	plat_panic_handler
 	check_vector_size SErrorA64
 
 	/* -----------------------------------------------------
@@ -131,23 +131,23 @@ vector_entry SErrorA64
 vector_entry SynchronousExceptionA32
 	mov	x0, #SYNC_EXCEPTION_AARCH32
 	bl	plat_report_exception
-	b	SynchronousExceptionA32
+	bl	plat_panic_handler
 	check_vector_size SynchronousExceptionA32
 
 vector_entry IrqA32
 	mov	x0, #IRQ_AARCH32
 	bl	plat_report_exception
-	b	IrqA32
+	bl	plat_panic_handler
 	check_vector_size IrqA32
 
 vector_entry FiqA32
 	mov	x0, #FIQ_AARCH32
 	bl	plat_report_exception
-	b	FiqA32
+	bl	plat_panic_handler
 	check_vector_size FiqA32
 
 vector_entry SErrorA32
 	mov	x0, #SERROR_AARCH32
 	bl	plat_report_exception
-	b	SErrorA32
+	bl	plat_panic_handler
 	check_vector_size SErrorA32


### PR DESCRIPTION
This patch removes the tight loop that calls `plat_report_exception`
in unhandled exceptions in AArch64 state.
The new behaviour is to call the `plat_report_exception` only
once followed by call to `plat_panic_handler`.
This allows platforms to take platform-specific action when
there is an unhandled exception, instead of always spinning
in a tight loop.

Note: This is a subtle break in behaviour for platforms that
      expect `plat_report_exception` to be continuously executed
      when there is an unhandled exception.

Change-Id: Ie2453804b9b7caf9b010ee73e1a90eeb8384e4e8