### PR TITLE
AArch32: Fix detection of virtualization support

### DIFF
--- a/bl1/aarch32/bl1_context_mgmt.c
+++ b/bl1/aarch32/bl1_context_mgmt.c
@@ -142,7 +142,7 @@ void bl1_prepare_next_image(unsigned int image_id)
 			SPSR_E_LITTLE, DISABLE_ALL_EXCEPTIONS);
 	} else {
 		/* Use HYP mode if supported else use SVC. */
-		if (GET_VIRT_EXT(read_id_pfr1()) == MODE32_hyp) {
+		if (GET_VIRT_EXT(read_id_pfr1())) {
 			next_bl_ep->spsr = SPSR_MODE32(MODE32_hyp, SPSR_T_ARM,
 				SPSR_E_LITTLE, DISABLE_ALL_EXCEPTIONS);
 		} else {


### PR DESCRIPTION
The Virtualization field in the ID_PFR1 register has only 2
valid values (0 or 1) but it was incorrectly checked against
unrelated value tied to the SPSR register instead.

This patch fixes the detection of virtualization support by
using the valid values in BL1 context management code.

Change-Id: If12592e343770e1da90f0f5fecf0a3376047ac29