### PR TITLE
Allow platform specific ERROR, NOTICE, WARNING, INFO, VERBOSE messages

### DIFF
--- a/docs/porting-guide.md
+++ b/docs/porting-guide.md
@@ -203,6 +203,14 @@ platform port to define additional platform porting constants in
     Currently, this macro is used by the Generic PSCI implementation to size
     the array used for PSCI_STAT_COUNT/RESIDENCY accounting.
 
+*   **#define : PLAT_LOG_MACROS **
+
+    Override the default log macros with platform specific logging mechanism.
+    See default_log_macros.h for details on macro functionality to replace.
+    To override, define PLAT_LOG_MACROS and create plat_log_macros.h.
+    For template, copy default_log_macros.h to your platform specific include
+    path and rename to plat_log_macros.h, then edit log macros.
+
 *   **#define : BL1_RO_BASE**
 
     Defines the base address in secure ROM where BL1 originally lives. Must be

--- a/include/common/default_debug_macros.h
+++ b/include/common/default_debug_macros.h
@@ -28,29 +28,50 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef __DEBUG_H__
-#define __DEBUG_H__
+#ifndef __DEFAULT_LOG_MACROS_H__
+#define __DEFAULT_LOG_MACROS_H__
 
-#define LOG_LEVEL_NONE			0
-#define LOG_LEVEL_ERROR			10
-#define LOG_LEVEL_NOTICE		20
-#define LOG_LEVEL_WARNING		30
-#define LOG_LEVEL_INFO			40
-#define LOG_LEVEL_VERBOSE		50
+/* The log output macros print output to the console. These macros produce
+ * compiled log output only if the LOG_LEVEL defined in the makefile (or the
+ * make command line) is greater or equal than the level required for that
+ * type of log output.
+ * The format expected is the same as for printf(). For example:
+ * INFO("Info %s.\n", "message")    -> INFO:    Info message.
+ * WARN("Warning %s.\n", "message") -> WARNING: Warning message.
+ */
 
 #ifndef __ASSEMBLY__
-#include <platform_def.h>
-#ifdef PLAT_LOG_MACROS
-#include <plat_log_macros.h>
-#else
-#include <default_log_macros.h>
-#endif
 #include <stdio.h>
 
-void __dead2 do_panic(void);
-#define panic()	do_panic()
+#if LOG_LEVEL >= LOG_LEVEL_NOTICE
+# define NOTICE(...)	tf_printf("NOTICE:  " __VA_ARGS__)
+#else
+# define NOTICE(...)
+#endif
 
-void tf_printf(const char *fmt, ...) __printflike(1, 2);
+#if LOG_LEVEL >= LOG_LEVEL_ERROR
+# define ERROR(...)	tf_printf("ERROR:   " __VA_ARGS__)
+#else
+# define ERROR(...)
+#endif
+
+#if LOG_LEVEL >= LOG_LEVEL_WARNING
+# define WARN(...)	tf_printf("WARNING: " __VA_ARGS__)
+#else
+# define WARN(...)
+#endif
+
+#if LOG_LEVEL >= LOG_LEVEL_INFO
+# define INFO(...)	tf_printf("INFO:    " __VA_ARGS__)
+#else
+# define INFO(...)
+#endif
+
+#if LOG_LEVEL >= LOG_LEVEL_VERBOSE
+# define VERBOSE(...)	tf_printf("VERBOSE: " __VA_ARGS__)
+#else
+# define VERBOSE(...)
+#endif
 
 #endif /* __ASSEMBLY__ */
-#endif /* __DEBUG_H__ */
+#endif /* __DEFAULT_LOG_MACROS_H__ */


### PR DESCRIPTION
Allow ERROR, NOTICE, WARNING, INFO, and VERBOSE
messages to be implemented on a platform specific basis.

Default remains current implementation.

Fixes ARM-software/tf-issues#462

Signed-off-by: Scott Branden <scott.branden@broadcom.com>