### PR TITLE
partition: fix the path of head file

### DIFF
--- a/drivers/partition/gpt.c
+++ b/drivers/partition/gpt.c
@@ -31,7 +31,7 @@
 #include <assert.h>
 #include <debug.h>
 #include <errno.h>
-#include <gpt.h>
+#include <partition/gpt.h>
 #include <string.h>
 
 static int unicode_to_ascii(unsigned short *str_in, unsigned char *str_out)

--- a/drivers/partition/partition.c
+++ b/drivers/partition/partition.c
@@ -31,9 +31,9 @@
 #include <assert.h>
 #include <debug.h>
 #include <io_storage.h>
-#include <gpt.h>
-#include <mbr.h>
-#include <partition.h>
+#include <partition/gpt.h>
+#include <partition/mbr.h>
+#include <partition/partition.h>
 #include <platform.h>
 #include <string.h>
 

--- a/include/drivers/partition/gpt.h
+++ b/include/drivers/partition/gpt.h
@@ -31,7 +31,7 @@
 #ifndef __GPT_H__
 #define __GPT_H__
 
-#include <partition.h>
+#include <partition/partition.h>
 
 #define PARTITION_TYPE_GPT		0xee
 #define GPT_HEADER_OFFSET		PARTITION_BLOCK_SIZE


### PR DESCRIPTION
Add partition path of head file in both head and source file.
Otherwise, partition path has to be filled in PLAT_INCLUDES of
platform.mk.

Fixes arm-software/tf-issues#450.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>