### PR TITLE
AArch32: Miscellaneous fixes in the AArch32 code

### DIFF
--- a/drivers/arm/pl011/aarch32/pl011_console.S
+++ b/drivers/arm/pl011/aarch32/pl011_console.S
@@ -118,15 +118,15 @@ func console_core_putc
 1:
 	/* Check if the transmit FIFO is full */
 	ldr	r2, [r1, #UARTFR]
-	tst	r2, #PL011_UARTFR_TXFF_BIT
-	beq	1b
+	tst	r2, #PL011_UARTFR_TXFF
+	bne	1b
 	mov	r2, #0xD
 	str	r2, [r1, #UARTDR]
 2:
 	/* Check if the transmit FIFO is full */
 	ldr	r2, [r1, #UARTFR]
-	tst	r2, #PL011_UARTFR_TXFF_BIT
-	beq	2b
+	tst	r2, #PL011_UARTFR_TXFF
+	bne	2b
 	str	r0, [r1, #UARTDR]
 	bx	lr
 putc_error:
@@ -149,8 +149,8 @@ func console_core_getc
 1:
 	/* Check if the receive FIFO is empty */
 	ldr	r1, [r0, #UARTFR]
-	tst	r1, #PL011_UARTFR_RXFE_BIT
-	beq	1b
+	tst	r1, #PL011_UARTFR_RXFE
+	bne	1b
 	ldr	r1, [r0, #UARTDR]
 	mov	r0, r1
 	bx	lr

--- a/include/lib/aarch32/smcc_macros.S
+++ b/include/lib/aarch32/smcc_macros.S
@@ -109,7 +109,13 @@
 	msr	spsr_und, r9
 	msr	sp_und, r10
 	msr	lr_und, r11
-	msr	spsr, r12
+	/*
+	 * Use the `_fsxc` suffix explicitly to instruct the assembler
+	 * to update all the 32 bits of SPSR. Else, by default, the
+	 * assembler assumes `_fc` suffix which only modifies
+	 * f->[31:24] and c->[7:0] bits of SPSR.
+	 */
+	msr	spsr_fsxc, r12
 
 	/* Restore the rest of the general purpose registers */
 	ldm	r0, {r0-r12}

--- a/plat/common/aarch32/platform_helpers.S
+++ b/plat/common/aarch32/platform_helpers.S
@@ -31,25 +31,10 @@
 #include <arch.h>
 #include <asm_macros.S>
 
-	.weak	plat_my_core_pos
 	.weak	plat_reset_handler
 	.weak	plat_disable_acp
 	.weak	platform_mem_init
 	.weak	plat_panic_handler
-
-	/* -----------------------------------------------------
-	 *  int plat_my_core_pos(void);
-	 *  With this function: CorePos	= (ClusterId * 4) +
-	 *				  CoreId
-	 * -----------------------------------------------------
-	 */
-func plat_my_core_pos
-	ldcopr	r0, MPIDR
-	and	r1, r0, #MPIDR_CPU_MASK
-	and	r0, r0, #MPIDR_CLUSTER_MASK
-	add	r0, r1, r0, LSR #6
-	bx	lr
-endfunc	plat_my_core_pos
 
 	/* -----------------------------------------------------
 	 * Placeholder function which should be redefined by


### PR DESCRIPTION
This patch makes following miscellaneous fixes:
* pl011_console.S: Fixed the bit mask used to check if the
  transmit FIFO is full or empty.
* smcc_macros.S: Added `_fsxc` suffix while updating the SPSR.
  By default the assembler assumes `_fc` suffix which does not
  update all the fields in SPSR. By adding `_fsxc` suffix all
  the fields gets updated.
* platform_helpers.S: Removed the weak definition for
  `plat_my_core_pos()` as this is a mandatory function which
  needs to be defined by all platforms.

Change-Id: I8302292533c943686fff8d7c749a07132c052a3b
Signed-off-by: Yatharth Kochar <yatharth.kochar@arm.com>