### PR TITLE
rockchip: fix A72 L2CTLR_DATA_RAM_LATENCY to 5

### DIFF
--- a/plat/rockchip/common/aarch64/plat_helpers.S
+++ b/plat/rockchip/common/aarch64/plat_helpers.S
@@ -67,7 +67,7 @@ handler_a72:
 	 * Set the L2 Data RAM latency for Cortex-A72.
 	 * Set the L2 Tag RAM latency to for Cortex-A72.
 	 */
-	mov x0, #((2 << L2CTLR_DATA_RAM_LATENCY_SHIFT) |	\
+	mov x0, #((5 << L2CTLR_DATA_RAM_LATENCY_SHIFT) |	\
 			 (0x1 << 5))
 	msr	L2CTLR_EL1, x0
 	isb


### PR DESCRIPTION
The default value of L2CTLR_DATA_RAM_LATENCY is 2, depends to
the test result on rk3399, the A72 will need lower voltage for
high frequency if it's set to be 5, and almost no effect on performance.

Change-Id: I99a6a43edcc0c58f7775c10f4b85669dc3eff66d