### PR TITLE
zynqmp: remove RESET_TO_BL31=1 from build instruction

### DIFF
--- a/docs/plat/xilinx-zynqmp.md
+++ b/docs/plat/xilinx-zynqmp.md
@@ -12,12 +12,12 @@ BL33 is the non-secure world software (U-Boot, Linux etc).
 
 To build:
 ```bash
-make ERROR_DEPRECATED=1 RESET_TO_BL31=1 CROSS_COMPILE=aarch64-none-elf- PLAT=zynqmp bl31
+make ERROR_DEPRECATED=1 CROSS_COMPILE=aarch64-none-elf- PLAT=zynqmp bl31
 ```
 
 To build bl32 TSP you have to rebuild bl31 too:
 ```bash
-make ERROR_DEPRECATED=1 RESET_TO_BL31=1 CROSS_COMPILE=aarch64-none-elf- PLAT=zynqmp SPD=tspd bl31 bl32
+make ERROR_DEPRECATED=1 CROSS_COMPILE=aarch64-none-elf- PLAT=zynqmp SPD=tspd bl31 bl32
 ```
 
 # ZynqMP platform specific build options


### PR DESCRIPTION
RESET_TO_BL31=1 is specified by plat/xilinx/zynqmp/platform.mk with
"override" directive.  So, RESET_TO_BL31=1 is guaranteed without any
operation on users' side.

Signed-off-by: Masahiro Yamada <yamada.masahiro@socionext.com>