### PR TITLE
Tegra: memctrl_v1: enable 'xlat_table_v2' library

### DIFF
--- a/plat/nvidia/tegra/common/drivers/memctrl/memctrl_v1.c
+++ b/plat/nvidia/tegra/common/drivers/memctrl/memctrl_v1.c
@@ -37,7 +37,7 @@
 #include <string.h>
 #include <tegra_def.h>
 #include <utils.h>
-#include <xlat_tables.h>
+#include <xlat_tables_v2.h>
 
 #define TEGRA_GPU_RESET_REG_OFFSET	0x28c
 #define  GPU_RESET_BIT			(1 << 24)
@@ -135,17 +135,18 @@ static void tegra_clear_videomem(uintptr_t non_overlap_area_start,
 				 unsigned long long non_overlap_area_size)
 {
 	/*
-	 * Perform cache maintenance to ensure that the non-overlapping area is
-	 * zeroed out. The first invalidation of this range ensures that
-	 * possible evictions of dirty cache lines do not interfere with the
-	 * 'zeromem' operation. Other CPUs could speculatively prefetch the
-	 * main memory contents of this area between the first invalidation and
-	 * the 'zeromem' operation. The second invalidation ensures that any
-	 * such cache lines are removed as well.
+	 * Map the NS memory first, clean it and then unmap it.
 	 */
-	inv_dcache_range(non_overlap_area_start, non_overlap_area_size);
+	mmap_add_dynamic_region(non_overlap_area_start, /* PA */
+				non_overlap_area_start, /* VA */
+				non_overlap_area_size, /* size */
+				MT_NS | MT_RW | MT_EXECUTE_NEVER); /* attrs */
+
 	zeromem((void *)non_overlap_area_start, non_overlap_area_size);
-	inv_dcache_range(non_overlap_area_start, non_overlap_area_size);
+	flush_dcache_range(non_overlap_area_start, non_overlap_area_size);
+
+	mmap_remove_dynamic_region(non_overlap_area_start,
+		non_overlap_area_size);
 }
 
 /*
@@ -194,7 +195,6 @@ void tegra_memctrl_videomem_setup(uint64_t phys_base, uint32_t size_in_bytes)
 	 */
 	INFO("Cleaning previous Video Memory Carveout\n");
 
-	disable_mmu_el3();
 	if (phys_base > vmem_end_old || video_mem_base > vmem_end_new) {
 		tegra_clear_videomem(video_mem_base, video_mem_size << 20);
 	} else {
@@ -207,7 +207,6 @@ void tegra_memctrl_videomem_setup(uint64_t phys_base, uint32_t size_in_bytes)
 			tegra_clear_videomem(vmem_end_new, non_overlap_area_size);
 		}
 	}
-	enable_mmu_el3(0);
 
 done:
 	tegra_mc_write_32(MC_VIDEO_PROTECT_BASE_HI, (uint32_t)(phys_base >> 32));

--- a/plat/nvidia/tegra/common/tegra_common.mk
+++ b/plat/nvidia/tegra/common/tegra_common.mk
@@ -38,12 +38,15 @@ USE_COHERENT_MEM	:=	0
 
 SEPARATE_CODE_AND_RODATA :=	1
 
+PLAT_XLAT_TABLES_DYNAMIC :=	1
+$(eval $(call add_define,PLAT_XLAT_TABLES_DYNAMIC))
+
 PLAT_INCLUDES		:=	-Iplat/nvidia/tegra/include/drivers \
 				-Iplat/nvidia/tegra/include \
 				-Iplat/nvidia/tegra/include/${TARGET_SOC}
 
-PLAT_BL_COMMON_SOURCES	:=	lib/xlat_tables/xlat_tables_common.c		\
-				lib/xlat_tables/aarch64/xlat_tables.c
+include lib/xlat_tables_v2/xlat_tables.mk
+PLAT_BL_COMMON_SOURCES	+=	${XLAT_TABLES_LIB_SRCS}
 
 COMMON_DIR		:=	plat/nvidia/tegra/common
 

--- a/plat/nvidia/tegra/include/platform_def.h
+++ b/plat/nvidia/tegra/include/platform_def.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -77,7 +77,8 @@
 /*******************************************************************************
  * Platform specific page table and MMU setup constants
  ******************************************************************************/
-#define ADDR_SPACE_SIZE			(1ull << 35)
+#define PLAT_PHY_ADDR_SPACE_SIZE	(1ull << 35)
+#define PLAT_VIRT_ADDR_SPACE_SIZE	(1ull << 35)
 
 /*******************************************************************************
  * Some data must be aligned on the biggest cache line size in the platform.


### PR DESCRIPTION
This patch enables the 'xlat_table_v2' library for the Tegra Memory
Controller driver. This library allows us to dynamically map/unmap
memory regions, with MMU enabled.

The Memory Controller driver maps/unmaps non-overlapping Video Memory
region, to clean it of any secure contents, before it resizes the
region.

Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>