### PR TITLE
build: Use separate CFLAGS for tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,11 @@ VERSION_MINOR			:= 3
 # Default goal is build all images
 .DEFAULT_GOAL			:= all
 
+# Avoid any implicit propagation of command line variable definitions to
+# sub-Makefiles, like CFLAGS that we reserved for the firmware images'
+# usage. Other command line options like "-s" are still propagated as usual.
+MAKEOVERRIDES =
+
 MAKE_HELPERS_DIRECTORY := make_helpers/
 include ${MAKE_HELPERS_DIRECTORY}build_macros.mk
 include ${MAKE_HELPERS_DIRECTORY}build_env.mk


### PR DESCRIPTION
Sharing the same CFLAGS for both the firmware and host tools is not
useful and can lead to compilation failure when CFLAGS is set on the
command line.

This patch make MAKEOVERRIDES special variable empty so make's command
line variable definitions are not implicitly forwarded to sub make
invocations. However, make options are still forwarded like "-s" option
to make the build silent.

Change-Id: Ia921c02beb1fd2041696a26160b9e7974ae000fa
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>