### PR TITLE
Migrate to Linaro Release 16.12

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -37,6 +37,9 @@ the different software components required to boot a Linux system:
 *   Linux kernel image
 *   Root filesystem
 
+Note: the ARM TF v1.3 release was tested with Linaro Release 16.06, and the
+latest version of ARM TF is tested with Linaro Release 16.12.
+
 This document also assumes that the user is familiar with the FVP models and
 the different command line options available to launch the model.
 
@@ -878,8 +881,8 @@ Firmware, obtain the additional required firmware, and pack it all together in
 a single FIP binary. It assumes that a [Linaro Release][Linaro Release Notes]
 has been installed.
 
-Note currently [Linaro Release][Linaro Release Notes] only includes pre-built
-binaries for AArch64. For AArch32, pre-built binaries are not available.
+Note: Linaro Release 16.06 only includes pre-built binaries for AArch64. For
+AArch32, pre-built binaries are only available from Linaro Release 16.12.
 
 Note: follow the full instructions for one platform before switching to a
 different one. Mixing instructions for different platforms may result in
@@ -1130,6 +1133,9 @@ downloaded for free from [ARM's website][ARM FVP website].
 Please refer to the FVP documentation for a detailed description of the model
 parameter options. A brief description of the important ones that affect the ARM
 Trusted Firmware and normal world software behavior is provided below.
+
+Note the instructions in the following sections assume that Linaro Release 16.06
+is being used.
 
 ### Obtaining the Flattened Device Trees
 


### PR DESCRIPTION
This Linaro release updates both the binaries and the toolchain:
Linaro binaries upgraded 16.06 --> 16.12
AArch64 compiler upgraded 15.05 (gcc 4.9) --> 5.3-2015.05 (gcc 5.3)
AArch32 compiler upgraded 15.05 (gcc 4.9) --> 5.3-2015.05 (gcc 5.3)

The ARM TF codebase has been tested against these new binaries. This patch
updates the User Guide to reflect that the 16.12 release is now a supported
Linaro Release.

Change-Id: I6247e820f591df7d05df4f622ee45a3abf2c2d72
Signed-off-by: David Cunado <david.cunado@arm.com>