### PR TITLE
drivers: ti: uart: remove UART_FCR read-modify-write

### DIFF
--- a/drivers/ti/uart/aarch64/16550_console.S
+++ b/drivers/ti/uart/aarch64/16550_console.S
@@ -115,9 +115,6 @@ func console_core_putc
 	b.ne	1b
 	mov	w2, #0xD		/* '\r' */
 	str	w2, [x1, #UARTTX]
-	ldr	w2, [x1, #UARTFCR]
-	orr	w2, w2, #UARTFCR_TXCLR
-	str	w2, [x1, #UARTFCR]
 
 	/* Check if the transmit FIFO is full */
 2:	ldr	w2, [x1, #UARTLSR]
@@ -125,9 +122,6 @@ func console_core_putc
 	cmp	w2, #(UARTLSR_TEMT | UARTLSR_THRE)
 	b.ne	2b
 	str	w0, [x1, #UARTTX]
-	ldr	w2, [x1, #UARTFCR]
-	orr	w2, w2, #UARTFCR_TXCLR
-	str	w2, [x1, #UARTFCR]
 	ret
 putc_error:
 	mov	w0, #-1


### PR DESCRIPTION
UARTFCR is a write-only register and so a read-modify-write is not
applicable. This patch updates the programming sequence to remove this
logic and write to it directly from console_core_putc().

Signed-off-by: Vincent Zhang <xunz@nvidia.com>
Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>