### PR TITLE
rockchip: Build m0 firmware without standard libraries

### DIFF
--- a/plat/rockchip/rk3399/drivers/m0/Makefile
+++ b/plat/rockchip/rk3399/drivers/m0/Makefile
@@ -59,7 +59,7 @@ ASFLAGS			:= -g -Wa,--gdwarf-2
 ASFLAGS			+= -mcpu=$(ARCH) -mthumb -Wall -ffunction-sections -O3
 CFLAGS			+= -mcpu=$(ARCH) -mthumb -Wall -ffunction-sections -O3
 
-LDFLAGS			:= -mcpu=$(ARCH) -mthumb -g -nostartfiles -O3
+LDFLAGS			:= -mcpu=$(ARCH) -mthumb -g -nostartfiles -nostdlib -O3
 LDFLAGS			+= -Wl,--gc-sections -Wl,--build-id=none
 
 # Cross tool


### PR DESCRIPTION
Depending on the compiler used, it might try to link in libc even though
it's not required. Stop it from doing that.

Signed-off-by: Patrick Georgi <pgeorgi@google.com>