### PR TITLE
Update LOAD_IMAGE_V2 user guide documentation

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -331,8 +331,8 @@ performed.
 *   `LOAD_IMAGE_V2`: Boolean option to enable support for new version (v2) of
     image loading, which provides more flexibility and scalability around what
     images are loaded and executed during boot. Default is 0.
-    Note: `TRUSTED_BOARD_BOOT` is currently not supported when `LOAD_IMAGE_V2`
-    is enabled.
+    Note: `TRUSTED_BOARD_BOOT` is currently only supported for AArch64 when
+    `LOAD_IMAGE_V2` is enabled.
 
 *   `LOG_LEVEL`: Chooses the log level, which controls the amount of console log
     output compiled into the build. This should be one of the following:


### PR DESCRIPTION
Now the TRUSTED_BOARD_BOOT is supported for AArch64 when LOAD_IMAGE_V2
is enabled. This patch updates the user-guide.md documentation for the
same.

Change-Id: I97de07435c81258c2a5f41a30a69736863a10bd1
Signed-off-by: Summer Qin <summer.qin@arm.com>