### PR TITLE
uart: 16550: Fix getc

### DIFF
--- a/drivers/ti/uart/aarch64/16550_console.S
+++ b/drivers/ti/uart/aarch64/16550_console.S
@@ -146,7 +146,7 @@ endfunc console_core_putc
 func console_core_getc
 	/* Check if the receive FIFO is empty */
 1:	ldr	w1, [x0, #UARTLSR]
-	tbz	w1, #UARTLSR_RDR, 1b
+	tbz	w1, #UARTLSR_RDR_BIT, 1b
 	ldr	w0, [x0, #UARTRX]
 	ret
 getc_error:

--- a/include/drivers/ti/uart/uart_16550.h
+++ b/include/drivers/ti/uart/uart_16550.h
@@ -88,6 +88,7 @@
 #define UARTLSR_FERR		(1 << 3)	/* Framing Error */
 #define UARTLSR_PERR		(1 << 3)	/* Parity Error */
 #define UARTLSR_OVRF		(1 << 2)	/* Rx Overrun Error */
-#define UARTLSR_RDR		(1 << 2)	/* Rx Data Ready */
+#define UARTLSR_RDR_BIT		(0)		/* Rx Data Ready Bit */
+#define UARTLSR_RDR		(1 << UARTLSR_RDR_BIT)	/* Rx Data Ready */
 
 #endif	/* __UART_16550_H__ */


### PR DESCRIPTION
tbz check for RDR status is to check for a bit being zero.
Unfortunately, we are using a mask rather than the bit position.

Further as per http://www.ti.com/lit/ds/symlink/pc16550d.pdf (page 17),
LSR register bit 0 is Data ready status (RDR), not bit position 2.

Update the same to match the specification.

Reported-by: Sekhar Nori <nsekhar@ti.com>
Signed-off-by: Nishanth Menon <nm@ti.com>