### PR TITLE
Add some missing forward declarations in plat_arm.h

### DIFF
--- a/include/plat/arm/common/plat_arm.h
+++ b/include/plat/arm/common/plat_arm.h
@@ -37,6 +37,12 @@
 #include <utils.h>
 #include <xlat_tables.h>
 
+/*******************************************************************************
+ * Forward declarations
+ ******************************************************************************/
+struct bl31_params;
+struct meminfo;
+
 #define ARM_CASSERT_MMAP						\
 	CASSERT((ARRAY_SIZE(plat_arm_mmap) + ARM_BL_REGIONS)		\
 		<= MAX_MMAP_REGIONS,					\
@@ -145,7 +151,7 @@ void arm_bl1_platform_setup(void);
 void arm_bl1_plat_arch_setup(void);
 
 /* BL2 utility functions */
-void arm_bl2_early_platform_setup(meminfo_t *mem_layout);
+void arm_bl2_early_platform_setup(struct meminfo *mem_layout);
 void arm_bl2_platform_setup(void);
 void arm_bl2_plat_arch_setup(void);
 uint32_t arm_get_spsr_for_bl32_entry(void);
@@ -158,7 +164,7 @@ void arm_bl2u_platform_setup(void);
 void arm_bl2u_plat_arch_setup(void);
 
 /* BL31 utility functions */
-void arm_bl31_early_platform_setup(bl31_params_t *from_bl2,
+void arm_bl31_early_platform_setup(struct bl31_params *from_bl2,
 				void *plat_params_from_bl2);
 void arm_bl31_platform_setup(void);
 void arm_bl31_plat_runtime_setup(void);


### PR DESCRIPTION
This patch adds a couple of missing forward declarations in plat_arm.h
so that all types it references are known within this header file,
without relying on previous header inclusions. This concerns the
meminfo and bl31_params structures, which are defined in bl_common.h.
Other external types referenced from plat_arm.h (e.g. mmap_region_t)
get declared through header files included by arm_plat.h so they
don't need forward declarations.
