### PR TITLE
mbedtls: Namespace TF specific macros

### DIFF
--- a/drivers/auth/mbedtls/mbedtls_common.c
+++ b/drivers/auth/mbedtls/mbedtls_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -36,9 +36,9 @@
 /*
  * mbed TLS heap
  */
-#if (MBEDTLS_KEY_ALG_ID == MBEDTLS_ECDSA)
+#if (TBBR_KEY_ALG_ID == TBBR_ECDSA)
 #define MBEDTLS_HEAP_SIZE		(14*1024)
-#elif (MBEDTLS_KEY_ALG_ID == MBEDTLS_RSA)
+#elif (TBBR_KEY_ALG_ID == TBBR_RSA)
 #define MBEDTLS_HEAP_SIZE		(8*1024)
 #endif
 static unsigned char heap[MBEDTLS_HEAP_SIZE];

--- a/drivers/auth/mbedtls/mbedtls_crypto.mk
+++ b/drivers/auth/mbedtls/mbedtls_crypto.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -55,18 +55,18 @@ ifeq (${MBEDTLS_KEY_ALG},ecdsa)
     					ecp_curves.c				\
     					ecp.c					\
     					)
-    MBEDTLS_KEY_ALG_ID		:=	MBEDTLS_ECDSA
+    TBBR_KEY_ALG_ID		:=	TBBR_ECDSA
 else ifeq (${MBEDTLS_KEY_ALG},rsa)
     MBEDTLS_CRYPTO_SOURCES	+=	$(addprefix ${MBEDTLS_DIR}/library/,	\
     					rsa.c					\
     					)
-    MBEDTLS_KEY_ALG_ID		:=	MBEDTLS_RSA
+    TBBR_KEY_ALG_ID		:=	TBBR_RSA
 else
     $(error "MBEDTLS_KEY_ALG=${MBEDTLS_KEY_ALG} not supported on mbed TLS")
 endif
 
-# mbed TLS libraries rely on this define to build correctly
-$(eval $(call add_define,MBEDTLS_KEY_ALG_ID))
+# Needs to be set to drive mbed TLS configuration correctly
+$(eval $(call add_define,TBBR_KEY_ALG_ID))
 
 BL1_SOURCES			+=	${MBEDTLS_CRYPTO_SOURCES}
 BL2_SOURCES			+=	${MBEDTLS_CRYPTO_SOURCES}

--- a/include/drivers/auth/mbedtls/mbedtls_config.h
+++ b/include/drivers/auth/mbedtls/mbedtls_config.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -33,8 +33,8 @@
 /*
  * Key algorithms currently supported on mbed TLS libraries
  */
-#define MBEDTLS_RSA			1
-#define MBEDTLS_ECDSA			2
+#define TBBR_RSA	1
+#define TBBR_ECDSA	2
 
 /*
  * Configuration file to build mbed TLS with the required features for
@@ -69,11 +69,11 @@
 
 #define MBEDTLS_PLATFORM_C
 
-#if (MBEDTLS_KEY_ALG_ID == MBEDTLS_ECDSA)
+#if (TBBR_KEY_ALG_ID == TBBR_ECDSA)
 #define MBEDTLS_ECDSA_C
 #define MBEDTLS_ECP_C
 #define MBEDTLS_ECP_DP_SECP256R1_ENABLED
-#elif (MBEDTLS_KEY_ALG_ID == MBEDTLS_RSA)
+#elif (TBBR_KEY_ALG_ID == TBBR_RSA)
 #define MBEDTLS_RSA_C
 #endif
 


### PR DESCRIPTION
These macros are not part of mbed TLS so they should not be prefixed
with `MBEDTLS_` to avoid potential collision in the future. Use the
`TBBR_` suffix to highlight that they only used in TF.

`MBEDTLS_KEY_ALG` was not modified because that is documented and used
by platforms to select the key algorithm.

Change-Id: Ief224681715c481691c80810501830ce16e210b0
Signed-off-by: dp-arm <dimitris.papastamos@arm.com>