### PR TITLE
fiptool: fix Segmentation fault when only --verbose option is given

### DIFF
--- a/tools/fiptool/fiptool.c
+++ b/tools/fiptool/fiptool.c
@@ -983,6 +983,8 @@ int main(int argc, char *argv[])
 	    strcmp(argv[0], "--verbose") == 0) {
 		verbose = 1;
 		argc--, argv++;
+		if (argc < 1)
+			usage();
 	}
 
 	for (i = 0; i < NELEM(cmds); i++) {


### PR DESCRIPTION
Fix the following bug:

  $ tools/fiptool/fiptool -v
  Segmentation fault (core dumped)

Signed-off-by: Masahiro Yamada <yamada.masahiro@socionext.com>