### PR TITLE
Replace tf_printf occurrences with ERROR

### DIFF
--- a/drivers/arm/cci/cci.c
+++ b/drivers/arm/cci/cci.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -54,20 +54,19 @@ static int validate_cci_map(const int *map)
 			continue;
 
 		if (slave_if_id >= CCI_SLAVE_INTERFACE_COUNT) {
-			tf_printf("Slave interface ID is invalid\n");
+			ERROR("Slave interface ID is invalid\n");
 			return 0;
 		}
 
 		if (valid_cci_map & (1 << slave_if_id)) {
-			tf_printf("Multiple masters are assigned same"
-						" slave interface ID\n");
+			ERROR("Multiple masters are assigned same slave interface ID\n");
 			return 0;
 		}
 		valid_cci_map |= 1 << slave_if_id;
 	}
 
 	if (!valid_cci_map) {
-		tf_printf("No master is assigned a valid slave interface\n");
+		ERROR("No master is assigned a valid slave interface\n");
 		return 0;
 	}
 


### PR DESCRIPTION
The amount of console output is controlled by the LOG_LEVEL build
option. Using tf_printf without any #ifdef depending on the LOG_LEVEL
doesn't give the user that flexibility.

This patch replaces all occurrences of tf_printf that prints error, but
aren't dependent on LOG_LEVEL, with the ERROR macro.

Change-Id: Ib5147f14fc1579398a11f19ddd0e840ff6692831
Signed-off-by: Antonio Nino Diaz <antonio.ninodiaz@arm.com>