### PR TITLE
fix gcc 6.2 build

### DIFF
--- a/include/lib/smcc.h
+++ b/include/lib/smcc.h
@@ -57,7 +57,7 @@
 #define SMC_64				1
 #define SMC_32				0
 #define SMC_UNK				0xffffffff
-#define SMC_TYPE_FAST			1
+#define SMC_TYPE_FAST			1U
 #define SMC_TYPE_STD			0
 #define SMC_PREEMPTED		0xfffffffe
 /*******************************************************************************


### PR DESCRIPTION
 * prevent error, when gcc 6.2 is used:
     "case label is not an integer constant expression"
   from file :
     "services/spd/opteed/opteed_main.c"
   code:
     "case TEESMC_OPTEED_RETURN_ON_DONE
      case TEESMC_OPTEED_RETURN_RESUME_DONE
      ..."
   source error:
    code:
      ./services/spd/opteed/teesmc_opteed_macros.h
    from TEESMC_OPTEED_RV: (SMC_TYPE_FAST << FUNCID_TYPE_SHIFT)

   "
   #define SMC_TYPE_FAST 1
   #define FUNCID_TYPE_SHIFT 31
   "

 * ref:
   http://c0x.coding-guidelines.com/6.5.7.html
   https://github.com/ARM-software/tf-issues/issues/438

Signed-off-by: Ronan <ronan.lemartret@iot.bzh>