### PR TITLE
Tegra: memctrl_v2: fix logic to calculate TZRAM_ADDR_HI bits

### DIFF
--- a/plat/nvidia/tegra/common/drivers/memctrl/memctrl_v2.c
+++ b/plat/nvidia/tegra/common/drivers/memctrl/memctrl_v2.c
@@ -392,8 +392,8 @@ void tegra_memctrl_tzram_setup(uint64_t phys_base, uint32_t size_in_bytes)
 
 	/* Extract the high address bits from the base/end values */
 	val = (uint32_t)(phys_base >> 32) & TZRAM_ADDR_HI_BITS_MASK;
-	val |= (((uint32_t)(tzram_end >> 32) << TZRAM_END_HI_BITS_SHIFT) &
-		TZRAM_ADDR_HI_BITS_MASK);
+	val |= (((uint32_t)(tzram_end >> 32) & TZRAM_ADDR_HI_BITS_MASK) <<
+		TZRAM_END_HI_BITS_SHIFT);
 	tegra_mc_write_32(MC_TZRAM_HI_ADDR_BITS, val);
 
 	/* Disable further writes to the TZRAM setup registers */


### PR DESCRIPTION
This patch fixes the logic to calculate the higher bits for TZRAM's base/end
addresses.

Fixes coverity error "31853: Wrong operator used (CONSTANT_EXPRESSION_RESULT)"

Change-Id: Iff62ef18cba59cd41ad63a5c71664872728356a8
Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>