### PR TITLE
Build: use the list of no-build targets to set IS_ANYTHING_TO_BUILD

### DIFF
--- a/make_helpers/build_macros.mk
+++ b/make_helpers/build_macros.mk
@@ -190,15 +190,12 @@ ifeq ($(MAKECMDGOALS),)
 MAKECMDGOALS := $(.DEFAULT_GOAL)
 endif
 
-define match_goals
-$(strip $(foreach goal,$(1),$(filter $(goal),$(MAKECMDGOALS))))
-endef
-
-# List of rules that involve building things
-BUILD_TARGETS := all bl1 bl2 bl2u bl31 bl32 certificates fip
+# List of rules that do not build things
+NO_BUILD_TARGETS := clean realclean distclean cscope \
+		locate-checkpatch checkcodebase checkpatch
 
 # Does the list of goals specified on the command line include a build target?
-ifneq ($(call match_goals,${BUILD_TARGETS}),)
+ifneq ($(filter-out $(NO_BUILD_TARGETS),$(MAKECMDGOALS)),)
 IS_ANYTHING_TO_BUILD := 1
 endif
 


### PR DESCRIPTION
Currently, we are supposed to build binaries via limited numbers
of pre-defined phony targets.

For example,

  make CROSS_COMPILE=aarch64-linux-gnu- bl1

works, but

  make CROSS_COMPILE=aarch64-linux-gnu- build/fvp/release/bl1.bin

fails because this does not set IS_ANYTHING_TO_BUILD flag.

This restriction keeps platforms from generating plat-specific
images based on the standard images.

Having such phony targets as "bl1", "bl2" in the dependency is not
good; any target depending on phony targets is always rebuilt.

Flip the logic and specify the no-build targets.  Also, this will
be more stable because we rarely add no-build targets.

While we are here, delete the unneeded match_goals helper because
$(filter ...) and $(filter-out ...) are clever enough to work
without $(foreach ...) loop.

Signed-off-by: Masahiro Yamada <yamada.masahiro@socionext.com>