### PR TITLE
Expose ABORT STD SMC to Test Secure Payload

### DIFF
--- a/services/spd/tspd/tspd_main.c
+++ b/services/spd/tspd/tspd_main.c
@@ -606,11 +606,10 @@ uint64_t tspd_smc_handler(uint32_t smc_fid,
 	 * call.
 	 */
 	case TSP_FID_ABORT:
-		/* ABORT should only be invoked by normal world */
-		if (!ns) {
-			assert(0);
-			break;
-		}
+		/*
+		 * ABORT can be invoked by both normal and secure world to
+		 * allow easy handling of runtime error in the TSP.
+		 */
 
 		/* Abort the preempted SMC request */
 		if (!tspd_abort_preempted_smc(tsp_ctx))


### PR DESCRIPTION
Allow the TSP to call the ABORT STD SMC to allow easy implementation of
runtime error handling in TSP. For example, Undefined Behavior Sanitizer
handlers could issue such an SMC to abort the current STD SMC if an
undefined behavior is detected at runtime.

Change-Id: Ifc6c84b7e0be989443b84d7be18359254dfd0683
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>