### PR TITLE
Clarify errata ERRATA_A53_836870 documentation

### DIFF
--- a/docs/cpu-specific-build-macros.md
+++ b/docs/cpu-specific-build-macros.md
@@ -58,7 +58,7 @@ For Cortex-A53, following errata build flags are defined :
 
 *   `ERRATA_A53_836870`: This applies errata 836870 workaround to Cortex-A53
      CPU. This needs to be enabled only for revision <= r0p3 of the CPU. From
-     r0p4 and onwards, this errata is enabled by default.
+     r0p4 and onwards, this errata is enabled by default in hardware.
 
 For Cortex-A57, following errata build flags are defined :
 

--- a/lib/cpus/cpu-ops.mk
+++ b/lib/cpus/cpu-ops.mk
@@ -63,7 +63,7 @@ ERRATA_A53_826319	?=0
 
 # Flag to apply erratum 836870 workaround during reset. This erratum applies
 # only to revision <= r0p3 of the Cortex A53 cpu. From r0p4 and onwards, this
-# erratum workaround is enabled by default.
+# erratum workaround is enabled by default in hardware.
 ERRATA_A53_836870	?=0
 
 # Flag to apply erratum 806969 workaround during reset. This erratum applies


### PR DESCRIPTION
The errata is enabled by default on r0p4, which is confusing given that
we state we do not enable errata by default.

This patch clarifies this sentence by saying it is enabled in hardware
by default.

Change-Id: I70a062d93e1da2416d5f6d5776a77a659da737aa
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>