### PR TITLE
Enable TRUSTED_BOARD_BOOT support for LOAD_IMAGE_V2=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,10 +122,6 @@ ifneq (${GENERATE_COT},0)
         FWU_FIP_DEPS += fwu_certificates
 endif
 
-# For AArch32, enable new version of image loading.
-ifeq (${ARCH},aarch32)
-        LOAD_IMAGE_V2	:=	1
-endif
 
 ################################################################################
 # Toolchain
@@ -294,18 +290,14 @@ ifeq (${NEED_BL33},yes)
         endif
 endif
 
-# TRUSTED_BOARD_BOOT is currently not supported when LOAD_IMAGE_V2 is enabled.
-ifeq (${LOAD_IMAGE_V2},1)
-        ifeq (${TRUSTED_BOARD_BOOT},1)
-                $(error "TRUSTED_BOARD_BOOT is currently not supported	\
-                for LOAD_IMAGE_V2=1")
-        endif
-endif
-
-# For AArch32, LOAD_IMAGE_V2 must be enabled.
 ifeq (${ARCH},aarch32)
+    # For AArch32, LOAD_IMAGE_V2 must be enabled.
     ifeq (${LOAD_IMAGE_V2}, 0)
         $(error "For AArch32, LOAD_IMAGE_V2 must be enabled.")
+    endif
+    # TRUSTED_BOARD_BOOT is currently not supported for AArch32.
+    ifeq (${TRUSTED_BOARD_BOOT},1)
+        $(error "TRUSTED_BOARD_BOOT is currently not supported for AArch32")
     endif
 endif
 

--- a/bl1/tbbr/tbbr_img_desc.c
+++ b/bl1/tbbr/tbbr_img_desc.c
@@ -38,6 +38,9 @@ image_desc_t bl1_tbbr_image_descs[] = {
 	    SET_STATIC_PARAM_HEAD(image_info, PARAM_IMAGE_BINARY,
 		    VERSION_1, image_info_t, 0),
 	    .image_info.image_base = BL2_BASE,
+#if LOAD_IMAGE_V2
+	    .image_info.image_max_size = BL2_LIMIT - BL2_BASE,
+#endif
 	    SET_STATIC_PARAM_HEAD(ep_info, PARAM_IMAGE_BINARY,
 		    VERSION_1, entry_point_info_t, SECURE),
     },
@@ -55,6 +58,9 @@ image_desc_t bl1_tbbr_image_descs[] = {
 	    SET_STATIC_PARAM_HEAD(image_info, PARAM_IMAGE_BINARY,
 		    VERSION_1, image_info_t, 0),
 	    .image_info.image_base = SCP_BL2U_BASE,
+#if LOAD_IMAGE_V2
+	    .image_info.image_max_size = SCP_BL2U_LIMIT - SCP_BL2U_BASE,
+#endif
 	    SET_STATIC_PARAM_HEAD(ep_info, PARAM_IMAGE_BINARY,
 		    VERSION_1, entry_point_info_t, SECURE),
     },
@@ -65,6 +71,9 @@ image_desc_t bl1_tbbr_image_descs[] = {
 	    SET_STATIC_PARAM_HEAD(image_info, PARAM_EP,
 		    VERSION_1, image_info_t, 0),
 	    .image_info.image_base = BL2U_BASE,
+#if LOAD_IMAGE_V2
+	    .image_info.image_max_size = BL2U_LIMIT - BL2U_BASE,
+#endif
 	    SET_STATIC_PARAM_HEAD(ep_info, PARAM_EP,
 		    VERSION_1, entry_point_info_t, SECURE | EXECUTABLE),
 	    .ep_info.pc = BL2U_BASE,

--- a/include/plat/arm/css/common/css_def.h
+++ b/include/plat/arm/css/common/css_def.h
@@ -135,8 +135,10 @@
  * SCP, it is discarded and BL31 is loaded over the top.
  */
 #define SCP_BL2_BASE			BL31_BASE
+#define SCP_BL2_LIMIT			(SCP_BL2_BASE + PLAT_CSS_MAX_SCP_BL2_SIZE)
 
 #define SCP_BL2U_BASE			BL31_BASE
+#define SCP_BL2U_LIMIT			(SCP_BL2U_BASE + PLAT_CSS_MAX_SCP_BL2U_SIZE)
 #endif /* CSS_LOAD_SCP_IMAGES */
 
 /* Load address of Non-Secure Image for CSS platform ports */

--- a/plat/arm/board/juno/include/platform_def.h
+++ b/plat/arm/board/juno/include/platform_def.h
@@ -191,6 +191,12 @@
 #define PLAT_CSS_MAX_SCP_BL2_SIZE	0x1D000
 
 /*
+ * PLAT_CSS_MAX_SCP_BL2U_SIZE is calculated using the current
+ * SCP_BL2U size plus a little space for growth.
+ */
+#define PLAT_CSS_MAX_SCP_BL2U_SIZE	0x1D000
+
+/*
  * Define a list of Group 1 Secure and Group 0 interrupts as per GICv3
  * terminology. On a GICv2 system or mode, the lists will be merged and treated
  * as Group 0 interrupts.

--- a/plat/arm/common/arm_common.mk
+++ b/plat/arm/common/arm_common.mk
@@ -97,6 +97,8 @@ ENABLE_PSCI_STAT		:=	1
 # mapping the former as executable and the latter as execute-never.
 SEPARATE_CODE_AND_RODATA	:=	1
 
+# Enable new version of image loading on ARM platforms
+LOAD_IMAGE_V2			:=	1
 
 PLAT_INCLUDES		+=	-Iinclude/common/tbbr				\
 				-Iinclude/plat/arm/common


### PR DESCRIPTION
This patch enables TRUSTED_BOARD_BOOT (Authentication and FWU)
support, for AArch64, when LOAD_IMAGE_V2 is enabled.

This patch also enables LOAD_IMAGE_V2 for ARM platforms.

Change-Id: I294a2eebce7a30b6784c80c9d4ac7752808ee3ad
Signed-off-by: Yatharth Kochar <yatharth.kochar@arm.com>