### PR TITLE
mt8173: Correct SPM MCDI firmware length

### DIFF
--- a/plat/mediatek/mt8173/drivers/spm/spm_mcdi.c
+++ b/plat/mediatek/mt8173/drivers/spm/spm_mcdi.c
@@ -232,7 +232,7 @@ static const unsigned int mcdi_binary[] = {
 static const struct pcm_desc mcdi_pcm = {
 	.version = "pcm_mcdi_mt8173_20160401_v1",
 	.base = mcdi_binary,
-	.size = 1019,
+	.size = 1001,
 	.sess = 2,
 	.replace = 0,
 };


### PR DESCRIPTION
The actual length of the firmware is 1001 32 bit words.

Signed-off-by: Paul Kocialkowski <contact@paulk.fr>