### PR TITLE
Mandate 'Signed-off-by' line in commit messages

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -36,9 +36,6 @@
 # This is not Linux so don't expect a Linux tree!
 --no-tree
 
-# 'Signed-off-by' lines in commit messages are not mandated for TF.
---no-signoff
-
 # This clarifes the lines indications in the report.
 #
 # E.g.:


### PR DESCRIPTION
This patch updates the configuration file for the checkpatch.pl
script to check for the presence of a 'Signed-off-by' line in the
commit message. This is now required by TF contribution process.
