### PR TITLE
rockchip: fixes the clock select and divide register for rk3399

### DIFF
--- a/plat/rockchip/rk3399/drivers/soc/soc.c
+++ b/plat/rockchip/rk3399/drivers/soc/soc.c
@@ -325,9 +325,16 @@ void plls_resume_finish(void)
 {
 	int i;
 
-	for (i = 0; i < CRU_CLKSEL_COUNT; i++)
-		mmio_write_32((CRU_BASE + CRU_CLKSEL_CON(i)),
-			      REG_SOC_WMSK | slp_data.cru_clksel_con[i]);
+	for (i = 0; i < CRU_CLKSEL_COUNT; i++) {
+		/* CRU_CLKSEL_CON96~107 the high 16-bit isb't write_mask */
+		if (i > 95)
+			mmio_write_32((CRU_BASE + CRU_CLKSEL_CON(i)),
+				      slp_data.cru_clksel_con[i]);
+		else
+			mmio_write_32((CRU_BASE + CRU_CLKSEL_CON(i)),
+				      REG_SOC_WMSK |
+				      slp_data.cru_clksel_con[i]);
+	}
 	for (i = 0; i < PMUCRU_CLKSEL_CONUT; i++)
 		mmio_write_32((PMUCRU_BASE +
 			      PMUCRU_CLKSEL_OFFSET + i * REG_SIZE),

--- a/plat/rockchip/rk3399/drivers/soc/soc.h
+++ b/plat/rockchip/rk3399/drivers/soc/soc.h
@@ -65,7 +65,7 @@
 
 #define PLL_CON_COUNT			0x06
 #define CRU_CLKSEL_COUNT		0x108
-#define CRU_CLKSEL_CON(n)		(0x80 + (n) * 4)
+#define CRU_CLKSEL_CON(n)		(0x100 + (n) * 4)
 
 #define PMUCRU_CLKSEL_CONUT		0x06
 #define PMUCRU_CLKSEL_OFFSET		0x080


### PR DESCRIPTION
As the new RK3399TRM v1.1, there are some wrong set for CRU_CLKSEL_CON
register.

As the CRU_CLKSEL_CON96～107 high 16-bit isn't write mask and the
CRU_CLKSEL_CON offset is 0x100,not 0x80.

Change-Id: Ie127e9de74b87100af9a0150aad43e89e4972529