### PR TITLE
ARM platforms: Add option to use xlat tables lib v1

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -568,6 +568,10 @@ performed.
     -   `tdram` : Trusted DRAM (if available)
     -   `dram`  : Secure region in DRAM (configured by the TrustZone controller)
 
+*   `ARM_XLAT_TABLES_LIB_V1`: boolean option to compile the Trusted Firmware
+    with version 1 of the translation tables library instead of version 2. It is
+    set to 0 by default, which selects version 2.
+
 For a better understanding of these options, the ARM development platform memory
 map is explained in the [Firmware Design].
 

--- a/include/plat/arm/board/common/v2m_def.h
+++ b/include/plat/arm/board/common/v2m_def.h
@@ -30,7 +30,7 @@
 #ifndef __V2M_DEF_H__
 #define __V2M_DEF_H__
 
-#include <xlat_tables_v2.h>
+#include <arm_xlat_tables.h>
 
 
 /* V2M motherboard system registers & offsets */

--- a/include/plat/arm/common/arm_xlat_tables.h
+++ b/include/plat/arm/common/arm_xlat_tables.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * Neither the name of ARM nor the names of its contributors may be used
+ * to endorse or promote products derived from this software without specific
+ * prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if ARM_XLAT_TABLES_LIB_V1
+#include <xlat_tables.h>
+#else
+#include <xlat_tables_v2.h>
+#endif /* ARM_XLAT_TABLES_LIB_V1 */

--- a/include/plat/arm/common/plat_arm.h
+++ b/include/plat/arm/common/plat_arm.h
@@ -30,12 +30,12 @@
 #ifndef __PLAT_ARM_H__
 #define __PLAT_ARM_H__
 
+#include <arm_xlat_tables.h>
 #include <bakery_lock.h>
 #include <cassert.h>
 #include <cpu_data.h>
 #include <stdint.h>
 #include <utils.h>
-#include <xlat_tables_v2.h>
 
 /*******************************************************************************
  * Forward declarations

--- a/plat/arm/common/arm_bl1_setup.c
+++ b/plat/arm/common/arm_bl1_setup.c
@@ -30,13 +30,13 @@
 
 #include <arch.h>
 #include <arm_def.h>
+#include <arm_xlat_tables.h>
 #include <bl_common.h>
 #include <console.h>
 #include <platform_def.h>
 #include <plat_arm.h>
 #include <sp805.h>
 #include <utils.h>
-#include <xlat_tables_v2.h>
 #include "../../../bl1/bl1_private.h"
 
 /* Weak definitions may be overridden in specific ARM standard platform */

--- a/plat/arm/common/arm_common.c
+++ b/plat/arm/common/arm_common.c
@@ -29,12 +29,12 @@
  */
 #include <arch.h>
 #include <arch_helpers.h>
+#include <arm_xlat_tables.h>
 #include <assert.h>
 #include <debug.h>
 #include <mmio.h>
 #include <plat_arm.h>
 #include <platform_def.h>
-#include <xlat_tables_v2.h>
 
 extern const mmap_region_t plat_arm_mmap[];
 

--- a/plat/arm/common/arm_common.mk
+++ b/plat/arm/common/arm_common.mk
@@ -95,6 +95,11 @@ ARM_PLAT_MT			:=	0
 $(eval $(call assert_boolean,ARM_PLAT_MT))
 $(eval $(call add_define,ARM_PLAT_MT))
 
+# Use translation tables library v2 by default
+ARM_XLAT_TABLES_LIB_V1		:=	0
+$(eval $(call assert_boolean,ARM_XLAT_TABLES_LIB_V1))
+$(eval $(call add_define,ARM_XLAT_TABLES_LIB_V1))
+
 # Enable PSCI_STAT_COUNT/RESIDENCY APIs on ARM platforms
 ENABLE_PSCI_STAT		:=	1
 ENABLE_PMF			:=	1
@@ -113,11 +118,17 @@ ifeq (${ARCH}, aarch64)
 PLAT_INCLUDES		+=	-Iinclude/plat/arm/common/aarch64
 endif
 
+PLAT_BL_COMMON_SOURCES	+=	plat/arm/common/${ARCH}/arm_helpers.S		\
+				plat/arm/common/arm_common.c
+
+ifeq (${ARM_XLAT_TABLES_LIB_V1}, 1)
+PLAT_BL_COMMON_SOURCES	+=	lib/xlat_tables/xlat_tables_common.c		\
+				lib/xlat_tables/${ARCH}/xlat_tables.c
+else
 include lib/xlat_tables_v2/xlat_tables.mk
 
-PLAT_BL_COMMON_SOURCES	+=	${XLAT_TABLES_LIB_SRCS}				\
-				plat/arm/common/${ARCH}/arm_helpers.S		\
-				plat/arm/common/arm_common.c
+PLAT_BL_COMMON_SOURCES	+=	${XLAT_TABLES_LIB_SRCS}
+endif
 
 BL1_SOURCES		+=	drivers/arm/sp805/sp805.c			\
 				drivers/io/io_fip.c				\


### PR DESCRIPTION
ARM platforms have migrated to the translation tables library v2.
However, for testing purposes, it can be useful to temporarily switch
back to the old version.

This patch introduces the option `ARM_XLAT_TABLES_LIB_V1`, that switches
to v1 of the library when is set to 1. By default, it is 0, so that ARM
platforms use the new version unless specifically stated.

Updated User Guide.

Change-Id: I53d3c8dd97706f6af9c6fca0364a88ef341efd31
Signed-off-by: Antonio Nino Diaz <antonio.ninodiaz@arm.com>