### PR TITLE
Makefile: use git describe for BUILD_STRING

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ endif
 
 # Default build string (git branch and commit)
 ifeq (${BUILD_STRING},)
-        BUILD_STRING	:=	$(shell git log -n 1 --pretty=format:"%h")
+        BUILD_STRING	:=	$(shell git describe --always --dirty --tags 2> /dev/null)
 endif
 VERSION_STRING		:=	v${VERSION_MAJOR}.${VERSION_MINOR}(${BUILD_TYPE}):${BUILD_STRING}
 


### PR DESCRIPTION
Currently, the BUILD_STRING is just 7-digits git hash.  It is true
we can identify which version is running, but we can not get a quick
idea about how new or old it is.

The command "git describe" provides us a bit more useful information
in the format of:
  (tag-name)-(number of commits on top the tag)-g(7 digits hash)

I added some options:
  --always
    Make "git describe" work without any tag in case the upstream
    ATF is cloned, but all the tags are locally dropped.

  --tags
    Use any tag instead of only annotated tags.  In ATF, only some
    tags are annotated, actually the last annotated tag is "v0.2",
    whereas we are on "v1.3" tag now.  This option is needed to get
    something like v1.3-233-gbcc2bf0 instead of v0.2-1713-gbcc2bf0.

  --dirty
    The mark "-dirty" is appended if the source tree is locally
    modified.

With this commit, the welcome string

  NOTICE:  BL1: v1.3(debug):bcc2bf0

will become like follows:

  NOTICE:  BL1: v1.3(debug):v1.3-233-gbcc2bf0-dirty

While we are here, let's add "2> /dev/null" as well to silently
ignore any error message from git.  We should not assume that users
always work in a git repository; the ATF might be released in a
tarball form instead of a git repository.  In such a case, the git
command will fail, then the ugly message "fatal: Not a git ..." will
be displayed during the build:

$ make CROSS_COMPILE=aarch64-linux-gnu-
fatal: Not a git repository (or any of the parent directories): .git
Building fvp
  CC      drivers/io/io_semihosting.c
  CC      lib/semihosting/semihosting.c
     ...

Signed-off-by: Masahiro Yamada <yamada.masahiro@socionext.com>