### PR TITLE
Fix parallel building

### DIFF
--- a/make_helpers/build_macros.mk
+++ b/make_helpers/build_macros.mk
@@ -227,11 +227,12 @@ endef
 # MAKE_LD generate the linker script using the C preprocessor
 #   $(1) = output linker script
 #   $(2) = input template
+#   $(3) = BL stage (2, 2u, 30, 31, 32, 33)
 define MAKE_LD
 
 $(eval DEP := $(1).d)
 
-$(1): $(2) | $(dir ${1})
+$(1): $(2) | bl$(3)_dirs
 	@echo "  PP      $$<"
 	$$(Q)$$(CPP) $$(CPPFLAGS) -P -D__ASSEMBLY__ -D__LINKER__ $(MAKE_DEP) -o $$@ $$<
 
@@ -297,7 +298,7 @@ define MAKE_BL
         $(eval BL_LINKERFILE := $(BL$(call uppercase,$(1))_LINKERFILE))
         # We use sort only to get a list of unique object directory names.
         # ordering is not relevant but sort removes duplicates.
-        $(eval TEMP_OBJ_DIRS := $(sort $(BUILD_DIR)/ $(dir ${OBJS})))
+        $(eval TEMP_OBJ_DIRS := $(sort $(BUILD_DIR)/ $(dir ${OBJS} ${LINKERFILE})))
         # The $(dir ) function leaves a trailing / on the directory names
         # We append a . then strip /. from each, to remove the trailing / characters
         # This gives names suitable for use as make rule targets.
@@ -314,7 +315,7 @@ $(eval $(foreach objd,${OBJ_DIRS},$(call MAKE_PREREQ_DIR,${objd},)))
 bl${1}_dirs: | ${OBJ_DIRS}
 
 $(eval $(call MAKE_OBJS,$(BUILD_DIR),$(SOURCES),$(1)))
-$(eval $(call MAKE_LD,$(LINKERFILE),$(BL_LINKERFILE)))
+$(eval $(call MAKE_LD,$(LINKERFILE),$(BL_LINKERFILE),$(1)))
 
 $(ELF): $(OBJS) $(LINKERFILE) | bl$(1)_dirs
 	@echo "  LD      $$@"

--- a/make_helpers/build_macros.mk
+++ b/make_helpers/build_macros.mk
@@ -300,9 +300,8 @@ define MAKE_BL
         # ordering is not relevant but sort removes duplicates.
         $(eval TEMP_OBJ_DIRS := $(sort $(BUILD_DIR)/ $(dir ${OBJS} ${LINKERFILE})))
         # The $(dir ) function leaves a trailing / on the directory names
-        # We append a . then strip /. from each, to remove the trailing / characters
-        # This gives names suitable for use as make rule targets.
-        $(eval OBJ_DIRS   := $(subst /.,,$(addsuffix .,$(TEMP_OBJ_DIRS))))
+        # Rip off the / to match directory names with make rule targets.
+        $(eval OBJ_DIRS   := $(patsubst %/,%,$(TEMP_OBJ_DIRS)))
 
 # Create generators for object directory structure
 


### PR DESCRIPTION
Soren reports build fails if -j option is given:

  $ make -j16 CROSS_COMPILE=aarch64-linux-gnu-
  Building fvp
  make: *** No rule to make target 'build/fvp/release/bl1/',
                    needed by 'build/fvp/release/bl1/bl1.ld'.  Stop.
  make: *** Waiting for unfinished jobs....

The cause of the failure is that $(dir ) leaves a trailing / on the
directory names.   It must be ripped off to let Make create the
directory.

Signed-off-by: Masahiro Yamada <yamada.masahiro@socionext.com>
Reported-by: Soren Brinkmann <soren.brinkmann@xilinx.com>