### PR TITLE
gitignore: ignore GNU GLOBAL tag files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ tools/cert_create/cert_create.exe
 # Ignore header files copied.
 tools/fiptool/firmware_image_package.h
 tools/fiptool/uuid.h
+
+# GNU GLOBAL files
+GPATH
+GRTAGS
+GSYMS
+GTAGS


### PR DESCRIPTION
GNU GLOBAL (https://www.gnu.org/software/global/) is source code
tagging system.  It creates 4 tag files (GTAGS, GRTAGS, GSYMS and
GPATH) for the symbol cross-reference.  Ignore them.

Signed-off-by: Masahiro Yamada <yamada.masahiro@socionext.com>