### PR TITLE
Add -fno-builtin to CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ ASFLAGS			+=	$(CPPFLAGS) $(ASFLAGS_$(ARCH))			\
 				-D__ASSEMBLY__ -ffreestanding 			\
 				-Wa,--fatal-warnings
 TF_CFLAGS		+=	$(CPPFLAGS) $(TF_CFLAGS_$(ARCH))		\
-				-ffreestanding -Wall -std=c99 -Os		\
+				-ffreestanding -fno-builtin -Wall -std=c99 -Os	\
 				-ffunction-sections -fdata-sections
 
 LDFLAGS			+=	--fatal-warnings -O1


### PR DESCRIPTION
Disable the automatic substitution of functions with builtins. The
existing -ffreestanding option should already do this but explicitly
adding -fno-builtin reduces the risk of compiler variation. With this
option, GCC is not supposed to be able to make assumptions on what the
function does, which could otherwise lead to security-sensitive code
removal.

This can lead to potentially less efficient code but improves
predictability of what code is actually compiled into the binary.

Change-Id: I06ad151c61318bd1b00d84976f051d2d94314acc
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>