### PR TITLE
Makefile: Add ability to build dtb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,6 +212,7 @@ OC			:=	${CROSS_COMPILE}objcopy
 OD			:=	${CROSS_COMPILE}objdump
 NM			:=	${CROSS_COMPILE}nm
 PP			:=	${CROSS_COMPILE}gcc -E
+DTC			?=	dtc
 
 ASFLAGS_aarch64		=	-mgeneral-regs-only
 TF_CFLAGS_aarch64	=	-mgeneral-regs-only -mstrict-align
@@ -229,7 +230,7 @@ TF_CFLAGS		+= 	-nostdinc -ffreestanding -Wall			\
 				$(TF_CFLAGS_$(ARCH))				\
 				${DEFINES} ${INCLUDES}
 TF_CFLAGS		+=	-ffunction-sections -fdata-sections
-
+DTC_FLAGS		+=	-I dts -O dtb
 LDFLAGS			+=	--fatal-warnings -O1
 LDFLAGS			+=	--gc-sections
 


### PR DESCRIPTION
Current build system has no means to automatically generate dtbs from
dts, instead, stores the dts and correponding dtbs in the fdts/ folder.

However, it makes much sense for us to build the dtbs while building
the ATF binaries by purely describing which dts sources we need to
build for which BL* stage and generate dtbs as required.

For example, with this change, we will now be able to describe the
dtbs we need for the platform in the corresponding platform.mk file:
BL31_SOURCES += fdts/abc.dts

This should be able to generate the abc.dtb appropriately.

Further, this approach allows us to maintain multiple dtbs which may be
required depending on platforms that we need to support, and all of
those can easily be generated without maintaining dtbs in the source.

If dtc is not available in default paths, but is available in an
alternate location, it can be chosen by overriding the DTC variable
such as 'make DTC=~/dtc/dtc ....`

Signed-off-by: Benjamin Fair <b-fair@ti.com>
Signed-off-by: Nishanth Menon <nm@ti.com>