### PR TITLE
PMF: Fixup PMF constants

### DIFF
--- a/include/lib/pmf/pmf.h
+++ b/include/lib/pmf/pmf.h
@@ -37,13 +37,13 @@
 /*
  * Constants used for/by PMF services.
  */
-#define PMF_ARM_TIF_IMPL_ID	(0x41000000)
+#define PMF_ARM_TIF_IMPL_ID	0x41
 #define PMF_TID_SHIFT		0
 #define PMF_TID_MASK		(0xFF << PMF_TID_SHIFT)
 #define PMF_SVC_ID_SHIFT	10
 #define PMF_SVC_ID_MASK		(0x3F << PMF_SVC_ID_SHIFT)
 #define PMF_IMPL_ID_SHIFT	24
-#define PMF_IMPL_ID_MASK	(0xFF << PMF_IMPL_ID_SHIFT)
+#define PMF_IMPL_ID_MASK	(0xFFU << PMF_IMPL_ID_SHIFT)
 
 /*
  * Flags passed to PMF_REGISTER_SERVICE


### PR DESCRIPTION
`PMF_ARM_TIF_IMPL_ID` should be set to 0x41.  The code already left
shifts it by 24 bit positions so this was overflowing.

This fixes a build error with GCC 6.2 when
`ENABLE_RUNTIME_INSTRUMENTATION` is set.

Change-Id: I4c99d48ea7ce3d76e9edd1325b1979994db2c0fb
Signed-off-by: dp-arm <dimitris.papastamos@arm.com>