### PR TITLE
Fixes for AArch32 port of TF

### DIFF
--- a/common/bl_common.c
+++ b/common/bl_common.c
@@ -419,9 +419,11 @@ void print_entry_point_info(const entry_point_info_t *ep_info)
 	PRINT_IMAGE_ARG(1);
 	PRINT_IMAGE_ARG(2);
 	PRINT_IMAGE_ARG(3);
+#ifndef AARCH32
 	PRINT_IMAGE_ARG(4);
 	PRINT_IMAGE_ARG(5);
 	PRINT_IMAGE_ARG(6);
 	PRINT_IMAGE_ARG(7);
+#endif
 #undef PRINT_IMAGE_ARG
 }

--- a/lib/el3_runtime/aarch32/context_mgmt.c
+++ b/lib/el3_runtime/aarch32/context_mgmt.c
@@ -86,6 +86,8 @@ static void cm_init_context_common(cpu_context_t *ctx, const entry_point_info_t 
 	/* Clear any residual register values from the context */
 	memset(ctx, 0, sizeof(*ctx));
 
+	reg_ctx = get_regs_ctx(ctx);
+
 	/*
 	 * Base the context SCR on the current value, adjust for entry point
 	 * specific requirements
@@ -120,8 +122,6 @@ static void cm_init_context_common(cpu_context_t *ctx, const entry_point_info_t 
 
 	if (GET_M32(ep->spsr) == MODE32_hyp)
 		scr |= SCR_HCE_BIT;
-
-	reg_ctx = get_regs_ctx(ctx);
 
 	write_ctx_reg(reg_ctx, CTX_SCR, scr);
 	write_ctx_reg(reg_ctx, CTX_LR, ep->pc);


### PR DESCRIPTION
This patch fixes a build error and CPU context initialization bug in the AArch32
port of context management library.