### PR TITLE
tbbr: Fix updating of Non-Trusted NV counter

### DIFF
--- a/docs/porting-guide.md
+++ b/docs/porting-guide.md
@@ -690,10 +690,30 @@ not be retrieved from the platform.
 
 This function is mandatory when Trusted Board Boot is enabled. It sets a new
 counter value in the platform. The cookie in the first argument may be used to
-select the counter (as explained in plat_get_nv_ctr()).
+select the counter (as explained in plat_get_nv_ctr()). The second argument is
+the updated counter value to be written to the NV counter.
 
 The function returns 0 on success. Any other value means the counter value could
 not be updated.
+
+
+### Function: plat_set_nv_ctr2()
+
+    Argument : void *, const auth_img_desc_t *, unsigned int
+    Return   : int
+
+This function is optional when Trusted Board Boot is enabled. If this
+interface is defined, then `plat_set_nv_ctr()` need not be defined. The
+first argument passed is a cookie and is typically used to
+differentiate between a Non Trusted NV Counter and a Trusted NV
+Counter. The second argument is a pointer to an authentication image
+descriptor and may be used to decide if the counter is allowed to be
+updated or not. The third argument is the updated counter value to
+be written to the NV counter.
+
+The function returns 0 on success. Any other value means the counter value
+either could not be updated or the authentication image descriptor indicates
+that it is not allowed to be updated.
 
 
 2.3 Common mandatory function modifications

--- a/drivers/auth/auth_mod.c
+++ b/drivers/auth/auth_mod.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2016, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -49,6 +49,8 @@
 			return rc; \
 		} \
 	} while (0)
+
+#pragma weak plat_set_nv_ctr2
 
 /* Pointer to CoT */
 extern const auth_img_desc_t *const cot_desc_ptr;
@@ -297,19 +299,18 @@ static int auth_nvctr(const auth_method_param_nv_ctr_t *param,
 		/* Invalid NV-counter */
 		return 1;
 	} else if (cert_nv_ctr > plat_nv_ctr) {
-		if (img_desc->parent == NULL) {
-			/* This certificate has been signed with the ROT key.
-			 * Update the platform counter value */
-			rc = plat_set_nv_ctr(param->plat_nv_ctr->cookie,
-					     cert_nv_ctr);
-			return_if_error(rc);
-		} else {
-			/* Secondary certificates cannot modify the counter */
-			return 1;
-		}
+		rc = plat_set_nv_ctr2(param->plat_nv_ctr->cookie,
+			img_desc, cert_nv_ctr);
+		return_if_error(rc);
 	}
 
 	return 0;
+}
+
+int plat_set_nv_ctr2(void *cookie, const auth_img_desc_t *img_desc __unused,
+		unsigned int nv_ctr)
+{
+	return plat_set_nv_ctr(cookie, nv_ctr);
 }
 
 /*

--- a/include/plat/common/platform.h
+++ b/include/plat/common/platform.h
@@ -39,6 +39,7 @@
 /*******************************************************************************
  * Forward declarations
  ******************************************************************************/
+struct auth_img_desc_s;
 struct meminfo;
 struct image_info;
 struct entry_point_info;
@@ -274,6 +275,8 @@ int plat_get_rotpk_info(void *cookie, void **key_ptr, unsigned int *key_len,
 			unsigned int *flags);
 int plat_get_nv_ctr(void *cookie, unsigned int *nv_ctr);
 int plat_set_nv_ctr(void *cookie, unsigned int nv_ctr);
+int plat_set_nv_ctr2(void *cookie, const struct auth_img_desc_s *img_desc,
+		unsigned int nv_ctr);
 
 #if LOAD_IMAGE_V2
 /*******************************************************************************

--- a/plat/arm/common/arm_common.mk
+++ b/plat/arm/common/arm_common.mk
@@ -165,9 +165,11 @@ ifneq (${TRUSTED_BOARD_BOOT},0)
 
     BL1_SOURCES		+=	${AUTH_SOURCES}					\
 				bl1/tbbr/tbbr_img_desc.c			\
-				plat/arm/common/arm_bl1_fwu.c
+				plat/arm/common/arm_bl1_fwu.c			\
+				plat/common/tbbr/plat_tbbr.c
 
-    BL2_SOURCES		+=	${AUTH_SOURCES}
+    BL2_SOURCES		+=	${AUTH_SOURCES}					\
+				plat/common/tbbr/plat_tbbr.c
 
     $(eval $(call FWU_FIP_ADD_IMG,NS_BL2U,--fwu))
 

--- a/plat/common/tbbr/plat_tbbr.c
+++ b/plat/common/tbbr/plat_tbbr.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * Neither the name of ARM nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <assert.h>
+#include <auth/auth_mod.h>
+#include <platform.h>
+#include <platform_oid.h>
+#include <string.h>
+
+/*
+ * Store a new non-volatile counter value. This implementation
+ * only allows updating of the platform's Trusted NV counter when a
+ * certificate protected by the Trusted NV counter is signed with
+ * the ROT key. This avoids a compromised secondary certificate from
+ * updating the platform's Trusted NV counter, which could lead to the
+ * platform becoming unusable. The function is suitable for all TBBR
+ * compliant platforms.
+ *
+ * Return: 0 = success, Otherwise = error
+ */
+int plat_set_nv_ctr2(void *cookie, const auth_img_desc_t *img_desc,
+		unsigned int nv_ctr)
+{
+	int trusted_nv_ctr;
+
+	assert(cookie != NULL);
+	assert(img_desc != NULL);
+
+	trusted_nv_ctr = strcmp(cookie, TRUSTED_FW_NVCOUNTER_OID) == 0;
+
+	/*
+	 * Only update the Trusted NV Counter if the certificate
+	 * has been signed with the ROT key. Non Trusted NV counter
+	 * updates are unconditional.
+	 */
+	if (!trusted_nv_ctr || (trusted_nv_ctr && img_desc->parent == NULL))
+		return plat_set_nv_ctr(cookie, nv_ctr);
+
+	/*
+	 * Trusted certificates not signed with the ROT key are not
+	 * allowed to update the Trusted NV Counter.
+	 */
+	return 1;
+}


### PR DESCRIPTION
The previous code required that a certificate be signed with the ROT
key before the platform's NV counter could be updated with the value
in the certificate.  This implies that the Non-Trusted NV counter was
not being updated for Non-Trusted content certificates, as they cannot
be signed with the ROT key in the TBBR CoT scheme.

The code is reworked to only allow updating the platform's Trusted NV
counter when a certificate protected by the Trusted NV counter is
signed with the ROT key.

Content certificates protected by the Non-Trusted NV counter are
allowed to update the platform's Non-Trusted NV counter, assuming
that the certificate value is higher than the platform's value.

A new optional platform API has been introduced, named
plat_set_nv_ctr2().  Platforms may choose to implement it and perform
additional checks based on the authentication image descriptor before
modifying the NV counters.  A default weak implementation is available
that just calls into plat_set_nv_ctr().

Fixes ARM-software/tf-issues#426

Change-Id: I4fc978fd28a3007bc0cef972ff1f69ad0413b79c
Signed-off-by: dp-arm <dimitris.papastamos@arm.com>