### PR TITLE
rockchip: fix the scu idle for rk3399

### DIFF
--- a/plat/rockchip/rk3399/drivers/pmu/pmu.c
+++ b/plat/rockchip/rk3399/drivers/pmu/pmu.c
@@ -546,8 +546,7 @@ static inline void clst_pwr_domain_suspend(plat_local_state_t lvl_state)
 
 	assert(cpu_id < PLATFORM_CORE_COUNT);
 
-	if (lvl_state == PLAT_MAX_RET_STATE  ||
-	    lvl_state == PLAT_MAX_OFF_STATE) {
+	if (lvl_state == PLAT_MAX_OFF_STATE) {
 		if (cpu_id < PLATFORM_CLUSTER0_CORE_COUNT) {
 			pll_id = ALPLL_ID;
 			clst_st_msk = CLST_L_CPUS_MSK;
@@ -591,8 +590,7 @@ static int clst_pwr_domain_resume(plat_local_state_t lvl_state)
 
 	assert(cpu_id < PLATFORM_CORE_COUNT);
 
-	if (lvl_state == PLAT_MAX_RET_STATE ||
-	    lvl_state == PLAT_MAX_OFF_STATE) {
+	if (lvl_state == PLAT_MAX_OFF_STATE) {
 		if (cpu_id < PLATFORM_CLUSTER0_CORE_COUNT)
 			pll_id = ALPLL_ID;
 		else


### PR DESCRIPTION
As rk3399 reported the d8/octane scores drop 10% with cpu idle.
The root cause is thc cpu cluster enter the slow mode.
We don't need switch the clock to 24MHz if cpu cluster enter the
retention mode. In order to improve performance, it just needs for
cluster enter powering off mode.

Also, we shouldn't do anything for hlvl if the system is off.

Change-Id: I2a02962a01343abd0cba47ed63192c1cdf88b119