### PR TITLE
Fix ARM_BL31_IN_DRAM build

### DIFF
--- a/include/plat/arm/board/common/board_css_def.h
+++ b/include/plat/arm/board/common/board_css_def.h
@@ -33,6 +33,7 @@
 
 #include <common_def.h>
 #include <soc_css_def.h>
+#include <utils.h>
 #include <v2m_def.h>
 
 /*

--- a/include/plat/arm/common/arm_def.h
+++ b/include/plat/arm/common/arm_def.h
@@ -34,6 +34,7 @@
 #include <common_def.h>
 #include <platform_def.h>
 #include <tbbr_img_def.h>
+#include <utils.h>
 #include <xlat_tables_defs.h>
 
 

--- a/include/plat/arm/soc/common/soc_css_def.h
+++ b/include/plat/arm/soc/common/soc_css_def.h
@@ -32,6 +32,7 @@
 #define __SOC_CSS_DEF_H__
 
 #include <common_def.h>
+#include <utils.h>
 
 
 /*

--- a/plat/arm/board/fvp/include/platform_def.h
+++ b/plat/arm/board/fvp/include/platform_def.h
@@ -35,6 +35,7 @@
 #include <board_arm_def.h>
 #include <common_def.h>
 #include <tzc400.h>
+#include <utils.h>
 #include <v2m_def.h>
 #include "../fvp_def.h"
 


### PR DESCRIPTION
Some header files using the ULL() macro were not directly including
utils.h where the macro definition resides. As a consequence, a linker
script with values using this macro did not see the macro definition
and kept the "ULL(<value>)" call in the preprocessed file, which lead to
link error.

Files using ULL() macro now include utils.h directly.

Change-Id: I433a7f36bd21a156c20e69bc2a2bb406140ebdf9
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>