### PR TITLE
Remove non-standard <sys/cdefs.h> include from uuid.h

### DIFF
--- a/include/lib/stdlib/sys/uuid.h
+++ b/include/lib/stdlib/sys/uuid.h
@@ -34,8 +34,6 @@
 #ifndef _SYS_UUID_H_
 #define _SYS_UUID_H_
 
-#include <sys/cdefs.h>
-
 /* Length of a node address (an IEEE 802 address). */
 #define	_UUID_NODE_LEN		6
 


### PR DESCRIPTION
This include provides nothing useful for TF and prevents building
the fiptool using musl libc[0].

[0] https://www.musl-libc.org/

Change-Id: Ied35e16b9ea2b40213433f2a8185dddc59077884