### PR TITLE
Clarify dependency for PSCI_EXTENDED_STATE_ID

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -380,7 +380,8 @@ performed.
     means by default the original power-state format is used by the PSCI
     implementation. This flag should be specified by the platform makefile
     and it governs the return value of PSCI_FEATURES API for CPU_SUSPEND
-    smc function id.
+    smc function id. When this option is enabled on ARM platforms, the
+    option `ARM_RECOM_STATE_ID_ENC` needs to be set to 1 as well.
 
 *   `RESET_TO_BL31`: Enable BL31 entrypoint as the CPU reset vector instead
     of the BL1 entrypoint. It can take the value 0 (CPU reset to BL1

--- a/plat/arm/common/arm_common.mk
+++ b/plat/arm/common/arm_common.mk
@@ -58,11 +58,12 @@ endif
 # State-ID encoding to be parsed.
 ARM_RECOM_STATE_ID_ENC := 0
 
-# If the PSCI_EXTENDED_STATE_ID is set, then the recommended state ID need to
-# be used. Else throw a build error.
+# If the PSCI_EXTENDED_STATE_ID is set, then ARM_RECOM_STATE_ID_ENC need to
+# be set. Else throw a build error.
 ifeq (${PSCI_EXTENDED_STATE_ID}, 1)
   ifeq (${ARM_RECOM_STATE_ID_ENC}, 0)
-    $(error "Incompatible STATE_ID build option specified")
+    $(error Build option ARM_RECOM_STATE_ID_ENC needs to be set if \
+            PSCI_EXTENDED_STATE_ID is set for ARM platforms)
   endif
 endif
 


### PR DESCRIPTION
Add dependency information in the user guide for ARM_RECOM_STATE_ID_ENC
that needs to be set when using PSCI_EXTENDED_STATE_ID on ARM
platforms. Also clarify the build error message.

Change-Id: Id125a0299b179f5f222bca4e2503204bf89a3c59
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>