### PR TITLE
Fix format of patches passed to checkpatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -666,7 +666,7 @@ checkcodebase:		locate-checkpatch
 
 checkpatch:		locate-checkpatch
 	@echo "  CHECKING STYLE"
-	${Q}git log -p ${BASE_COMMIT}..HEAD -- ${CHECK_PATHS} | ${CHECKPATCH} - || true
+	${Q}git format-patch --stdout ${BASE_COMMIT}..HEAD -- ${CHECK_PATHS} | ${CHECKPATCH} - || true
 
 certtool: ${CRTTOOL}
 


### PR DESCRIPTION
Checkpatch is a script developed to verify the style of Linux kernel
patches. As Kernel developers use emails to send patches for review,
checkpatch is prepared for that specific format. This change adapts
the Makefile to use said format.

As a result, indentation in the commit message has been removed, thus
fixing the warnings about Signed-off-by lines being preceded by
whitespace.

Fixes ARM-software/tf-issues#432

Change-Id: I00cb86365fe15f7e2c3a99a306c8eb51cf02fe86
Signed-off-by: Antonio Nino Diaz <antonio.ninodiaz@arm.com>