### PR TITLE
rockchip: fixes the gic panic for rk3399 resume

### DIFF
--- a/plat/rockchip/rk3399/drivers/pmu/pmu.c
+++ b/plat/rockchip/rk3399/drivers/pmu/pmu.c
@@ -1189,6 +1189,9 @@ static int sys_pwr_domain_resume(void)
 				BIT(PMU_CLR_PERILP) |
 				BIT(PMU_CLR_PMU) |
 				BIT(PMU_CLR_GIC));
+
+	plat_rockchip_gic_cpuif_enable();
+
 	return 0;
 }
 


### PR DESCRIPTION
We make sure the resuming of gic need to be enabled.
Otherwise, The resume will hit the below panic.
...
[   24.230541] CPU0: update max cpu_capacity 451
[   24.236029] CPU5: update max cpu_capacity 1024
[   24.236046] CPU4: shutdown
[   24.243205] psci: CPU4 killed.
[   24.258730] CPU5: shutdown
[   24.261472] psci: CPU5 killed.
[   24.270417] GIC: unable to set SRE (disabled at EL2), panic ahead
[   24.270417] cat[7801]: undefined instruction: pc=ffffffc0004e65d0
[   24.270417] Code: b0003940 91274400 97f871af d2801e00 (d5184600)
[   24.270417] Internal error: Oops - undefined instruction: 0 [#1] PREEMPT

Change-Id: Ie9542c8d5768ba0accfa073453da8bfe06d4f921