### PR TITLE
Automatically select initial xlation lookup level

### DIFF
--- a/include/lib/aarch32/arch.h
+++ b/include/lib/aarch32/arch.h
@@ -254,6 +254,8 @@
 
 #define TTBCR_T1SZ_SHIFT	16
 #define TTBCR_T1SZ_MASK		(0x7)
+#define TTBCR_TxSZ_MIN		0
+#define TTBCR_TxSZ_MAX		7
 
 #define TTBCR_SH0_NON_SHAREABLE		(0x0 << 12)
 #define TTBCR_SH0_OUTER_SHAREABLE	(0x2 << 12)

--- a/include/lib/aarch64/arch.h
+++ b/include/lib/aarch64/arch.h
@@ -243,6 +243,9 @@
 #define TCR_EL1_IPS_SHIFT	32
 #define TCR_EL3_PS_SHIFT	16
 
+#define TCR_TxSZ_MIN		16
+#define TCR_TxSZ_MAX		39
+
 /* (internal) physical address size bits in EL3/EL1 */
 #define TCR_PS_BITS_4GB		(0x0)
 #define TCR_PS_BITS_64GB	(0x1)

--- a/include/lib/xlat_tables.h
+++ b/include/lib/xlat_tables.h
@@ -32,29 +32,12 @@
 #define __XLAT_TABLES_H__
 
 /* Miscellaneous MMU related constants */
-#define NUM_2MB_IN_GB		(1 << 9)
-#define NUM_4K_IN_2MB		(1 << 9)
-#define NUM_GB_IN_4GB		(1 << 2)
-
-#define TWO_MB_SHIFT		21
-#define ONE_GB_SHIFT		30
 #define FOUR_KB_SHIFT		12
 
-#define ONE_GB_INDEX(x)		((x) >> ONE_GB_SHIFT)
-#define TWO_MB_INDEX(x)		((x) >> TWO_MB_SHIFT)
-#define FOUR_KB_INDEX(x)	((x) >> FOUR_KB_SHIFT)
-
 #define INVALID_DESC		0x0
-#define BLOCK_DESC		0x1
-#define TABLE_DESC		0x3
-
-#define FIRST_LEVEL_DESC_N	ONE_GB_SHIFT
-#define SECOND_LEVEL_DESC_N	TWO_MB_SHIFT
-#define THIRD_LEVEL_DESC_N	FOUR_KB_SHIFT
-
-#define LEVEL1			1
-#define LEVEL2			2
-#define LEVEL3			3
+#define BLOCK_DESC		0x1 /* Table levels 0-2 */
+#define TABLE_DESC		0x3 /* Table levels 0-2 */
+#define PAGE_DESC		0x3 /* Table level 3 */
 
 #define XN			(1ull << 2)
 #define PXN			(1ull << 1)
@@ -78,6 +61,14 @@
 #define XLAT_TABLE_SIZE_SHIFT	PAGE_SIZE_SHIFT
 #define XLAT_TABLE_SIZE		(1 << XLAT_TABLE_SIZE_SHIFT)
 
+#ifdef AARCH32
+#define XLAT_TABLE_LEVEL_MIN	1
+#else
+#define XLAT_TABLE_LEVEL_MIN	0
+#endif /* AARCH32 */
+
+#define XLAT_TABLE_LEVEL_MAX	3
+
 /* Values for number of entries in each MMU translation table */
 #define XLAT_TABLE_ENTRIES_SHIFT (XLAT_TABLE_SIZE_SHIFT - XLAT_ENTRY_SIZE_SHIFT)
 #define XLAT_TABLE_ENTRIES	(1 << XLAT_TABLE_ENTRIES_SHIFT)
@@ -87,6 +78,7 @@
 #define L3_XLAT_ADDRESS_SHIFT	PAGE_SIZE_SHIFT
 #define L2_XLAT_ADDRESS_SHIFT	(L3_XLAT_ADDRESS_SHIFT + XLAT_TABLE_ENTRIES_SHIFT)
 #define L1_XLAT_ADDRESS_SHIFT	(L2_XLAT_ADDRESS_SHIFT + XLAT_TABLE_ENTRIES_SHIFT)
+#define L0_XLAT_ADDRESS_SHIFT	(L1_XLAT_ADDRESS_SHIFT + XLAT_TABLE_ENTRIES_SHIFT)
 
 /*
  * AP[1] bit is ignored by hardware and is

--- a/lib/xlat_tables/xlat_tables_private.h
+++ b/lib/xlat_tables/xlat_tables_private.h
@@ -31,6 +31,12 @@
 #ifndef __XLAT_TABLES_PRIVATE_H__
 #define __XLAT_TABLES_PRIVATE_H__
 
+#include <cassert.h>
+#include <utils.h>
+
+/* The virtual address space size must be a power of two. */
+CASSERT(IS_POWER_OF_TWO(ADDR_SPACE_SIZE), assert_valid_addr_space_size);
+
 void print_mmap(void);
 void init_xlation_table(uintptr_t base_va, uint64_t *table,
 			int level, uintptr_t *max_va,


### PR DESCRIPTION
Instead of hardcoding a level 1 table as the base translation level
table, let the code decide which level is the most appropriate given
the virtual address space size.

As the table granularity is 4 KB, this allows the code to select
level 0, 1 or 2 as base level for AArch64. This way, instead of
limiting the virtual address space width to 39-31 bits, widths of
48-25 bit can be used.

For AArch32, this change allows the code to select level 1 or 2
as the base translation level table and use virtual address space
width of 32-25 bits.

Also removed some unused definitions related to translation tables.

Fixes ARM-software/tf-issues#362

Change-Id: Ie3bb5d6d1a4730a26700b09827c79f37ca3cdb65