### PR TITLE
firmware-design.md: Fix broken link

### DIFF
--- a/docs/firmware-design.md
+++ b/docs/firmware-design.md
@@ -1077,7 +1077,7 @@ reset handling functions.
 
 Details for implementing a CPU specific reset handler can be found in
 Section 8. Details for implementing a platform specific reset handler can be
-found in the [Porting Guide](see the `plat_reset_handler()` function).
+found in the [Porting Guide] (see the `plat_reset_handler()` function).
 
 When adding functionality to a reset handler, keep in mind that if a different
 reset handling behavior is required between the first and the subsequent


### PR DESCRIPTION
Fix a link broken by a missing space that turned
it into a link to an non-existent anchor.

Change-Id: Ie863e963db28afa3a28b69d3f63bd7638bdf5af9
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>