### PR TITLE
plat_common: do not suppress runtime logs when DEBUG is defined

### DIFF
--- a/plat/common/aarch64/plat_common.c
+++ b/plat/common/aarch64/plat_common.c
@@ -56,11 +56,13 @@ void bl32_plat_enable_mmu(uint32_t flags)
 
 void bl31_plat_runtime_setup(void)
 {
+#if !DEBUG
 	/*
 	 * Finish the use of console driver in BL31 so that any runtime logs
 	 * from BL31 will be suppressed.
 	 */
 	console_uninit();
+#endif
 }
 
 #if !ENABLE_PLAT_COMPAT


### PR DESCRIPTION
When debugging, runtime logs will be useful.  For example,
psci_print_power_domain_map() will display details if compiled
with DEBUG option, but the console is needed to see the log.

Signed-off-by: Masahiro Yamada <yamada.masahiro@socionext.com>