### PR TITLE
Revert "tbbr: Use constant-time bcmp() to compare hashes"

### DIFF
--- a/drivers/auth/mbedtls/mbedtls_crypto.c
+++ b/drivers/auth/mbedtls/mbedtls_crypto.c
@@ -217,7 +217,7 @@ static int verify_hash(void *data_ptr, unsigned int data_len,
 	}
 
 	/* Compare values */
-	rc = timingsafe_bcmp(data_hash, hash, mbedtls_md_get_size(md_info));
+	rc = memcmp(data_hash, hash, mbedtls_md_get_size(md_info));
 	if (rc != 0) {
 		return CRYPTO_ERR_HASH;
 	}

--- a/drivers/auth/mbedtls/mbedtls_x509_parser.c
+++ b/drivers/auth/mbedtls/mbedtls_x509_parser.c
@@ -392,7 +392,7 @@ static int cert_parse(void *img, unsigned int img_len)
 	if (sig_alg1.len != sig_alg2.len) {
 		return IMG_PARSER_ERR_FORMAT;
 	}
-	if (0 != timingsafe_bcmp(sig_alg1.p, sig_alg2.p, sig_alg1.len)) {
+	if (0 != memcmp(sig_alg1.p, sig_alg2.p, sig_alg1.len)) {
 		return IMG_PARSER_ERR_FORMAT;
 	}
 	memcpy(&sig_alg, &sig_alg1, sizeof(sig_alg));


### PR DESCRIPTION
This reverts commit b621fb503c76f3bdf06ed5ed1d3a995df8da9c50.

Because of the Trusted Firmware design, timing-safe functions are not
needed. Using them may be misleading as it could be interpreted as being
a protection against private data leakage, which isn't the case here.

For each image, the SHA-256 hash is calculated. Some padding is appended
and the result is encrypted with a private key using RSA-2048. This is
the signature of the image. The public key is stored along with BL1 in
read-only memory and the encrypted hash is stored in the FIP.

When authenticating an image, the TF decrypts the hash stored in the FIP
and recalculates the hash of the image. If they don't match, the boot
sequence won't continue.

A constant-time comparison does not provide additional security as all
the data involved in this process is already known to any attacker.
There is no private data that can leaked through a timing attack when
authenticating an image.

`timingsafe_bcmp()` is kept in the codebase because it could be useful
in the future.

Change-Id: I44bdcd58faa586a050cc89447e38c142508c9888
Signed-off-by: Antonio Nino Diaz <antonio.ninodiaz@arm.com>