### PR TITLE
fiptool: Add support for printing the sha256 digest with info command

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -64,7 +64,7 @@ Cygwin, and Msys (MinGW) shells, using version 4.9.1 of the GNU toolchain.
 Install the required packages to build Trusted Firmware with the following
 command:
 
-    sudo apt-get install build-essential gcc make git
+    sudo apt-get install build-essential gcc make git libssl-dev
 
 Download and install the AArch64 little-endian GCC cross compiler as indicated
 in the [Linaro instructions][Linaro SW Instructions].
@@ -73,8 +73,6 @@ In addition, the following optional packages and tools may be needed:
 
 *   `device-tree-compiler` package if you need to rebuild the Flattened Device
     Tree (FDT) source files (`.dts` files) provided with this software.
-
-*   `libssl-dev` package if Trusted Board Boot is enabled in the build.
 
 *   For debugging, ARM [Development Studio 5 (DS-5)][DS-5].
 

--- a/tools/fiptool/Makefile
+++ b/tools/fiptool/Makefile
@@ -44,6 +44,7 @@ ifeq (${DEBUG},1)
 else
   CFLAGS += -O2
 endif
+LDLIBS := -lcrypto
 
 ifeq (${V},0)
   Q := @
@@ -62,7 +63,7 @@ all: ${PROJECT} fip_create
 
 ${PROJECT}: ${OBJECTS} Makefile
 	@echo "  LD      $@"
-	${Q}${CC} ${OBJECTS} -o $@
+	${Q}${CC} ${OBJECTS} -o $@ ${LDLIBS}
 	@${ECHO_BLANK_LINE}
 	@echo "Built $@ successfully"
 	@${ECHO_BLANK_LINE}


### PR DESCRIPTION
This feature allows one to quickly verify that the expected
image is contained in the FIP without extracting the image and
running sha256sum(1) on it.

The sha256 digest is only shown when the verbose flag is used.

This change requires libssl-dev to be installed in order to build
Trusted Firmware. Previously, libssl-dev was optionally needed only
to support Trusted Board Boot configurations.

Fixes ARM-Software/tf-issues#124

Change-Id: Ifb1408d17f483d482bb270a589ee74add25ec5a6