### PR TITLE
rk3399: Add CFI debug information to SRAM functions

### DIFF
--- a/plat/rockchip/rk3399/drivers/pmu/plat_pmu_macros.S
+++ b/plat/rockchip/rk3399/drivers/pmu/plat_pmu_macros.S
@@ -32,9 +32,11 @@
 	.globl	clst_warmboot_data
 
 	.macro sram_func _name
+	.cfi_sections .debug_frame
 	.section .sram.text, "ax"
 	.type \_name, %function
 	.func \_name
+	.cfi_startproc
 	\_name:
 	.endm
 


### PR DESCRIPTION
Commit b91d935feebdf2c3edef19949023645b6cb34b20
("Add CFI debug frame information for ASM functions") modifies the
assembly macros 'func' and 'endfunc' to include CFI debug frame
information.

The rockchip platform uses a custom version of the 'func' macro with the
common 'endfunc' macro. The custom macro wasn't updated in
b91d935feebdf2c3edef19949023645b6cb34b20 resulting in the following
build error:
  plat/rockchip/rk3399/drivers/pmu/plat_pmu_macros.S: Assembler messages:
  plat/rockchip/rk3399/drivers/pmu/plat_pmu_macros.S:155: Error: .cfi_endproc without corresponding .cfi_startproc
  Makefile:532: recipe for target 'build/rk3399/release/bl31/plat_helpers.o' failed
  make: *** [build/rk3399/release/bl31/plat_helpers.o] Error 1

Fixing this by updating the sram_func macro in the rk3399 port.

Fixes: b91d935feebdf2c3edef19949023645b6cb34b20 ("Add CFI debug frame information for ASM functions")
Signed-off-by: Soren Brinkmann <soren.brinkmann@xilinx.com>