### PR TITLE
Unify SCTLR initialization for AArch32 normal world

### DIFF
--- a/include/lib/aarch32/arch.h
+++ b/include/lib/aarch32/arch.h
@@ -108,7 +108,7 @@
 
 /* SCTLR definitions */
 #define SCTLR_RES1	((1 << 23) | (1 << 22) | (1 << 11) | (1 << 4) | \
-			(1 << 3) | SCTLR_CP15BEN_BIT | SCTLR_NTWI_BIT | SCTLR_NTWE_BIT)
+			(1 << 3))
 #define SCTLR_M_BIT		(1 << 0)
 #define SCTLR_A_BIT		(1 << 1)
 #define SCTLR_C_BIT		(1 << 2)
@@ -128,7 +128,7 @@
 /* HSCTLR definitions */
 #define HSCTLR_RES1 	((1 << 29) | (1 << 28) | (1 << 23) | (1 << 22)	\
 			| (1 << 18) | (1 << 16) | (1 << 11) | (1 << 4)	\
-			| (1 << 3) | HSCTLR_CP15BEN_BIT)
+			| (1 << 3))
 #define HSCTLR_M_BIT		(1 << 0)
 #define HSCTLR_A_BIT		(1 << 1)
 #define HSCTLR_C_BIT		(1 << 2)

--- a/include/lib/aarch64/arch.h
+++ b/include/lib/aarch64/arch.h
@@ -155,7 +155,10 @@
 #define SCTLR_A_BIT		(1 << 1)
 #define SCTLR_C_BIT		(1 << 2)
 #define SCTLR_SA_BIT		(1 << 3)
+#define SCTLR_CP15BEN_BIT	(1 << 5)
 #define SCTLR_I_BIT		(1 << 12)
+#define SCTLR_NTWI_BIT		(1 << 16)
+#define SCTLR_NTWE_BIT		(1 << 18)
 #define SCTLR_WXN_BIT		(1 << 19)
 #define SCTLR_EE_BIT		(1 << 25)
 

--- a/lib/el3_runtime/aarch32/context_mgmt.c
+++ b/lib/el3_runtime/aarch32/context_mgmt.c
@@ -116,7 +116,12 @@ static void cm_init_context_common(cpu_context_t *ctx, const entry_point_info_t 
 	 */
 	if (security_state != SECURE) {
 		sctlr = EP_GET_EE(ep->h.attr) ? SCTLR_EE_BIT : 0;
-		sctlr |= SCTLR_RES1;
+		/*
+		 * In addition to SCTLR_RES1, set the CP15_BEN, nTWI & nTWE
+		 * bits that architecturally reset to 1.
+		 */
+		sctlr |= SCTLR_RES1 | SCTLR_CP15BEN_BIT |
+				SCTLR_NTWI_BIT | SCTLR_NTWE_BIT;
 		write_ctx_reg(reg_ctx, CTX_NS_SCTLR, sctlr);
 	}
 

--- a/lib/el3_runtime/aarch64/context_mgmt.c
+++ b/lib/el3_runtime/aarch64/context_mgmt.c
@@ -143,8 +143,19 @@ static void cm_init_context_common(cpu_context_t *ctx, const entry_point_info_t 
 	sctlr_elx = EP_GET_EE(ep->h.attr) ? SCTLR_EE_BIT : 0;
 	if (GET_RW(ep->spsr) == MODE_RW_64)
 		sctlr_elx |= SCTLR_EL1_RES1;
-	else
+	else {
 		sctlr_elx |= SCTLR_AARCH32_EL1_RES1;
+		/*
+		 * If lower non-secure EL is AArch32, enable the CP15BEN, nTWI
+		 * & nTWI bits. This aligns with SCTLR initialization on
+		 * systems with an AArch32 EL3, where these bits
+		 * architecturally reset to 1.
+		 */
+		if (security_state != SECURE)
+			sctlr_elx |= SCTLR_CP15BEN_BIT | SCTLR_NTWI_BIT
+						| SCTLR_NTWE_BIT;
+	}
+
 	write_ctx_reg(get_sysregs_ctx(ctx), CTX_SCTLR_EL1, sctlr_elx);
 
 	if ((GET_RW(ep->spsr) == MODE_RW_64


### PR DESCRIPTION
The values of CP15BEN, nTWI & nTWE bits in SCTLR_EL1 are architecturally
unknown if EL3 is AARCH64 whereas they reset to 1 if EL3 is AArch32. This
might be a compatibility break for legacy AArch32 normal world software if
these bits are not set to 1 when EL3 is AArch64. This patch enables the
CP15BEN, nTWI and nTWE bits in the SCTLR_EL1 if the lower non-secure EL is
AArch32. This unifies the SCTLR settings for lower non-secure EL in AArch32
mode for both AArch64 and AArch32 builds of Trusted Firmware.

Fixes ARM-software/tf-issues#428

Change-Id: I3152d1580e4869c0ea745c5bd9da765f9c254947
Signed-off-by: Soby Mathew <soby.mathew@arm.com>
