### PR TITLE
Cosmetic change to exception table

### DIFF
--- a/bl31/aarch64/runtime_exceptions.S
+++ b/bl31/aarch64/runtime_exceptions.S
@@ -38,10 +38,10 @@
 
 	.globl	runtime_exceptions
 
-	/* -----------------------------------------------------
-	 * Handle SMC exceptions separately from other sync.
-	 * exceptions.
-	 * -----------------------------------------------------
+	/* ---------------------------------------------------------------------
+	 * This macro handles Synchronous exceptions.
+	 * Only SMC exceptions are supported.
+	 * ---------------------------------------------------------------------
 	 */
 	.macro	handle_sync_exception
 	/* Enable the SError interrupt */
@@ -50,11 +50,10 @@
 	str	x30, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_LR]
 
 #if ENABLE_RUNTIME_INSTRUMENTATION
-
 	/*
-	 * Read the timestamp value and store it in per-cpu data.
-	 * The value will be extracted from per-cpu data by the
-	 * C level SMC handler and saved to the PMF timestamp region.
+	 * Read the timestamp value and store it in per-cpu data. The value
+	 * will be extracted from per-cpu data by the C level SMC handler and
+	 * saved to the PMF timestamp region.
 	 */
 	mrs	x30, cntpct_el0
 	str	x29, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_X29]
@@ -66,26 +65,22 @@
 	mrs	x30, esr_el3
 	ubfx	x30, x30, #ESR_EC_SHIFT, #ESR_EC_LENGTH
 
+	/* Handle SMC exceptions separately from other synchronous exceptions */
 	cmp	x30, #EC_AARCH32_SMC
 	b.eq	smc_handler32
 
 	cmp	x30, #EC_AARCH64_SMC
 	b.eq	smc_handler64
 
-	/* -----------------------------------------------------
-	 * The following code handles any synchronous exception
-	 * that is not an SMC.
-	 * -----------------------------------------------------
-	 */
-
+	/* Other kinds of synchronous exceptions are not handled */
 	bl	report_unhandled_exception
 	.endm
 
 
-	/* -----------------------------------------------------
-	 * This macro handles FIQ or IRQ interrupts i.e. EL3,
-	 * S-EL1 and NS interrupts.
-	 * -----------------------------------------------------
+	/* ---------------------------------------------------------------------
+	 * This macro handles FIQ or IRQ interrupts i.e. EL3, S-EL1 and NS
+	 * interrupts.
+	 * ---------------------------------------------------------------------
 	 */
 	.macro	handle_interrupt_exception label
 	/* Enable the SError interrupt */
@@ -94,10 +89,7 @@
 	str	x30, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_LR]
 	bl	save_gp_registers
 
-	/*
-	 * Save the EL3 system registers needed to return from
-	 * this exception.
-	 */
+	/* Save the EL3 system registers needed to return from this exception */
 	mrs	x0, spsr_el3
 	mrs	x1, elr_el3
 	stp	x0, x1, [sp, #CTX_EL3STATE_OFFSET + CTX_SPSR_EL3]
@@ -109,36 +101,34 @@
 	mov	sp, x2
 
 	/*
-	 * Find out whether this is a valid interrupt type. If the
-	 * interrupt controller reports a spurious interrupt then
-	 * return to where we came from.
+	 * Find out whether this is a valid interrupt type.
+	 * If the interrupt controller reports a spurious interrupt then return
+	 * to where we came from.
 	 */
 	bl	plat_ic_get_pending_interrupt_type
 	cmp	x0, #INTR_TYPE_INVAL
 	b.eq	interrupt_exit_\label
 
 	/*
-	 * Get the registered handler for this interrupt type. A
-	 * NULL return value could be 'cause of the following
-	 * conditions:
+	 * Get the registered handler for this interrupt type.
+	 * A NULL return value could be 'cause of the following conditions:
 	 *
-	 * a. An interrupt of a type was routed correctly but a
-	 *    handler for its type was not registered.
+	 * a. An interrupt of a type was routed correctly but a handler for its
+	 *    type was not registered.
 	 *
-	 * b. An interrupt of a type was not routed correctly so
-	 *    a handler for its type was not registered.
+	 * b. An interrupt of a type was not routed correctly so a handler for
+	 *    its type was not registered.
 	 *
-	 * c. An interrupt of a type was routed correctly to EL3,
-	 *    but was deasserted before its pending state could
-	 *    be read. Another interrupt of a different type pended
-	 *    at the same time and its type was reported as pending
-	 *    instead. However, a handler for this type was not
-	 *    registered.
+	 * c. An interrupt of a type was routed correctly to EL3, but was
+	 *    deasserted before its pending state could be read. Another
+	 *    interrupt of a different type pended at the same time and its
+	 *    type was reported as pending instead. However, a handler for this
+	 *    type was not registered.
 	 *
-	 * a. and b. can only happen due to a programming error.
-	 * The occurrence of c. could be beyond the control of
-	 * Trusted Firmware. It makes sense to return from this
-	 * exception instead of reporting an error.
+	 * a. and b. can only happen due to a programming error. The
+	 * occurrence of c. could be beyond the control of Trusted Firmware.
+	 * It makes sense to return from this exception instead of reporting an
+	 * error.
 	 */
 	bl	get_interrupt_type_handler
 	cbz	x0, interrupt_exit_\label
@@ -153,7 +143,7 @@
 	/* Restore the reference to the 'handle' i.e. SP_EL3 */
 	mov	x2, x20
 
-	/*  x3 will point to a cookie (not used now) */
+	/* x3 will point to a cookie (not used now) */
 	mov	x3, xzr
 
 	/* Call the interrupt type handler */
@@ -180,24 +170,20 @@ interrupt_exit_\label:
 
 vector_base runtime_exceptions
 
-	/* -----------------------------------------------------
-	 * Current EL with _sp_el0 : 0x0 - 0x200
-	 * -----------------------------------------------------
+	/* ---------------------------------------------------------------------
+	 * Current EL with SP_EL0 : 0x0 - 0x200
+	 * ---------------------------------------------------------------------
 	 */
 vector_entry sync_exception_sp_el0
-	/* -----------------------------------------------------
-	 * We don't expect any synchronous exceptions from EL3
-	 * -----------------------------------------------------
-	 */
+	/* We don't expect any synchronous exceptions from EL3 */
 	bl	report_unhandled_exception
 	check_vector_size sync_exception_sp_el0
 
-	/* -----------------------------------------------------
-	 * EL3 code is non-reentrant. Any asynchronous exception
-	 * is a serious error. Loop infinitely.
-	 * -----------------------------------------------------
-	 */
 vector_entry irq_sp_el0
+	/*
+	 * EL3 code is non-reentrant. Any asynchronous exception is a serious
+	 * error. Loop infinitely.
+	 */
 	bl	report_unhandled_interrupt
 	check_vector_size irq_sp_el0
 
@@ -211,18 +197,16 @@ vector_entry serror_sp_el0
 	bl	report_unhandled_exception
 	check_vector_size serror_sp_el0
 
-	/* -----------------------------------------------------
-	 * Current EL with SPx: 0x200 - 0x400
-	 * -----------------------------------------------------
+	/* ---------------------------------------------------------------------
+	 * Current EL with SP_ELx: 0x200 - 0x400
+	 * ---------------------------------------------------------------------
 	 */
-
 vector_entry sync_exception_sp_elx
-	/* -----------------------------------------------------
-	 * This exception will trigger if anything went wrong
-	 * during a previous exception entry or exit or while
-	 * handling an earlier unexpected synchronous exception.
-	 * There is a high probability that SP_EL3 is corrupted.
-	 * -----------------------------------------------------
+	/*
+	 * This exception will trigger if anything went wrong during a previous
+	 * exception entry or exit or while handling an earlier unexpected
+	 * synchronous exception. There is a high probability that SP_EL3 is
+	 * corrupted.
 	 */
 	bl	report_unhandled_exception
 	check_vector_size sync_exception_sp_elx
@@ -239,27 +223,20 @@ vector_entry serror_sp_elx
 	bl	report_unhandled_exception
 	check_vector_size serror_sp_elx
 
-	/* -----------------------------------------------------
+	/* ---------------------------------------------------------------------
 	 * Lower EL using AArch64 : 0x400 - 0x600
-	 * -----------------------------------------------------
+	 * ---------------------------------------------------------------------
 	 */
 vector_entry sync_exception_aarch64
-	/* -----------------------------------------------------
-	 * This exception vector will be the entry point for
-	 * SMCs and traps that are unhandled at lower ELs most
-	 * commonly. SP_EL3 should point to a valid cpu context
-	 * where the general purpose and system register state
-	 * can be saved.
-	 * -----------------------------------------------------
+	/*
+	 * This exception vector will be the entry point for SMCs and traps
+	 * that are unhandled at lower ELs most commonly. SP_EL3 should point
+	 * to a valid cpu context where the general purpose and system register
+	 * state can be saved.
 	 */
 	handle_sync_exception
 	check_vector_size sync_exception_aarch64
 
-	/* -----------------------------------------------------
-	 * Asynchronous exceptions from lower ELs are not
-	 * currently supported. Report their occurrence.
-	 * -----------------------------------------------------
-	 */
 vector_entry irq_aarch64
 	handle_interrupt_exception irq_aarch64
 	check_vector_size irq_aarch64
@@ -269,30 +246,27 @@ vector_entry fiq_aarch64
 	check_vector_size fiq_aarch64
 
 vector_entry serror_aarch64
+	/*
+	 * SError exceptions from lower ELs are not currently supported.
+	 * Report their occurrence.
+	 */
 	bl	report_unhandled_exception
 	check_vector_size serror_aarch64
 
-	/* -----------------------------------------------------
+	/* ---------------------------------------------------------------------
 	 * Lower EL using AArch32 : 0x600 - 0x800
-	 * -----------------------------------------------------
+	 * ---------------------------------------------------------------------
 	 */
 vector_entry sync_exception_aarch32
-	/* -----------------------------------------------------
-	 * This exception vector will be the entry point for
-	 * SMCs and traps that are unhandled at lower ELs most
-	 * commonly. SP_EL3 should point to a valid cpu context
-	 * where the general purpose and system register state
-	 * can be saved.
-	 * -----------------------------------------------------
+	/*
+	 * This exception vector will be the entry point for SMCs and traps
+	 * that are unhandled at lower ELs most commonly. SP_EL3 should point
+	 * to a valid cpu context where the general purpose and system register
+	 * state can be saved.
 	 */
 	handle_sync_exception
 	check_vector_size sync_exception_aarch32
 
-	/* -----------------------------------------------------
-	 * Asynchronous exceptions from lower ELs are not
-	 * currently supported. Report their occurrence.
-	 * -----------------------------------------------------
-	 */
 vector_entry irq_aarch32
 	handle_interrupt_exception irq_aarch32
 	check_vector_size irq_aarch32
@@ -302,34 +276,34 @@ vector_entry fiq_aarch32
 	check_vector_size fiq_aarch32
 
 vector_entry serror_aarch32
+	/*
+	 * SError exceptions from lower ELs are not currently supported.
+	 * Report their occurrence.
+	 */
 	bl	report_unhandled_exception
 	check_vector_size serror_aarch32
 
 
-	/* -----------------------------------------------------
+	/* ---------------------------------------------------------------------
 	 * The following code handles secure monitor calls.
-	 * Depending upon the execution state from where the SMC
-	 * has been invoked, it frees some general purpose
-	 * registers to perform the remaining tasks. They
-	 * involve finding the runtime service handler that is
-	 * the target of the SMC & switching to runtime stacks
-	 * (SP_EL0) before calling the handler.
+	 * Depending upon the execution state from where the SMC has been
+	 * invoked, it frees some general purpose registers to perform the
+	 * remaining tasks. They involve finding the runtime service handler
+	 * that is the target of the SMC & switching to runtime stacks (SP_EL0)
+	 * before calling the handler.
 	 *
-	 * Note that x30 has been explicitly saved and can be
-	 * used here
-	 * -----------------------------------------------------
+	 * Note that x30 has been explicitly saved and can be used here
+	 * ---------------------------------------------------------------------
 	 */
 func smc_handler
 smc_handler32:
 	/* Check whether aarch32 issued an SMC64 */
 	tbnz	x0, #FUNCID_CC_SHIFT, smc_prohibited
 
-	/* -----------------------------------------------------
-	 * Since we're are coming from aarch32, x8-x18 need to
-	 * be saved as per SMC32 calling convention. If a lower
-	 * EL in aarch64 is making an SMC32 call then it must
-	 * have saved x8-x17 already therein.
-	 * -----------------------------------------------------
+	/*
+	 * Since we're are coming from aarch32, x8-x18 need to be saved as per
+	 * SMC32 calling convention. If a lower EL in aarch64 is making an
+	 * SMC32 call then it must have saved x8-x17 already therein.
 	 */
 	stp	x8, x9, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_X8]
 	stp	x10, x11, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_X10]
@@ -340,15 +314,14 @@ smc_handler32:
 	/* x4-x7, x18, sp_el0 are saved below */
 
 smc_handler64:
-	/* -----------------------------------------------------
-	 * Populate the parameters for the SMC handler. We
-	 * already have x0-x4 in place. x5 will point to a
-	 * cookie (not used now). x6 will point to the context
-	 * structure (SP_EL3) and x7 will contain flags we need
-	 * to pass to the handler Hence save x5-x7. Note that x4
-	 * only needs to be preserved for AArch32 callers but we
-	 * do it for AArch64 callers as well for convenience
-	 * -----------------------------------------------------
+	/*
+	 * Populate the parameters for the SMC handler.
+	 * We already have x0-x4 in place. x5 will point to a cookie (not used
+	 * now). x6 will point to the context structure (SP_EL3) and x7 will
+	 * contain flags we need to pass to the handler Hence save x5-x7.
+	 *
+	 * Note: x4 only needs to be preserved for AArch32 callers but we do it
+	 *       for AArch64 callers as well for convenience
 	 */
 	stp	x4, x5, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_X4]
 	stp	x6, x7, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_X6]
@@ -370,12 +343,10 @@ smc_handler64:
 	adr	x14, rt_svc_descs_indices
 	ldrb	w15, [x14, x16]
 
-	/* -----------------------------------------------------
-	 * Restore the saved C runtime stack value which will
-	 * become the new SP_EL0 i.e. EL3 runtime stack. It was
-	 * saved in the 'cpu_context' structure prior to the last
-	 * ERET from EL3.
-	 * -----------------------------------------------------
+	/*
+	 * Restore the saved C runtime stack value which will become the new
+	 * SP_EL0 i.e. EL3 runtime stack. It was saved in the 'cpu_context'
+	 * structure prior to the last ERET from EL3.
 	 */
 	ldr	x12, [x6, #CTX_EL3STATE_OFFSET + CTX_RUNTIME_SP]
 
@@ -388,22 +359,19 @@ smc_handler64:
 	/* Switch to SP_EL0 */
 	msr	spsel, #0
 
-	/* -----------------------------------------------------
+	/*
 	 * Get the descriptor using the index
 	 * x11 = (base + off), x15 = index
 	 *
 	 * handler = (base + off) + (index << log2(size))
-	 * -----------------------------------------------------
 	 */
 	lsl	w10, w15, #RT_SVC_SIZE_LOG2
 	ldr	x15, [x11, w10, uxtw]
 
-	/* -----------------------------------------------------
-	 * Save the SPSR_EL3, ELR_EL3, & SCR_EL3 in case there
-	 * is a world switch during SMC handling.
-	 * TODO: Revisit if all system registers can be saved
-	 * later.
-	 * -----------------------------------------------------
+	/*
+	 * Save the SPSR_EL3, ELR_EL3, & SCR_EL3 in case there is a world
+	 * switch during SMC handling.
+	 * TODO: Revisit if all system registers can be saved later.
 	 */
 	mrs	x16, spsr_el3
 	mrs	x17, elr_el3
@@ -416,12 +384,10 @@ smc_handler64:
 
 	mov	sp, x12
 
-	/* -----------------------------------------------------
-	 * Call the Secure Monitor Call handler and then drop
-	 * directly into el3_exit() which will program any
-	 * remaining architectural state prior to issuing the
-	 * ERET to the desired lower EL.
-	 * -----------------------------------------------------
+	/*
+	 * Call the Secure Monitor Call handler and then drop directly into
+	 * el3_exit() which will program any remaining architectural state
+	 * prior to issuing the ERET to the desired lower EL.
 	 */
 #if DEBUG
 	cbz	x15, rt_svc_fw_critical_error
@@ -436,7 +402,7 @@ smc_unknown:
 	 * callers will find the registers contents unchanged, but AArch64
 	 * callers will find the registers modified (with stale earlier NS
 	 * content). Either way, we aren't leaking any secure information
-	 * through them
+	 * through them.
 	 */
 	mov	w0, #SMC_UNK
 	b	restore_gp_registers_callee_eret
@@ -447,6 +413,7 @@ smc_prohibited:
 	eret
 
 rt_svc_fw_critical_error:
-	msr	spsel, #1 /* Switch to SP_ELx */
+	/* Switch to SP_ELx */
+	msr	spsel, #1
 	bl	report_unhandled_exception
 endfunc smc_handler


### PR DESCRIPTION
* Move comments on unhandled exceptions at the right place.
* Reformat the existing comments to highlight the start of
  each block of 4 entries in the exception table to ease
  navigation (lines of dash reserved for head comments).
* Reflow comments to 80 columns.

Change-Id: I5ab88a93d0628af8e151852cb5b597eb34437677
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>