### PR TITLE
fixes the build warning from __deprecated

### DIFF
--- a/include/plat/common/platform.h
+++ b/include/plat/common/platform.h
@@ -61,7 +61,10 @@ struct bl_params;
 /*******************************************************************************
  * Mandatory common functions
  ******************************************************************************/
-unsigned long long plat_get_syscnt_freq(void) __deprecated;
+static inline unsigned long long plat_get_syscnt_freq(void)
+{
+        return 0;
+}
 unsigned int plat_get_syscnt_freq2(void);
 
 int plat_get_image_source(unsigned int image_id,
@@ -324,7 +327,10 @@ unsigned int plat_get_aff_state(unsigned int, unsigned long);
  * haven't migrated to the new platform API to compile on platforms which
  * have the compatibility layer disabled.
  */
-unsigned int platform_get_core_pos(unsigned long mpidr) __deprecated;
+static inline unsigned int platform_get_core_pos(unsigned long mpidr)
+{
+        return 0;
+}
 
 #endif /* __ENABLE_PLAT_COMPAT__ */
 #endif /* __PLATFORM_H__ */


### PR DESCRIPTION
It should not be used because there is (or there will be) a better
alternative in that should be used instead.
Then, warn about uses of the below functions marked as deprecated by
using the deprecated attribute, maybe we can return zero value to avoid
the warning.

bl31/bl31_context_mgmt.c: In function 'cm_get_context_by_mpidr':
bl31/bl31_context_mgmt.c:106:2: warning: 'platform_get_core_pos'
is deprecated (declared at include/plat/common/platform.h:284)
[-Wdeprecated-declarations]

plat/common/aarch64/plat_common.c: In function 'plat_get_syscnt_freq2':
plat/common/aarch64/plat_common.c:84:2: warning: 'plat_get_syscnt_freq'
is deprecated (declared at include/plat/common/platform.h:62)
[-Wdeprecated-declarations]

Change-Id: I7bc1ffca76d1ffdbf6858529dfe5fca2632f3f4a
Signed-off-by: Caesar Wang <wxt@rock-chips.com>