### PR TITLE
Add io_retry mechanism for boot redundancy

### DIFF
--- a/bl1/bl1_main.c
+++ b/bl1/bl1_main.c
@@ -42,6 +42,7 @@
 #include <utils.h>
 #include "bl1_private.h"
 #include <uuid.h>
+#include <io_storage.h>
 
 /* BL1 Service UUID */
 DEFINE_SVC_UUID(bl1_svc_uid,
@@ -198,17 +199,18 @@ void bl1_load_bl2(void)
 
 	INFO("BL1: Loading BL2\n");
 
+	do {
 #if LOAD_IMAGE_V2
-	err = load_auth_image(BL2_IMAGE_ID, image_info);
+		err = load_auth_image(BL2_IMAGE_ID, image_info);
 #else
-	/* Load the BL2 image */
-	err = load_auth_image(bl1_tzram_layout,
-			 BL2_IMAGE_ID,
-			 image_info->image_base,
-			 image_info,
-			 ep_info);
-
-#endif /* LOAD_IMAGE_V2 */
+		/* Load the BL2 image */
+		err = load_auth_image(bl1_tzram_layout,
+				      BL2_IMAGE_ID,
+				      image_info->image_base,
+				      image_info,
+				      ep_info);
+#endif
+	} while (err && io_retry() > 0);
 
 	if (err) {
 		ERROR("Failed to load BL2 firmware.\n");

--- a/bl2/bl2_image_load.c
+++ b/bl2/bl2_image_load.c
@@ -35,6 +35,7 @@
 #include <bl_common.h>
 #include <debug.h>
 #include <errno.h>
+#include <io_storage.h>
 #include <platform.h>
 #include <platform_def.h>
 #include <stdint.h>
@@ -212,7 +213,10 @@ entry_point_info_t *bl2_load_images(void)
 	entry_point_info_t *bl31_ep_info;
 	int e;
 
-	e = load_scp_bl2();
+	do {
+		e = load_scp_bl2();
+	} while (e && io_retry() > 0);
+
 	if (e) {
 		ERROR("Failed to load SCP_BL2 (%i)\n", e);
 		plat_error_handler(e);
@@ -244,7 +248,10 @@ entry_point_info_t *bl2_load_images(void)
 	bl31_ep_info->args.arg0 = (unsigned long) bl2_to_bl31_params;
 	bl2_plat_set_bl31_ep_info(NULL, bl31_ep_info);
 #else
-	e = load_bl31(bl2_to_bl31_params, bl31_ep_info);
+	do {
+		e = load_bl31(bl2_to_bl31_params, bl31_ep_info);
+	} while (e && io_retry() > 0);
+
 	if (e) {
 		ERROR("Failed to load BL31 (%i)\n", e);
 		plat_error_handler(e);

--- a/drivers/io/io_fip.c
+++ b/drivers/io/io_fip.c
@@ -188,11 +188,6 @@ static int fip_dev_init(io_dev_info_t *dev_info, const uintptr_t init_params)
 static int fip_dev_close(io_dev_info_t *dev_info)
 {
 	/* TODO: Consider tracking open files and cleaning them up here */
-
-	/* Clear the backend. */
-	backend_dev_handle = (uintptr_t)NULL;
-	backend_image_spec = (uintptr_t)NULL;
-
 	return 0;
 }
 

--- a/include/drivers/io/io_storage.h
+++ b/include/drivers/io/io_storage.h
@@ -122,5 +122,10 @@ int io_write(uintptr_t handle, const uintptr_t buffer, size_t length,
 
 int io_close(uintptr_t handle);
 
+int io_retry(void);
+
+int io_get_num_retries(void);
+
+void io_set_num_retries(int num_retries);
 
 #endif /* __IO_H__ */


### PR DESCRIPTION
Add io_retry mechanism to io_storage.
With io_retry in place BL1 and BL2 can both search for the FIP image
in multiple locations.  And, the io_memmap device knows where to look
for the image based on the retry count.
There doesn't seem to be a way to cleanly pass a retry count between the
various components in the current ATF software architecture otherwise.