### PR TITLE
Tegra186: Support AARCH32/64 encoding for MCE calls

### DIFF
--- a/plat/nvidia/tegra/common/tegra_sip_calls.c
+++ b/plat/nvidia/tegra/common/tegra_sip_calls.c
@@ -86,7 +86,7 @@ uint64_t tegra_sip_handler(uint32_t smc_fid,
 	/* Check if this is a SoC specific SiP */
 	err = plat_sip_handler(smc_fid, x1, x2, x3, x4, cookie, handle, flags);
 	if (err == 0)
-		SMC_RET1(handle, err);
+		SMC_RET1(handle, (uint64_t)err);
 
 	switch (smc_fid) {
 

--- a/plat/nvidia/tegra/soc/t186/plat_sip_calls.c
+++ b/plat/nvidia/tegra/soc/t186/plat_sip_calls.c
@@ -52,27 +52,27 @@ extern uint32_t tegra186_system_powerdn_state;
 /*******************************************************************************
  * Tegra186 SiP SMCs
  ******************************************************************************/
-#define TEGRA_SIP_SYSTEM_SHUTDOWN_STATE			0x82FFFE01
-#define TEGRA_SIP_GET_ACTMON_CLK_COUNTERS		0x82FFFE02
-#define TEGRA_SIP_MCE_CMD_ENTER_CSTATE			0x82FFFF00
-#define TEGRA_SIP_MCE_CMD_UPDATE_CSTATE_INFO		0x82FFFF01
-#define TEGRA_SIP_MCE_CMD_UPDATE_CROSSOVER_TIME		0x82FFFF02
-#define TEGRA_SIP_MCE_CMD_READ_CSTATE_STATS		0x82FFFF03
-#define TEGRA_SIP_MCE_CMD_WRITE_CSTATE_STATS		0x82FFFF04
-#define TEGRA_SIP_MCE_CMD_IS_SC7_ALLOWED		0x82FFFF05
-#define TEGRA_SIP_MCE_CMD_ONLINE_CORE			0x82FFFF06
-#define TEGRA_SIP_MCE_CMD_CC3_CTRL			0x82FFFF07
-#define TEGRA_SIP_MCE_CMD_ECHO_DATA			0x82FFFF08
-#define TEGRA_SIP_MCE_CMD_READ_VERSIONS			0x82FFFF09
-#define TEGRA_SIP_MCE_CMD_ENUM_FEATURES			0x82FFFF0A
-#define TEGRA_SIP_MCE_CMD_ROC_FLUSH_CACHE_TRBITS	0x82FFFF0B
-#define TEGRA_SIP_MCE_CMD_ENUM_READ_MCA			0x82FFFF0C
-#define TEGRA_SIP_MCE_CMD_ENUM_WRITE_MCA		0x82FFFF0D
-#define TEGRA_SIP_MCE_CMD_ROC_FLUSH_CACHE		0x82FFFF0E
-#define TEGRA_SIP_MCE_CMD_ROC_CLEAN_CACHE		0x82FFFF0F
-#define TEGRA_SIP_MCE_CMD_ENABLE_LATIC			0x82FFFF10
-#define TEGRA_SIP_MCE_CMD_UNCORE_PERFMON_REQ		0x82FFFF11
-#define TEGRA_SIP_MCE_CMD_MISC_CCPLEX			0x82FFFF12
+#define TEGRA_SIP_SYSTEM_SHUTDOWN_STATE			0xC2FFFE01
+#define TEGRA_SIP_GET_ACTMON_CLK_COUNTERS		0xC2FFFE02
+#define TEGRA_SIP_MCE_CMD_ENTER_CSTATE			0xC2FFFF00
+#define TEGRA_SIP_MCE_CMD_UPDATE_CSTATE_INFO		0xC2FFFF01
+#define TEGRA_SIP_MCE_CMD_UPDATE_CROSSOVER_TIME		0xC2FFFF02
+#define TEGRA_SIP_MCE_CMD_READ_CSTATE_STATS		0xC2FFFF03
+#define TEGRA_SIP_MCE_CMD_WRITE_CSTATE_STATS		0xC2FFFF04
+#define TEGRA_SIP_MCE_CMD_IS_SC7_ALLOWED		0xC2FFFF05
+#define TEGRA_SIP_MCE_CMD_ONLINE_CORE			0xC2FFFF06
+#define TEGRA_SIP_MCE_CMD_CC3_CTRL			0xC2FFFF07
+#define TEGRA_SIP_MCE_CMD_ECHO_DATA			0xC2FFFF08
+#define TEGRA_SIP_MCE_CMD_READ_VERSIONS			0xC2FFFF09
+#define TEGRA_SIP_MCE_CMD_ENUM_FEATURES			0xC2FFFF0A
+#define TEGRA_SIP_MCE_CMD_ROC_FLUSH_CACHE_TRBITS	0xC2FFFF0B
+#define TEGRA_SIP_MCE_CMD_ENUM_READ_MCA			0xC2FFFF0C
+#define TEGRA_SIP_MCE_CMD_ENUM_WRITE_MCA		0xC2FFFF0D
+#define TEGRA_SIP_MCE_CMD_ROC_FLUSH_CACHE		0xC2FFFF0E
+#define TEGRA_SIP_MCE_CMD_ROC_CLEAN_CACHE		0xC2FFFF0F
+#define TEGRA_SIP_MCE_CMD_ENABLE_LATIC			0xC2FFFF10
+#define TEGRA_SIP_MCE_CMD_UNCORE_PERFMON_REQ		0xC2FFFF11
+#define TEGRA_SIP_MCE_CMD_MISC_CCPLEX			0xC2FFFF12
 
 /*******************************************************************************
  * This function is responsible for handling all T186 SiP calls
@@ -90,8 +90,20 @@ int plat_sip_handler(uint32_t smc_fid,
 	int impl, cpu;
 	uint32_t base, core_clk_ctr, ref_clk_ctr;
 
-	switch (smc_fid) {
+	if (((smc_fid >> FUNCID_CC_SHIFT) & FUNCID_CC_MASK) == SMC_32) {
+		/* 32-bit function, clear top parameter bits */
 
+		x1 = (uint32_t)x1;
+		x2 = (uint32_t)x2;
+		x3 = (uint32_t)x3;
+	}
+
+	/*
+	 * Convert SMC FID to SMC64, to support SMC32/SMC64 configurations
+	 */
+	smc_fid |= (SMC_64 << FUNCID_CC_SHIFT);
+
+	switch (smc_fid) {
 	/*
 	 * Micro Coded Engine (MCE) commands reside in the 0x82FFFF00 -
 	 * 0x82FFFFFF SiP SMC space
@@ -120,7 +132,8 @@ int plat_sip_handler(uint32_t smc_fid,
 
 		/* execute the command and store the result */
 		mce_ret = mce_command_handler(smc_fid, x1, x2, x3);
-		write_ctx_reg(get_gpregs_ctx(handle), CTX_GPREG_X0, mce_ret);
+		write_ctx_reg(get_gpregs_ctx(handle), CTX_GPREG_X0,
+			      (uint64_t)mce_ret);
 
 		return 0;
 
@@ -176,8 +189,10 @@ int plat_sip_handler(uint32_t smc_fid,
 		ref_clk_ctr = mmio_read_32(base + (8 * cpu) + REF_CLK_OFFSET);
 
 		/* return the counter values as two different parameters */
-		write_ctx_reg(get_gpregs_ctx(handle), CTX_GPREG_X1, core_clk_ctr);
-		write_ctx_reg(get_gpregs_ctx(handle), CTX_GPREG_X2, ref_clk_ctr);
+		write_ctx_reg(get_gpregs_ctx(handle), CTX_GPREG_X1,
+			      (uint64_t)core_clk_ctr);
+		write_ctx_reg(get_gpregs_ctx(handle), CTX_GPREG_X2,
+			      (uint64_t)ref_clk_ctr);
 
 		return 0;
 


### PR DESCRIPTION
On Tegra systems, there are multiple software components that
require to interact with MCE. The components can either be 32-bit
or 64-bit payloads. This patch supports MCE SMC functions ID for
AARCH32 and AARCH64 architectures to support such clients.

Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>