### PR TITLE
Build: pass extra options via TF_EXTRA_CFLAGS instead of CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,8 @@ ASFLAGS			+=	$(CPPFLAGS) $(ASFLAGS_$(ARCH))			\
 				-Wa,--fatal-warnings
 TF_CFLAGS		+=	$(CPPFLAGS) $(TF_CFLAGS_$(ARCH))		\
 				-ffreestanding -fno-builtin -Wall -std=c99 -Os	\
-				-ffunction-sections -fdata-sections
+				-ffunction-sections -fdata-sections		\
+				$(TF_EXTRA_CFLAGS)
 
 LDFLAGS			+=	--fatal-warnings -O1
 LDFLAGS			+=	--gc-sections

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -596,10 +596,9 @@ NOTE: Using `-O0` could cause output images to be larger and base addresses
 might need to be recalculated (see the **Memory layout on ARM development
 platforms** section in the [Firmware Design]).
 
-Extra debug options can be passed to the build system by setting `CFLAGS`:
+Extra debug options can be passed to the build system via `TF_EXTRA_CFLAGS`:
 
-    CFLAGS='-O0 -gdwarf-2'                                     \
-    make PLAT=<platform> DEBUG=1 V=1 all
+    make PLAT=<platform> TF_EXTRA_CFLAGS='-O0 -gdwarf-2' DEBUG=1 V=1 all
 
 It is also possible to introduce an infinite loop to help in debugging the
 post-BL2 phase of the Trusted Firmware. This can be done by rebuilding BL1 with

--- a/make_helpers/build_macros.mk
+++ b/make_helpers/build_macros.mk
@@ -198,7 +198,7 @@ $(eval IMAGE := IMAGE_BL$(call uppercase,$(3)))
 
 $(OBJ): $(2) | bl$(3)_dirs
 	@echo "  CC      $$<"
-	$$(Q)$$(CC) $$(TF_CFLAGS) $$(CFLAGS) -D$(IMAGE) $(MAKE_DEP) -c $$< -o $$@
+	$$(Q)$$(CC) $$(TF_CFLAGS) -D$(IMAGE) $(MAKE_DEP) -c $$< -o $$@
 
 -include $(DEP)
 
@@ -323,7 +323,7 @@ ifdef MAKE_BUILD_STRINGS
 else
 	@echo 'const char build_message[] = "Built : "$(BUILD_MESSAGE_TIMESTAMP); \
 	       const char version_string[] = "${VERSION_STRING}";' | \
-		$$(CC) $$(TF_CFLAGS) $$(CFLAGS) -xc -c - -o $(BUILD_DIR)/build_message.o
+		$$(CC) $$(TF_CFLAGS) -xc -c - -o $(BUILD_DIR)/build_message.o
 endif
 	$$(Q)$$(LD) -o $$@ $$(LDFLAGS) -Map=$(MAPFILE) --script $(LINKERFILE) \
 					$(BUILD_DIR)/build_message.o $(OBJS)

--- a/make_helpers/windows.mk
+++ b/make_helpers/windows.mk
@@ -104,6 +104,6 @@ BUILT_TIME_DATE_STRING = const char build_message[] = "Built : "${BUILD_MESSAGE_
 VERSION_STRING_MESSAGE = const char version_string[] = "${VERSION_STRING}";
 define MAKE_BUILD_STRINGS
 	@echo $$(BUILT_TIME_DATE_STRING) $$(VERSION_STRING_MESSAGE) | \
-		$$(CC) $$(TF_CFLAGS) $$(CFLAGS) -x c -c - -o $1
+		$$(CC) $$(TF_CFLAGS) -x c -c - -o $1
 endef
 


### PR DESCRIPTION
The doc/user-guide.md says as follows:

  Extra debug options can be passed to the build system by
  setting `CFLAGS`:

  CFLAGS='-O0 -gdwarf-2'                                     \
  make PLAT=<platform> DEBUG=1 V=1 all

The usage of CFLAGS is confusing.

If CFLAGS is passed as an environment like above, it works.  On the
other hand, if CFLAGS is passed from the command line, it causes
an error.  For example,

  make CFLAGS=-mgeneral-regs-only CROSS_COMPILE=aarch64-linux-gnu- \
  fip BL33=...

will fail to build the fiptool because CFLAGS will also override the
instance in tools/fiptool/Makefile.  Sharing the same CFLAGS for
both the firmware and host tools is problematic.  Actually, CFLAGS
will be a potential name conflict because I also see it in
plat/rockchip/rk3399/drivers/m0/Makefile.  Let's use a different
flag, TF_EXTRA_CFLAGS, for the extra opitons for firmware.  This can
be passed via either an environment or a command line option.

Signed-off-by: Masahiro Yamada <yamada.masahiro@socionext.com>