### PR TITLE
Ensure PMF service timestamps are properly aligned on a cache line bo…

### DIFF
--- a/include/lib/pmf/pmf_helpers.h
+++ b/include/lib/pmf/pmf_helpers.h
@@ -71,7 +71,9 @@ typedef struct pmf_svc_desc {
  */
 #define PMF_ALLOCATE_TIMESTAMP_MEMORY(_name, _total_id)		\
 	unsigned long long pmf_ts_mem_ ## _name[_total_id]	\
-	__section("pmf_timestamp_array") __used;
+	__aligned(CACHE_WRITEBACK_GRANULE)			\
+	__section("pmf_timestamp_array")			\
+	__used;
 
 /*
  * Convenience macro to validate tid index for the given TS array.


### PR DESCRIPTION
…undary

When using more than a single service in PMF, it is necessary that the
per-service timestamps begin on a cache line boundary.  Previously it
was possible that two services shared a cache line for their
timestamps.  This made it difficult to reason about cache maintenance
operations within a single service and required a global understanding
of how all services operate.

Change-Id: Iacaae5154a7e19ad4107468e56df9ad082ee371c