### PR TITLE
Move plat/common source file definitions to generic Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,7 @@ BL_COMMON_SOURCES	+=	common/bl_common.c			\
 				common/${ARCH}/debug.S			\
 				lib/${ARCH}/cache_helpers.S		\
 				lib/${ARCH}/misc_helpers.S		\
+				plat/common/${ARCH}/plat_common.c	\
 				plat/common/${ARCH}/platform_helpers.S	\
 				${STDLIB_SRCS}
 

--- a/bl1/bl1.mk
+++ b/bl1/bl1.mk
@@ -36,8 +36,8 @@ BL1_SOURCES		+=	bl1/bl1_main.c				\
 				lib/cpus/${ARCH}/cpu_helpers.S		\
 				lib/cpus/errata_report.c		\
 				lib/el3_runtime/${ARCH}/context_mgmt.c	\
-				plat/common/plat_bl1_common.c
-
+				plat/common/plat_bl1_common.c		\
+				plat/common/${ARCH}/platform_up_stack.S
 
 ifeq (${ARCH},aarch64)
 BL1_SOURCES		+=	lib/el3_runtime/aarch64/context.S

--- a/bl2/bl2.mk
+++ b/bl2/bl2.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2016, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -31,7 +31,8 @@
 BL2_SOURCES		+=	bl2/bl2_main.c				\
 				bl2/${ARCH}/bl2_entrypoint.S		\
 				bl2/${ARCH}/bl2_arch_setup.c		\
-				lib/locks/exclusive/${ARCH}/spinlock.S
+				lib/locks/exclusive/${ARCH}/spinlock.S	\
+				plat/common/${ARCH}/platform_up_stack.S
 
 ifeq (${ARCH},aarch64)
 BL2_SOURCES		+=	common/aarch64/early_exceptions.S

--- a/bl2u/bl2u.mk
+++ b/bl2u/bl2u.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -30,6 +30,7 @@
 
 BL2U_SOURCES		+=	bl2u/bl2u_main.c			\
 				bl2u/aarch64/bl2u_entrypoint.S		\
-				common/aarch64/early_exceptions.S
+				common/aarch64/early_exceptions.S	\
+				plat/common/aarch64/platform_up_stack.S
 
 BL2U_LINKERFILE		:=	bl2u/bl2u.ld.S

--- a/bl31/bl31.mk
+++ b/bl31/bl31.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2016, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -37,6 +37,7 @@ BL31_SOURCES		+=	bl31/bl31_main.c				\
 				bl31/aarch64/crash_reporting.S			\
 				bl31/bl31_context_mgmt.c			\
 				common/runtime_svc.c				\
+				plat/common/aarch64/platform_mp_stack.S		\
 				services/std_svc/std_svc_setup.c		\
 				${PSCI_LIB_SOURCES}
 

--- a/plat/arm/common/arm_common.mk
+++ b/plat/arm/common/arm_common.mk
@@ -112,16 +112,14 @@ include lib/xlat_tables_v2/xlat_tables.mk
 
 PLAT_BL_COMMON_SOURCES	+=	${XLAT_TABLES_LIB_SRCS}				\
 				plat/arm/common/${ARCH}/arm_helpers.S		\
-				plat/arm/common/arm_common.c			\
-				plat/common/${ARCH}/plat_common.c
+				plat/arm/common/arm_common.c
 
 BL1_SOURCES		+=	drivers/arm/sp805/sp805.c			\
 				drivers/io/io_fip.c				\
 				drivers/io/io_memmap.c				\
 				drivers/io/io_storage.c				\
 				plat/arm/common/arm_bl1_setup.c			\
-				plat/arm/common/arm_io_storage.c		\
-				plat/common/${ARCH}/platform_up_stack.S
+				plat/arm/common/arm_io_storage.c
 ifdef EL3_PAYLOAD_BASE
 # Need the arm_program_trusted_mailbox() function to release secondary CPUs from
 # their holding pen
@@ -132,21 +130,18 @@ BL2_SOURCES		+=	drivers/io/io_fip.c				\
 				drivers/io/io_memmap.c				\
 				drivers/io/io_storage.c				\
 				plat/arm/common/arm_bl2_setup.c			\
-				plat/arm/common/arm_io_storage.c		\
-				plat/common/${ARCH}/platform_up_stack.S
+				plat/arm/common/arm_io_storage.c
 ifeq (${LOAD_IMAGE_V2},1)
 BL2_SOURCES		+=	plat/arm/common/${ARCH}/arm_bl2_mem_params_desc.c\
 				plat/arm/common/arm_image_load.c		\
 				common/desc_image_load.c
 endif
 
-BL2U_SOURCES		+=	plat/arm/common/arm_bl2u_setup.c		\
-				plat/common/aarch64/platform_up_stack.S
+BL2U_SOURCES		+=	plat/arm/common/arm_bl2u_setup.c
 
 BL31_SOURCES		+=	plat/arm/common/arm_bl31_setup.c		\
 				plat/arm/common/arm_pm.c			\
 				plat/arm/common/arm_topology.c			\
-				plat/common/aarch64/platform_mp_stack.S		\
 				plat/common/plat_psci_common.c
 
 ifeq (${ENABLE_PMF}, 1)

--- a/plat/common/aarch32/platform_up_stack.S
+++ b/plat/common/aarch32/platform_up_stack.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -32,8 +32,8 @@
 #include <asm_macros.S>
 #include <platform_def.h>
 
-	.globl	plat_get_my_stack
-	.globl	plat_set_my_stack
+	.weak	plat_get_my_stack
+	.weak	plat_set_my_stack
 
 	/* -----------------------------------------------------
 	 * unsigned long plat_get_my_stack ()

--- a/plat/common/aarch64/platform_up_stack.S
+++ b/plat/common/aarch64/platform_up_stack.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -34,10 +34,10 @@
 
 
 	.local	platform_normal_stacks
-	.globl	plat_set_my_stack
-	.globl	plat_get_my_stack
-	.globl	platform_set_stack
-	.globl	platform_get_stack
+	.weak	plat_set_my_stack
+	.weak	plat_get_my_stack
+	.weak	platform_set_stack
+	.weak	platform_get_stack
 
 	/* -----------------------------------------------------
 	 * uintptr_t plat_get_my_stack ()

--- a/plat/mediatek/mt6795/platform.mk
+++ b/plat/mediatek/mt6795/platform.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -51,7 +51,6 @@ PLAT_INCLUDES		:=	-I${MTK_PLAT}/common/				\
 				${OEMS_INCLUDES}
 
 PLAT_BL_COMMON_SOURCES	:=	lib/aarch64/xlat_tables.c			\
-				plat/common/aarch64/plat_common.c		\
 				plat/common/plat_gic.c
 
 BL31_SOURCES		+=	drivers/arm/cci/cci.c				\
@@ -63,7 +62,6 @@ BL31_SOURCES		+=	drivers/arm/cci/cci.c				\
 				drivers/console/console.S			\
 				drivers/delay_timer/delay_timer.c		\
 				lib/cpus/aarch64/cortex_a53.S			\
-				plat/common/aarch64/platform_mp_stack.S		\
 				${MTK_PLAT_SOC}/bl31_plat_setup.c		\
 				${MTK_PLAT_SOC}/plat_mt_gic.c			\
 				${MTK_PLAT}/common/mtk_sip_svc.c		\

--- a/plat/mediatek/mt8173/platform.mk
+++ b/plat/mediatek/mt8173/platform.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -45,7 +45,6 @@ PLAT_INCLUDES		:=	-I${MTK_PLAT}/common/				\
 
 PLAT_BL_COMMON_SOURCES	:=	lib/xlat_tables/xlat_tables_common.c		\
 				lib/xlat_tables/aarch64/xlat_tables.c		\
-				plat/common/aarch64/plat_common.c		\
 				plat/arm/common/arm_gicv2.c			\
 				plat/common/plat_gicv2.c
 
@@ -60,7 +59,6 @@ BL31_SOURCES		+=	drivers/arm/cci/cci.c				\
 				lib/cpus/aarch64/cortex_a53.S			\
 				lib/cpus/aarch64/cortex_a57.S			\
 				lib/cpus/aarch64/cortex_a72.S			\
-				plat/common/aarch64/platform_mp_stack.S		\
 				${MTK_PLAT}/common/drivers/uart/8250_console.S	\
 				${MTK_PLAT}/common/mtk_plat_common.c		\
 				${MTK_PLAT}/common/mtk_sip_svc.c		\

--- a/plat/nvidia/tegra/common/tegra_common.mk
+++ b/plat/nvidia/tegra/common/tegra_common.mk
@@ -43,8 +43,7 @@ PLAT_INCLUDES		:=	-Iplat/nvidia/tegra/include/drivers \
 				-Iplat/nvidia/tegra/include/${TARGET_SOC}
 
 PLAT_BL_COMMON_SOURCES	:=	lib/xlat_tables/xlat_tables_common.c		\
-				lib/xlat_tables/aarch64/xlat_tables.c		\
-				plat/common/aarch64/plat_common.c
+				lib/xlat_tables/aarch64/xlat_tables.c
 
 COMMON_DIR		:=	plat/nvidia/tegra/common
 
@@ -52,7 +51,6 @@ BL31_SOURCES		+=	drivers/arm/gic/gic_v2.c			\
 				drivers/console/aarch64/console.S		\
 				drivers/delay_timer/delay_timer.c		\
 				drivers/ti/uart/aarch64/16550_console.S		\
-				plat/common/aarch64/platform_mp_stack.S		\
 				${COMMON_DIR}/aarch64/tegra_helpers.S		\
 				${COMMON_DIR}/drivers/pmc/pmc.c			\
 				${COMMON_DIR}/tegra_bl31_setup.c		\

--- a/plat/qemu/platform.mk
+++ b/plat/qemu/platform.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2015, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -51,7 +51,6 @@ BL1_SOURCES		+=	drivers/io/io_semihosting.c		\
 				lib/cpus/aarch64/aem_generic.S		\
 				lib/cpus/aarch64/cortex_a53.S		\
 				lib/cpus/aarch64/cortex_a57.S		\
-				plat/common/aarch64/platform_mp_stack.S	\
 				plat/qemu/aarch64/plat_helpers.S	\
 				plat/qemu/qemu_bl1_setup.c
 
@@ -59,7 +58,6 @@ BL2_SOURCES		+=	drivers/io/io_semihosting.c		\
 				drivers/io/io_storage.c			\
 				drivers/io/io_fip.c			\
 				drivers/io/io_memmap.c			\
-				plat/common/aarch64/platform_mp_stack.S	\
 				lib/semihosting/semihosting.c		\
 				lib/semihosting/aarch64/semihosting_call.S\
 				plat/qemu/qemu_io_storage.c		\
@@ -74,9 +72,7 @@ BL31_SOURCES		+=	lib/cpus/aarch64/aem_generic.S		\
 				drivers/arm/gic/v2/gicv2_helpers.c	\
 				drivers/arm/gic/v2/gicv2_main.c		\
 				drivers/arm/gic/common/gic_common.c	\
-				plat/common/aarch64/platform_mp_stack.S	\
 				plat/common/aarch64/plat_psci_common.c	\
-				plat/common/aarch64/plat_common.c	\
 				plat/qemu/qemu_pm.c			\
 				plat/qemu/topology.c			\
 				plat/qemu/aarch64/plat_helpers.S	\

--- a/plat/rockchip/rk3368/platform.mk
+++ b/plat/rockchip/rk3368/platform.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -50,7 +50,6 @@ RK_GIC_SOURCES         :=	drivers/arm/gic/common/gic_common.c		\
 
 PLAT_BL_COMMON_SOURCES	:=	lib/xlat_tables/xlat_tables_common.c		\
 				lib/xlat_tables/aarch64/xlat_tables.c		\
-				plat/common/aarch64/plat_common.c		\
 				plat/common/plat_psci_common.c
 
 BL31_SOURCES		+=	${RK_GIC_SOURCES}				\
@@ -60,7 +59,6 @@ BL31_SOURCES		+=	${RK_GIC_SOURCES}				\
 				drivers/delay_timer/delay_timer.c		\
 				drivers/delay_timer/generic_delay_timer.c	\
 				lib/cpus/aarch64/cortex_a53.S			\
-				plat/common/aarch64/platform_mp_stack.S		\
 				${RK_PLAT_COMMON}/aarch64/plat_helpers.S	\
 				${RK_PLAT_COMMON}/bl31_plat_setup.c		\
 				${RK_PLAT_COMMON}/params_setup.c                \

--- a/plat/rockchip/rk3399/platform.mk
+++ b/plat/rockchip/rk3399/platform.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -53,7 +53,6 @@ RK_GIC_SOURCES		:=	drivers/arm/gic/common/gic_common.c	\
 
 PLAT_BL_COMMON_SOURCES	:=	lib/xlat_tables/xlat_tables_common.c	\
 				lib/xlat_tables/aarch64/xlat_tables.c	\
-				plat/common/aarch64/plat_common.c	\
 				plat/common/plat_psci_common.c
 
 BL31_SOURCES	+=	${RK_GIC_SOURCES}				\
@@ -65,7 +64,6 @@ BL31_SOURCES	+=	${RK_GIC_SOURCES}				\
 			drivers/gpio/gpio.c				\
 			lib/cpus/aarch64/cortex_a53.S			\
 			lib/cpus/aarch64/cortex_a72.S			\
-			plat/common/aarch64/platform_mp_stack.S		\
 			${RK_PLAT_COMMON}/aarch64/plat_helpers.S	\
 			${RK_PLAT_COMMON}/bl31_plat_setup.c		\
 			${RK_PLAT_COMMON}/params_setup.c		\

--- a/plat/xilinx/zynqmp/platform.mk
+++ b/plat/xilinx/zynqmp/platform.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2016, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -78,7 +78,6 @@ PLAT_BL_COMMON_SOURCES	:=	lib/xlat_tables/xlat_tables_common.c		\
 				plat/arm/common/arm_common.c			\
 				plat/arm/common/arm_gicv2.c			\
 				plat/common/plat_gicv2.c			\
-				plat/common/aarch64/plat_common.c		\
 				plat/xilinx/zynqmp/aarch64/zynqmp_helpers.S	\
 				plat/xilinx/zynqmp/aarch64/zynqmp_common.c
 
@@ -86,7 +85,6 @@ BL31_SOURCES		+=	drivers/arm/cci/cci.c				\
 				lib/cpus/aarch64/aem_generic.S			\
 				lib/cpus/aarch64/cortex_a53.S			\
 				plat/common/plat_psci_common.c			\
-				plat/common/aarch64/platform_mp_stack.S		\
 				plat/xilinx/zynqmp/bl31_zynqmp_setup.c		\
 				plat/xilinx/zynqmp/plat_psci.c			\
 				plat/xilinx/zynqmp/plat_zynqmp.c		\


### PR DESCRIPTION
These source file definitions should be defined in generic
Makefiles so that all platforms can benefit. Ensure that the
symbols are properly marked as weak so they can be overridden
by platforms.

NOTE: This change is a potential compatibility break for
non-upstream platforms.

Change-Id: I7b892efa9f2d6d216931360dc6c436e1d10cffed
Signed-off-by: dp-arm <dimitris.papastamos@arm.com>