### PR TITLE
readme.md: Add tested Linaro release information for FVPs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -105,7 +105,7 @@ The AArch64 build of this release has been tested on variants r0, r1 and r2
 of the [Juno ARM Development Platform] [Juno] with [Linaro Release 16.06].
 
 The AArch64 build of this release has been tested on the following ARM
-[FVP]s (64-bit host machine only):
+[FVP]s (64-bit host machine only, with [Linaro Release 16.06]):
 
 *   `Foundation_Platform` (Version 10.1, Build 10.1.32)
 *   `FVP_Base_AEMv8A-AEMv8A` (Version 7.7, Build 0.8.7701)
@@ -114,7 +114,7 @@ The AArch64 build of this release has been tested on the following ARM
 *   `FVP_Base_Cortex-A57x2-A53x4` (Version 7.7, Build 0.8.7701)
 
 The AArch32 build of this release has been tested on the following ARM
-[FVP]s (64-bit host machine only):
+[FVP]s (64-bit host machine only, with [Linaro Release 16.06]):
 
 *   `FVP_Base_AEMv8A-AEMv8A` (Version 7.7, Build 0.8.7701)
 *   `FVP_Base_Cortex-A32x4` (Version 10.1, Build 10.1.32)


### PR DESCRIPTION
The platform testing information in the readme currently states which
Linaro release has been tested on Juno platform.

This patch adds the same information for the AArch64/32 FVPs platforms.

Change-Id: Ifa89843ee1744e5030367197648b7a2f4c44cc24
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>