### PR TITLE
TBB: fix comment about MBEDTLS_KEY_ALG default

### DIFF
--- a/drivers/auth/mbedtls/mbedtls_crypto.mk
+++ b/drivers/auth/mbedtls/mbedtls_crypto.mk
@@ -31,7 +31,7 @@
 include drivers/auth/mbedtls/mbedtls_common.mk
 
 # The platform may define the variable 'MBEDTLS_KEY_ALG' to select the key
-# algorithm to use. Default algorithm is ECDSA.
+# algorithm to use. Default algorithm is RSA.
 ifeq (${MBEDTLS_KEY_ALG},)
     MBEDTLS_KEY_ALG		:=	rsa
 endif


### PR DESCRIPTION
This comment block says the default algorithm is ESDSA, while the
code obviously sets the default to RSA:

  ifeq (${MBEDTLS_KEY_ALG},)
      MBEDTLS_KEY_ALG            :=      rsa
  endif

The git log of commit 7d37aa171158 ("TBB: add mbedTLS authentication
related libraries") states available options are:

  * 'rsa' (for RSA-2048) (default option)
  * 'ecdsa' (for ECDSA-SECP256R1)

So, my best guess is the comment block is wrong.

The mismatch between the code and the comment is confusing. Fix it.

Signed-off-by: Masahiro Yamada <yamada.masahiro@socionext.com>