### PR TITLE
Check Trusty is present during the SPD's initialization

### DIFF
--- a/services/spd/trusty/trusty.c
+++ b/services/spd/trusty/trusty.c
@@ -236,7 +236,12 @@ static int32_t trusty_init(void)
 	int reg_width = GET_RW(read_ctx_reg(get_el3state_ctx(&ctx->cpu_ctx),
 			       CTX_SPSR_EL3));
 
+	/*
+	 * Get information about the Trusty image. Its absence is a critical
+	 * failure.
+	 */
 	ep_info = bl31_plat_get_next_image_ep_info(SECURE);
+	assert(ep_info);
 
 	cm_el1_sysregs_context_save(NON_SECURE);
 


### PR DESCRIPTION
Add a debug assertion in the initialization function of Trusty's SPD
to check for the presence of Trusty. If Trusty is absent then the SPD's
setup function already detects it and returns an error code so the init
function will never been called. Therefore, a debug assertion is enough
to catch this improbable error case.
