### PR TITLE
stdlib: Fix signedness issue in memcmp()

### DIFF
--- a/lib/stdlib/mem.c
+++ b/lib/stdlib/mem.c
@@ -48,10 +48,10 @@ void *memset(void *dst, int val, size_t count)
  */
 int memcmp(const void *s1, const void *s2, size_t len)
 {
-	const char *s = s1;
-	const char *d = s2;
-	char dc;
-	char sc;
+	const unsigned char *s = s1;
+	const unsigned char *d = s2;
+	unsigned char sc;
+	unsigned char dc;
 
 	while (len--) {
 		sc = *s++;


### PR DESCRIPTION
There is no guarantee on the signedness of char.  It can be either
signed or unsigned.  On ARM it is unsigned and hence this memcmp()
implementation works as intended.

On other machines, char can be signed (x86 for example).  In that case
(and assuming a 2's complement implementation), interpreting a
bit-pattern of 0xFF as signed char can yield -1.  If *s1 is 0 and *s2
is 255 then the difference *s1 - *s2 should be negative.  The C
integer promotion rules guarantee that the unsigned chars will be
converted to int before the operation takes place.  The current
implementation will return a positive value (0 - (-1)) instead, which
is wrong.

Fix it by changing the signedness to unsigned to avoid surprises for
anyone using this code on non-ARM systems.

Change-Id: Ie222fcaa7c0c4272d7a521a6f2f51995fd5130cc
Signed-off-by: dp-arm <dimitris.papastamos@arm.com>