### PR TITLE
Update Foundation Model version

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1102,7 +1102,7 @@ to load the ELF file over JTAG on Juno.
 The AArch64 build of this version of ARM Trusted Firmware has been tested on
 the following ARM FVPs (64-bit host machine only).
 
-*   `Foundation_Platform` (Version 10.1, Build 10.1.32)
+*   `Foundation_Platform` (Version 10.2, Build 10.2.20)
 *   `FVP_Base_AEMv8A-AEMv8A` (Version 7.7, Build 0.8.7701)
 *   `FVP_Base_Cortex-A57x4-A53x4` (Version 7.7, Build 0.8.7701)
 *   `FVP_Base_Cortex-A57x1-A53x1` (Version 7.7, Build 0.8.7701)


### PR DESCRIPTION
Foundation Model release 10.2 has been made available and Trusted
Firmware has been tested against that it as part of its CI system.

This patch updates the user guide documentation to reflect the version
of Foundation Model that Trusted Firmware has been tested against.

Change-Id: I8571e1027b24892b41d04b93b24245a371ca2cae
Signed-off-by: David Cunado <david.cunado@arm.com>