### PR TITLE
Fix documentation of bootwrapper boot on juno

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1034,9 +1034,9 @@ used when compiling the FIP must match the ELF entry point.
 #### Boot of a preloaded bootwrapped kernel image on Juno
 
 The procedure to obtain and compile the boot wrapper is very similar to the case
-of the FVP. Once compiled, the `SPIN_ON_BL1_EXIT=1` loading method explained
-above in the EL3 payload boot flow section may be used to load the ELF file over
-JTAG on Juno.
+of the FVP. The execution must be stopped at the end of bl2_main(), and the
+loading method explained above in the EL3 payload boot flow section may be used
+to load the ELF file over JTAG on Juno.
 
 
 9.  Running the software on FVP


### PR DESCRIPTION
The user guide incorrectly claimed that it is possible to load a
bootwrapped kernel over JTAG on Juno in the same manner as an EL3
payload. In the EL3 payload boot flow, some of the platform
initialisations in BL2 are modified. In particular, the TZC settings
are modified to allow unrestricted access to DRAM. This in turn allows
the debugger to access the DRAM and therefore to load the image there.

In the BL33-preloaded boot flow though, BL2 uses the default TZC
programming, which prevent access to most of the DRAM from secure state.
When execution reaches the SPIN_ON_BL1_EXIT loop, the MMU is disabled
and thus DS-5 presumably issues secure access transactions while trying
to load the image, which fails.

One way around it is to stop execution at the end of BL2 instead. At
this point, the MMU is still enabled and the DRAM is mapped as
non-secure memory. Therefore, the debugger is allowed to access this
memory in this context and to sucessfully load the bootwrapped kernel in
DRAM. The user guide is updated to suggest this alternative method.

Co-Authored-By: Sandrine Bailleux <sandrine.bailleux@arm.com>
Signed-off-by: Dan Handley <dan.handley@arm.com>

Change-Id: I537ea1c6d2f96edc06bc3f512e770c748bcabe94