### PR TITLE
Correct system include order

### DIFF
--- a/lib/cpus/aarch64/cpu_helpers.S
+++ b/lib/cpus/aarch64/cpu_helpers.S
@@ -31,10 +31,10 @@
 #include <arch.h>
 #include <asm_macros.S>
 #include <assert_macros.S>
-#include <cpu_macros.S>
 #if IMAGE_BL31
 #include <cpu_data.h>
 #endif
+#include <cpu_macros.S>
 #include <debug.h>
 
  /* Reset fn is needed in BL at reset vector */


### PR DESCRIPTION
NOTE - this is patch does not address all occurrences of system
includes not being in alphabetical order, just this one case.

Change-Id: I3cd23702d69b1f60a4a9dd7fd4ae27418f15b7a3