### PR TITLE
Tegra210: enable errata for Cortex-A57 and Cortex-A53 CPUs

### DIFF
--- a/plat/nvidia/tegra/platform.mk
+++ b/plat/nvidia/tegra/platform.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015-2016, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -35,14 +35,6 @@ PSCI_EXTENDED_STATE_ID	:=	1
 
 # Disable the PSCI platform compatibility layer
 ENABLE_PLAT_COMPAT	:=	0
-
-# Disable cache non-temporal hint for A57
-A57_DISABLE_NON_TEMPORAL_HINT		:= 0
-$(eval $(call add_define,A57_DISABLE_NON_TEMPORAL_HINT))
-
-# Disable cache non-temporal hint for A53
-A53_DISABLE_NON_TEMPORAL_HINT		:= 0
-$(eval $(call add_define,A53_DISABLE_NON_TEMPORAL_HINT))
 
 include plat/nvidia/tegra/common/tegra_common.mk
 include ${SOC_DIR}/platform_${TARGET_SOC}.mk

--- a/plat/nvidia/tegra/soc/t210/platform_t210.mk
+++ b/plat/nvidia/tegra/soc/t210/platform_t210.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -54,6 +54,15 @@ BL31_SOURCES		+=	lib/cpus/aarch64/cortex_a53.S		\
 				${SOC_DIR}/plat_setup.c			\
 				${SOC_DIR}/plat_secondary.c
 
-# Enable workarounds for selected Cortex-A53 erratas.
-ERRATA_A53_826319	:=	1
+# Enable workarounds for selected Cortex-A57 erratas.
+A57_DISABLE_NON_TEMPORAL_HINT	:=	1
+ERRATA_A57_826974		:=	1
+ERRATA_A57_826977		:=	1
+ERRATA_A57_828024		:=	1
+ERRATA_A57_829520		:=	1
+ERRATA_A57_833471		:=	1
 
+# Enable workarounds for selected Cortex-A53 erratas.
+A53_DISABLE_NON_TEMPORAL_HINT	:=	1
+ERRATA_A53_826319		:=	1
+ERRATA_A53_836870		:=	1


### PR DESCRIPTION
This patch enables the following erratas for the Tegra210 SoC:

* Cortex-A57
=========
- A57_DISABLE_NON_TEMPORAL_HINT
- ERRATA_A57_826974
- ERRATA_A57_826977
- ERRATA_A57_828024
- ERRATA_A57_829520
- ERRATA_A57_833471

* Cortex-A53
=========
- A53_DISABLE_NON_TEMPORAL_HINT
- ERRATA_A53_826319
- ERRATA_A53_836870

Tegra210 uses Cortex-A57 revision: r1p1 and Cortex-A53 revision: r0p2.

Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>