### PR TITLE
Remove redundant assert

### DIFF
--- a/drivers/io/io_memmap.c
+++ b/drivers/io/io_memmap.c
@@ -125,8 +125,6 @@ static int memmap_block_open(io_dev_info_t *dev_info, const uintptr_t spec,
 	int result = -ENOMEM;
 	const io_block_spec_t *block_spec = (io_block_spec_t *)spec;
 
-	assert(block_spec->length >= 0);
-
 	/* Since we need to track open state for seek() we only allow one open
 	 * spec at a time. When we have dynamic memory we can malloc and set
 	 * entity->info.


### PR DESCRIPTION
Static checks flag an assert added in commit 1f786b0 that compares
unsigned value to 0, which will never fail.

Change-Id: I4b02031c2cfbd9a25255d12156919dda7d4805a0
Signed-off-by: Jeenu Viswambharan <jeenu.viswambharan@arm.com>