### PR TITLE
fiptool: Embed a pointer to an image within the image descriptor

### DIFF
--- a/tools/fiptool/fiptool.h
+++ b/tools/fiptool/fiptool.h
@@ -58,13 +58,13 @@ typedef struct image_desc {
 	char              *cmdline_name;
 	int                action;
 	char              *action_arg;
+	struct image      *image;
 	struct image_desc *next;
 } image_desc_t;
 
 typedef struct image {
 	struct fip_toc_entry toc_e;
 	void                *buffer;
-	struct image        *next;
 } image_t;
 
 typedef struct cmd {


### PR DESCRIPTION
Currently, fiptool uses two linked lists.  One to chain together all
the images and one for all the image descriptors.  Initially this was
done because not all images had a corresponding image descriptor.
This was the case for unknown images which existed in the FIP but
there was no descriptor in the builtin table for them.  When support
for the --blob option came in, we started building descriptors for the
unknown images on the fly.  As a result every image now has a
corresponding image descriptor and therefore it is no longer necessary
to keep track of them separately.

To simplify the design, maintain only a single linked list of image
descriptors.  An image descriptor contains a pointer to the
corresponding image.  If the pointer is NULL, then the descriptor is
skipped in all the operations.  This approach simplifies the traversal
code and avoids redundant lookups.

The linked list of image descriptors is populated based on the
`toc_entries` array.  This means that the order of the images in the
FIP file remains the same across add/remove or create/update
operations.  This is true for all standard images (those specified in
`toc_entries`) but not for those specified via the --blob option.

Change-Id: Ic29a263c86c8f1efdad322b430368c7623782e2d
Signed-off-by: dp-arm <dimitris.papastamos@arm.com>