### PR TITLE
Enable OS Initiated mode

### DIFF
--- a/include/lib/psci/psci.h
+++ b/include/lib/psci/psci.h
@@ -83,6 +83,7 @@
 #define PSCI_NODE_HW_STATE_AARCH64	0xc400000d
 #define PSCI_SYSTEM_SUSPEND_AARCH32	0x8400000E
 #define PSCI_SYSTEM_SUSPEND_AARCH64	0xc400000E
+#define PSCI_SET_SUSPEND_MODE		0x8400000F
 #define PSCI_STAT_RESIDENCY_AARCH32	0x84000010
 #define PSCI_STAT_RESIDENCY_AARCH64	0xc4000010
 #define PSCI_STAT_COUNT_AARCH32		0x84000011
@@ -95,9 +96,9 @@
  * Number of PSCI calls (above) implemented
  */
 #if ENABLE_PSCI_STAT
-#define PSCI_NUM_CALLS			22
+#define PSCI_NUM_CALLS			23
 #else
-#define PSCI_NUM_CALLS			18
+#define PSCI_NUM_CALLS			19
 #endif
 
 /* The macros below are used to identify PSCI calls from the SMC function ID */
@@ -413,6 +414,8 @@ void psci_warmboot_entrypoint(void);
 void psci_register_spd_pm_hook(const spd_pm_ops_t *pm);
 void psci_prepare_next_non_secure_ctx(
 			  entry_point_info_t *next_image_info);
+
+uint32_t psci_suspend_mode;
 
 #endif /*__ASSEMBLY__*/
 

--- a/lib/psci/psci_main.c
+++ b/lib/psci/psci_main.c
@@ -347,13 +347,47 @@ int psci_features(unsigned int psci_fid)
 	if (psci_fid == PSCI_CPU_SUSPEND_AARCH32 ||
 			psci_fid == PSCI_CPU_SUSPEND_AARCH64) {
 		/*
-		 * The trusted firmware does not support OS Initiated Mode.
+		 * The trusted firmware supports OS Initiated Mode.
 		 */
 		return (FF_PSTATE << FF_PSTATE_SHIFT) |
-			((!FF_SUPPORTS_OS_INIT_MODE) << FF_MODE_SUPPORT_SHIFT);
+			((FF_SUPPORTS_OS_INIT_MODE) << FF_MODE_SUPPORT_SHIFT);
 	}
 
 	/* Return 0 for all other fid's */
+	return PSCI_E_SUCCESS;
+}
+
+int psci_set_suspend_mode(unsigned int mode)
+{
+	unsigned int idx;
+
+	if (mode > 1)
+		return PSCI_E_INVALID_PARAMS;
+
+	for (idx = 0; idx < PLATFORM_CORE_COUNT; idx++) {
+		INFO("  CPU Node : MPID 0x%lx, parent_node %d,"
+						" State 0x%x\n",
+					psci_cpu_pd_nodes[idx].mpidr,
+					psci_cpu_pd_nodes[idx].parent_node,
+					psci_get_cpu_local_state_by_idx(idx));
+
+		if (psci_get_cpu_local_state_by_idx(idx) >
+					(PLAT_MAX_PWR_LVL + 1))
+			return PSCI_E_DENIED;
+	}
+
+	INFO("mode = 0x%x\n", mode);
+	switch (mode) {
+	case 0:
+		if (psci_suspend_mode == 1)
+			psci_suspend_mode = 0;
+		break;
+	case 1:
+		if (psci_suspend_mode == 0)
+			psci_suspend_mode = 1;
+		break;
+	}
+
 	return PSCI_E_SUCCESS;
 }
 
@@ -432,6 +466,9 @@ u_register_t psci_smc_handler(uint32_t smc_fid,
 		case PSCI_STAT_COUNT_AARCH32:
 			return psci_stat_count(x1, x2);
 #endif
+
+		case PSCI_SET_SUSPEND_MODE:
+			return psci_set_suspend_mode(x1);
 
 		default:
 			break;

--- a/lib/psci/psci_setup.c
+++ b/lib/psci/psci_setup.c
@@ -273,6 +273,8 @@ int psci_setup(const psci_lib_args_t *lib_args)
 	psci_caps |=  define_psci_cap(PSCI_STAT_COUNT_AARCH64);
 #endif
 
+	psci_caps |=  define_psci_cap(PSCI_SET_SUSPEND_MODE);
+
 	return 0;
 }
 


### PR DESCRIPTION
Make OS Initiated mode run. Genpd-based SoC idle [1]
relies on OS Initiated mode to work. This patch adds
a function for setting PSCI suspend mode to either
platform coordinated mode or OS Initiated mode.

[1] https://www.spinics.net/lists/arm-kernel/msg526814.html

Signed-off-by: Koan-Sin Tan <koansin.tan@gmail.com>