### PR TITLE
Fix integer comparison in memcpy16

### DIFF
--- a/lib/aarch64/misc_helpers.S
+++ b/lib/aarch64/misc_helpers.S
@@ -123,7 +123,7 @@ func memcpy16
 /* copy 16 bytes at a time */
 m_loop16:
 	cmp	x2, #16
-	b.lt	m_loop1
+	b.lo	m_loop1
 	ldp	x3, x4, [x1], #16
 	stp	x3, x4, [x0], #16
 	sub	x2, x2, #16


### PR DESCRIPTION
Unsigned conditions should be used instead of signed ones when comparing
addresses or sizes in assembly.

Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>
Change-Id: Id3bd9ccaf58c37037761af35ac600907c4bb0580