### PR TITLE
BL31 runtime instrumentation fixes and documentation update

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -466,6 +466,12 @@ performed.
     Note: `TRUSTED_BOARD_BOOT` is currently not supported when `LOAD_IMAGE_V2`
     is enabled.
 
+*   `ENABLE_RUNTIME_INSTRUMENTATION`: Boolean option to enable runtime
+    instrumentation which injects timestamp collection points into
+    Trusted Firmware to allow runtime performance to be measured.
+    Currently, only PSCI is instrumented. Enabling this option enables
+    the `ENABLE_PMF` build option as well. Default is 0.
+
 #### ARM development platform specific build options
 
 *   `ARM_TSP_RAM_LOCATION`: location of the TSP binary. Options:

--- a/services/std_svc/std_svc_setup.c
+++ b/services/std_svc/std_svc_setup.c
@@ -81,9 +81,14 @@ uintptr_t std_svc_smc_handler(uint32_t smc_fid,
 		uint64_t ret;
 
 #if ENABLE_RUNTIME_INSTRUMENTATION
+
+		/*
+		 * Flush cache line so that even if CPU power down happens
+		 * the timestamp update is reflected in memory.
+		 */
 		PMF_WRITE_TIMESTAMP(rt_instr_svc,
 		    RT_INSTR_ENTER_PSCI,
-		    PMF_NO_CACHE_MAINT,
+		    PMF_CACHE_MAINT,
 		    get_cpu_data(cpu_data_pmf_ts[CPU_DATA_PMF_TS0_IDX]));
 #endif
 


### PR DESCRIPTION
The first patch documents the ENABLE_RUNTIME_INSTRUMENTATION option in the user guide.  The second patch fixes a cache maintenance issue in the implementation of runtime instrumentation.  See the individual patches for more details.
