### PR TITLE
Add CFI debug frame information for ASM functions

### DIFF
--- a/include/common/asm_macros_common.S
+++ b/include/common/asm_macros_common.S
@@ -33,12 +33,30 @@
 	/*
 	 * This macro is used to create a function label and place the
 	 * code into a separate text section based on the function name
-	 * to enable elimination of unused code during linking
+	 * to enable elimination of unused code during linking. It also adds
+	 * basic debug information to enable call stack printing most of the
+	 * time.
 	 */
 	.macro func _name
+	/*
+	 * Add Call Frame Information entry in the .debug_frame section for
+	 * debugger consumption. This enables callstack printing in debuggers.
+	 * This does not use any space in the final loaded binary, only in the
+	 * ELF file.
+	 * Note that a function manipulating the CFA pointer location (i.e. the
+	 * x29 frame pointer on AArch64) should declare it using the
+	 * appropriate .cfi* directives, or be prepared to have a degraded
+	 * debugging experience.
+	 */
+	.cfi_sections .debug_frame
 	.section .text.\_name, "ax"
 	.type \_name, %function
 	.func \_name
+	/*
+	 * .cfi_startproc and .cfi_endproc are needed to output entries in
+	 * .debug_frame
+	 */
+	.cfi_startproc
 	\_name:
 	.endm
 
@@ -47,6 +65,7 @@
 	 */
 	.macro endfunc _name
 	.endfunc
+	.cfi_endproc
 	.size \_name, . - \_name
 	.endm
 


### PR DESCRIPTION
This allows the debugger to print the callstack when there is an
assembly function in the callstack.

It will work as long as the CFA pointer (frame pointer) location is not
modified (i.e. x29 is not touched in AArch64 state). It is the case in
almost all assembly functions, so this patch improves the average
debugging experience. Call stacks from the debugger should still be
interpreted with care. In more complex functions, one could use .cfi*
directives to inform the debugger about the new location of the CFA
pointer.

Change-Id: I9dabfbc033b45e8528e67f4823c17de7bf02fa24
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>