### PR TITLE
ARM platforms: Add support for MT bit in MPIDR

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -197,6 +197,12 @@ performed.
     by the interrupt management framework. Default is 2 (that is, version 2.0).
     This build option is deprecated.
 
+*   `ARM_PLAT_MT`: This flag determines whether the ARM platform layer has to
+    cater for the multi-threading `MT` bit when accessing MPIDR. When this
+    flag is set, the functions which deal with MPIDR assume that the `MT` bit
+    in MPIDR is set and access the bit-fields in MPIDR accordingly. Default
+    value of this flag is 0.
+
 *   `ASM_ASSERTION`: This flag determines whether the assertion checks within
     assembly source files are enabled or not. This option defaults to the
     value of `DEBUG` - that is, by default this is only enabled for a debug

--- a/include/lib/aarch32/arch.h
+++ b/include/lib/aarch32/arch.h
@@ -46,6 +46,7 @@
 /*******************************************************************************
  * MPIDR macros
  ******************************************************************************/
+#define MPIDR_MT_MASK		(1 << 24)
 #define MPIDR_CPU_MASK		MPIDR_AFFLVL_MASK
 #define MPIDR_CLUSTER_MASK	(MPIDR_AFFLVL_MASK << MPIDR_AFFINITY_BITS)
 #define MPIDR_AFFINITY_BITS	8

--- a/include/lib/aarch64/arch.h
+++ b/include/lib/aarch64/arch.h
@@ -49,6 +49,7 @@
 /*******************************************************************************
  * MPIDR macros
  ******************************************************************************/
+#define MPIDR_MT_MASK		(1 << 24)
 #define MPIDR_CPU_MASK		MPIDR_AFFLVL_MASK
 #define MPIDR_CLUSTER_MASK	MPIDR_AFFLVL_MASK << MPIDR_AFFINITY_BITS
 #define MPIDR_AFFINITY_BITS	8

--- a/include/plat/arm/common/plat_arm.h
+++ b/include/plat/arm/common/plat_arm.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -202,6 +202,10 @@ void plat_arm_pwrc_setup(void);
 void plat_arm_interconnect_init(void);
 void plat_arm_interconnect_enter_coherency(void);
 void plat_arm_interconnect_exit_coherency(void);
+
+#if ARM_PLAT_MT
+unsigned int plat_arm_get_cpu_pe_count(u_register_t mpidr);
+#endif
 
 #if LOAD_IMAGE_V2
 /*

--- a/plat/arm/common/arm_common.mk
+++ b/plat/arm/common/arm_common.mk
@@ -90,6 +90,11 @@ ARM_BL31_IN_DRAM		:=	0
 $(eval $(call assert_boolean,ARM_BL31_IN_DRAM))
 $(eval $(call add_define,ARM_BL31_IN_DRAM))
 
+# Process ARM_PLAT_MT flag
+ARM_PLAT_MT			:=	0
+$(eval $(call assert_boolean,ARM_PLAT_MT))
+$(eval $(call add_define,ARM_PLAT_MT))
+
 # Enable PSCI_STAT_COUNT/RESIDENCY APIs on ARM platforms
 ENABLE_PSCI_STAT		:=	1
 ENABLE_PMF			:=	1

--- a/plat/arm/css/common/css_topology.c
+++ b/plat/arm/css/common/css_topology.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -30,6 +30,10 @@
 
 #include <plat_arm.h>
 
+#if ARM_PLAT_MT
+#pragma weak plat_arm_get_cpu_pe_count
+#endif
+
 /******************************************************************************
  * This function implements a part of the critical interface between the psci
  * generic layer and the platform that allows the former to query the platform
@@ -43,3 +47,14 @@ int plat_core_pos_by_mpidr(u_register_t mpidr)
 
 	return -1;
 }
+
+#if ARM_PLAT_MT
+/******************************************************************************
+ * This function returns the PE count within the physical cpu corresponding to
+ * `mpidr`. Now one cpu only have one thread, so just return 1.
+ *****************************************************************************/
+unsigned int plat_arm_get_cpu_pe_count(u_register_t mpidr)
+{
+	return 1;
+}
+#endif /* ARM_PLAT_MT */

--- a/plat/arm/css/drivers/scpi/css_scpi.c
+++ b/plat/arm/css/drivers/scpi/css_scpi.c
@@ -150,8 +150,18 @@ void scpi_set_css_power_state(unsigned int mpidr,
 	uint32_t state = 0;
 	uint32_t *payload_addr;
 
+#if ARM_PLAT_MT
+	/*
+	 * The current SCPI driver only caters for single-threaded platforms.
+	 * Hence we ignore the thread ID (which is always 0) for such platforms.
+	 */
+	state |= (mpidr >> MPIDR_AFF1_SHIFT) & 0x0f;	/* CPU ID */
+	state |= ((mpidr >> MPIDR_AFF2_SHIFT) & 0x0f) << 4;	/* Cluster ID */
+#else
 	state |= mpidr & 0x0f;	/* CPU ID */
 	state |= (mpidr & 0xf00) >> 4;	/* Cluster ID */
+#endif /* ARM_PLAT_MT */
+
 	state |= cpu_state << 8;
 	state |= cluster_state << 12;
 	state |= css_state << 16;


### PR DESCRIPTION
This patch modifies some of the functions in ARM platform layer to cater
for the case when multi-threading `MT` is set in MPIDR. A new build flag
`ARM_PLAT_MT` is added, and when enabled, the functions accessing MPIDR
now assume that the `MT` bit is set for the platform and access the bit
fields accordingly.

Also, a new API plat_arm_get_cpu_pe_count is added when `ARM_PLAT_MT` is
enabled, returning the PE count within the physical cpu corresponding to
`mpidr`.

Change-Id: I04ccf212ac3054a60882761f4087bae299af13cb
Signed-off-by: Summer Qin <summer.qin@arm.com>