### PR TITLE
Build: add generic way to include SCP_BL2 into FIP image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,6 +341,11 @@ ifdef BL2_SOURCES
         endif
 endif
 
+# If SCP_BL2 is given, we always want FIP to include it.
+ifdef SCP_BL2
+        NEED_SCP_BL2		:=	yes
+endif
+
 # Process TBB related flags
 ifneq (${GENERATE_COT},0)
         # Common cert_create options
@@ -534,6 +539,10 @@ endif
 ifeq (${NEED_BL2},yes)
 $(if ${BL2}, $(eval $(call MAKE_TOOL_ARGS,2,${BL2},tb-fw)),\
 	$(eval $(call MAKE_BL,2,tb-fw)))
+endif
+
+ifeq (${NEED_SCP_BL2},yes)
+$(eval $(call FIP_ADD_IMG,SCP_BL2,--scp-fw))
 endif
 
 ifeq (${NEED_BL31},yes)

--- a/plat/arm/css/common/css_common.mk
+++ b/plat/arm/css/common/css_common.mk
@@ -64,7 +64,7 @@ $(eval $(call assert_boolean,CSS_LOAD_SCP_IMAGES))
 $(eval $(call add_define,CSS_LOAD_SCP_IMAGES))
 
 ifeq (${CSS_LOAD_SCP_IMAGES},1)
-  $(eval $(call FIP_ADD_IMG,SCP_BL2,--scp-fw))
+  NEED_SCP_BL2 := yes
   ifneq (${TRUSTED_BOARD_BOOT},0)
     $(eval $(call FWU_FIP_ADD_IMG,SCP_BL2U,--scp-fwu-cfg))
   endif


### PR DESCRIPTION
If SCP_BL2 is passed in from the command line, it is recognized by
make_helpers/tbbr/tbbr_tools.mk, and the cert_create tool generates
the corresponding key and content certificates.

On the other hand, the top-level Makefile does not care SCP_BL2, so
the --scp-fw option is not passed to the fiptool.  As far as I see
plat/arm/css/common/css_common.mk, it looks like a platform's job to
add $(eval $(call FIP_ADD_IMG,SCP_BL2,--scp-fw)).

We can make the top-level Makefile kind enough to take care of it.
This is useful when we want to have optional SCP_BL2 firmware.

Adjust css_common.mk so that Juno still requires SCP_BL2 by default.

Signed-off-by: Masahiro Yamada <yamada.masahiro@socionext.com>