### PR TITLE
Flush `psci_plat_pm_ops` after initialization

### DIFF
--- a/lib/psci/psci_setup.c
+++ b/lib/psci/psci_setup.c
@@ -238,6 +238,13 @@ int psci_setup(uintptr_t mailbox_ep)
 	plat_setup_psci_ops(mailbox_ep, &psci_plat_pm_ops);
 	assert(psci_plat_pm_ops);
 
+	/*
+	 * Flush `psci_plat_pm_ops` as it will be accessed by secondary CPUs
+	 * during warm boot before data cache is enabled.
+	 */
+	flush_dcache_range((uintptr_t)&psci_plat_pm_ops,
+					sizeof(psci_plat_pm_ops));
+
 	/* Initialize the psci capability */
 	psci_caps = PSCI_GENERIC_CAP;
 


### PR DESCRIPTION
The `psci_plat_pm_ops` global pointer is initialized during cold boot by the
primary CPU and will be accessed by the secondary CPUs before enabling data
cache during warm boot. This patch adds a missing data cache flush of
`psci_plat_psci_ops` after initialization during psci_setup() so that
secondaries can see the updated `psci_plat_psci_ops` pointer.

Fixes ARM-software/tf-issues#424

Change-Id: Id4554800b5646302b944115a33be69507d53cedb