### PR TITLE
Add support to change xlat_tables to non-cacheable

### DIFF
--- a/include/lib/xlat_tables/xlat_tables_defs.h
+++ b/include/lib/xlat_tables/xlat_tables_defs.h
@@ -135,4 +135,10 @@
  */
 #define DISABLE_DCACHE			(1 << 0)
 
+/*
+ * This flag marks the translation tables are Non-cacheable for MMU accesses.
+ * If the flag is not specified, by default the tables are cacheable.
+ */
+#define XLAT_TABLE_NC			(1 << 1)
+
 #endif /* __XLAT_TABLES_DEFS_H__ */

--- a/lib/xlat_tables/aarch32/xlat_tables.c
+++ b/lib/xlat_tables/aarch32/xlat_tables.c
@@ -130,13 +130,21 @@ void enable_mmu_secure(unsigned int flags)
 	tlbiall();
 
 	/*
-	 * Set TTBCR bits as well. Set TTBR0 table properties as Inner
-	 * & outer WBWA & shareable. Disable TTBR1.
+	 * Set TTBCR bits as well. Set TTBR0 table properties. Disable TTBR1.
 	 */
-	ttbcr = TTBCR_EAE_BIT |
-		TTBCR_SH0_INNER_SHAREABLE | TTBCR_RGN0_OUTER_WBA |
-		TTBCR_RGN0_INNER_WBA |
-		(32 - __builtin_ctzl((uintptr_t)PLAT_VIRT_ADDR_SPACE_SIZE));
+	if (flags & XLAT_TABLE_NC) {
+		/* Inner & outer non-cacheable non-shareable. */
+		ttbcr = TTBCR_EAE_BIT |
+			TTBCR_SH0_NON_SHAREABLE | TTBCR_RGN0_OUTER_NC |
+			TTBCR_RGN0_INNER_NC |
+			(32 - __builtin_ctzl((uintptr_t)PLAT_VIRT_ADDR_SPACE_SIZE));
+	} else {
+		/* Inner & outer WBWA & shareable. */
+		ttbcr = TTBCR_EAE_BIT |
+			TTBCR_SH0_INNER_SHAREABLE | TTBCR_RGN0_OUTER_WBA |
+			TTBCR_RGN0_INNER_WBA |
+			(32 - __builtin_ctzl((uintptr_t)PLAT_VIRT_ADDR_SPACE_SIZE));
+	}
 	ttbcr |= TTBCR_EPD1_BIT;
 	write_ttbcr(ttbcr);
 

--- a/lib/xlat_tables/aarch64/xlat_tables.c
+++ b/lib/xlat_tables/aarch64/xlat_tables.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -192,11 +192,18 @@ void init_xlat_tables(void)
 		_tlbi_fct();						\
 									\
 		/* Set TCR bits as well. */				\
-		/* Inner & outer WBWA & shareable. */			\
 		/* Set T0SZ to (64 - width of virtual address space) */	\
-		tcr = TCR_SH_INNER_SHAREABLE | TCR_RGN_OUTER_WBA |	\
-			TCR_RGN_INNER_WBA |				\
-			(64 - __builtin_ctzl(PLAT_VIRT_ADDR_SPACE_SIZE));\
+		if (flags & XLAT_TABLE_NC) {				\
+			/* Inner & outer non-cacheable non-shareable. */\
+			tcr = TCR_SH_NON_SHAREABLE |			\
+				TCR_RGN_OUTER_NC | TCR_RGN_INNER_NC |	\
+				(64 - __builtin_ctzl(PLAT_VIRT_ADDR_SPACE_SIZE));\
+		} else {						\
+			/* Inner & outer WBWA & shareable. */		\
+			tcr = TCR_SH_INNER_SHAREABLE |			\
+				TCR_RGN_OUTER_WBA | TCR_RGN_INNER_WBA |	\
+				(64 - __builtin_ctzl(PLAT_VIRT_ADDR_SPACE_SIZE));\
+		}							\
 		tcr |= _tcr_extra;					\
 		write_tcr_el##_el(tcr);					\
 									\

--- a/lib/xlat_tables_v2/aarch32/xlat_tables_arch.c
+++ b/lib/xlat_tables_v2/aarch32/xlat_tables_arch.c
@@ -122,13 +122,21 @@ void enable_mmu_internal_secure(unsigned int flags, uint64_t *base_table)
 	write_mair0(mair0);
 
 	/*
-	 * Set TTBCR bits as well. Set TTBR0 table properties as Inner
-	 * & outer WBWA & shareable. Disable TTBR1.
+	 * Set TTBCR bits as well. Set TTBR0 table properties. Disable TTBR1.
 	 */
-	ttbcr = TTBCR_EAE_BIT |
-		TTBCR_SH0_INNER_SHAREABLE | TTBCR_RGN0_OUTER_WBA |
-		TTBCR_RGN0_INNER_WBA |
-		(32 - __builtin_ctzl((uintptr_t)PLAT_VIRT_ADDR_SPACE_SIZE));
+	if (flags & XLAT_TABLE_NC) {
+		/* Inner & outer non-cacheable non-shareable. */
+		ttbcr = TTBCR_EAE_BIT |
+			TTBCR_SH0_NON_SHAREABLE | TTBCR_RGN0_OUTER_NC |
+			TTBCR_RGN0_INNER_NC |
+			(32 - __builtin_ctzl((uintptr_t)PLAT_VIRT_ADDR_SPACE_SIZE));
+	} else {
+		/* Inner & outer WBWA & shareable. */
+		ttbcr = TTBCR_EAE_BIT |
+			TTBCR_SH0_INNER_SHAREABLE | TTBCR_RGN0_OUTER_WBA |
+			TTBCR_RGN0_INNER_WBA |
+			(32 - __builtin_ctzl((uintptr_t)PLAT_VIRT_ADDR_SPACE_SIZE));
+	}
 	ttbcr |= TTBCR_EPD1_BIT;
 	write_ttbcr(ttbcr);
 

--- a/lib/xlat_tables_v2/aarch64/xlat_tables_arch.c
+++ b/lib/xlat_tables_v2/aarch64/xlat_tables_arch.c
@@ -201,11 +201,18 @@ void init_xlat_tables_arch(unsigned long long max_pa)
 		write_mair_el##_el(mair);				\
 									\
 		/* Set TCR bits as well. */				\
-		/* Inner & outer WBWA & shareable. */			\
 		/* Set T0SZ to (64 - width of virtual address space) */	\
-		tcr = TCR_SH_INNER_SHAREABLE | TCR_RGN_OUTER_WBA |	\
-			TCR_RGN_INNER_WBA |				\
-			(64 - __builtin_ctzl(PLAT_VIRT_ADDR_SPACE_SIZE));\
+		if (flags & XLAT_TABLE_NC) {				\
+			/* Inner & outer non-cacheable non-shareable. */\
+			tcr = TCR_SH_NON_SHAREABLE |			\
+				TCR_RGN_OUTER_NC | TCR_RGN_INNER_NC |	\
+				(64 - __builtin_ctzl(PLAT_VIRT_ADDR_SPACE_SIZE));\
+		} else {						\
+			/* Inner & outer WBWA & shareable. */		\
+			tcr = TCR_SH_INNER_SHAREABLE |			\
+				TCR_RGN_OUTER_WBA | TCR_RGN_INNER_WBA |	\
+				(64 - __builtin_ctzl(PLAT_VIRT_ADDR_SPACE_SIZE));\
+		}							\
 		tcr |= _tcr_extra;					\
 		write_tcr_el##_el(tcr);					\
 									\


### PR DESCRIPTION
This patch adds an additional flag `XLAT_TABLE_NC` which marks the
translation tables as Non-cacheable for MMU accesses.

Change-Id: I7c28ab87f0ce67da237fadc3627beb6792860fd4
Signed-off-by: Summer Qin <summer.qin@arm.com>