### PR TITLE
Add `ENABLE_ASSERTIONS` build option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,9 @@ include ${MAKE_HELPERS_DIRECTORY}build_env.mk
 
 include ${MAKE_HELPERS_DIRECTORY}defaults.mk
 
-# ASM_ASSERTION enabled for DEBUG builds only
+# Assertions enabled for DEBUG builds by default
 ASM_ASSERTION			:= ${DEBUG}
+ENABLE_ASSERTIONS		:= ${DEBUG}
 ENABLE_PMF			:= ${ENABLE_RUNTIME_INSTRUMENTATION}
 PLAT				:= ${DEFAULT_PLAT}
 
@@ -446,6 +447,7 @@ $(eval $(call assert_boolean,CTX_INCLUDE_AARCH32_REGS))
 $(eval $(call assert_boolean,CTX_INCLUDE_FPREGS))
 $(eval $(call assert_boolean,DEBUG))
 $(eval $(call assert_boolean,DISABLE_PEDANTIC))
+$(eval $(call assert_boolean,ENABLE_ASSERTIONS))
 $(eval $(call assert_boolean,ENABLE_PLAT_COMPAT))
 $(eval $(call assert_boolean,ENABLE_PMF))
 $(eval $(call assert_boolean,ENABLE_PSCI_STAT))
@@ -482,6 +484,7 @@ $(eval $(call add_define,ASM_ASSERTION))
 $(eval $(call add_define,COLD_BOOT_SINGLE_CPU))
 $(eval $(call add_define,CTX_INCLUDE_AARCH32_REGS))
 $(eval $(call add_define,CTX_INCLUDE_FPREGS))
+$(eval $(call add_define,ENABLE_ASSERTIONS))
 $(eval $(call add_define,ENABLE_PLAT_COMPAT))
 $(eval $(call add_define,ENABLE_PMF))
 $(eval $(call add_define,ENABLE_PSCI_STAT))

--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,13 @@ include ${MAKE_HELPERS_DIRECTORY}build_env.mk
 # Default values for build configurations, and their dependencies
 ################################################################################
 
+ifdef ASM_ASSERTION
+        $(warning ASM_ASSERTION is removed, use ENABLE_ASSERTIONS instead.)
+endif
+
 include ${MAKE_HELPERS_DIRECTORY}defaults.mk
 
 # Assertions enabled for DEBUG builds by default
-ASM_ASSERTION			:= ${DEBUG}
 ENABLE_ASSERTIONS		:= ${DEBUG}
 ENABLE_PMF			:= ${ENABLE_RUNTIME_INSTRUMENTATION}
 PLAT				:= ${DEFAULT_PLAT}
@@ -440,7 +443,6 @@ endif
 # Build options checks
 ################################################################################
 
-$(eval $(call assert_boolean,ASM_ASSERTION))
 $(eval $(call assert_boolean,COLD_BOOT_SINGLE_CPU))
 $(eval $(call assert_boolean,CREATE_KEYS))
 $(eval $(call assert_boolean,CTX_INCLUDE_AARCH32_REGS))
@@ -480,7 +482,6 @@ $(eval $(call add_define,ARM_CCI_PRODUCT_ID))
 $(eval $(call add_define,ARM_ARCH_MAJOR))
 $(eval $(call add_define,ARM_ARCH_MINOR))
 $(eval $(call add_define,ARM_GIC_ARCH))
-$(eval $(call add_define,ASM_ASSERTION))
 $(eval $(call add_define,COLD_BOOT_SINGLE_CPU))
 $(eval $(call add_define,CTX_INCLUDE_AARCH32_REGS))
 $(eval $(call add_define,CTX_INCLUDE_FPREGS))

--- a/bl1/bl1_main.c
+++ b/bl1/bl1_main.c
@@ -114,7 +114,7 @@ void bl1_main(void)
 
 	print_errata_status();
 
-#if DEBUG
+#if ENABLE_ASSERTIONS
 	u_register_t val;
 	/*
 	 * Ensure that MMU/Caches and coherency are turned on
@@ -141,7 +141,7 @@ void bl1_main(void)
 		assert(CACHE_WRITEBACK_GRANULE == SIZE_FROM_LOG2_WORDS(val));
 	else
 		assert(CACHE_WRITEBACK_GRANULE <= MAX_CACHE_LINE_SIZE);
-#endif
+#endif /* ENABLE_ASSERTIONS */
 
 	/* Perform remaining generic architectural setup from EL3 */
 	bl1_arch_setup();

--- a/common/aarch32/debug.S
+++ b/common/aarch32/debug.S
@@ -107,6 +107,11 @@ assert_msg2:
  * ---------------------------------------------------------------------------
  */
 func asm_assert
+#if LOG_LEVEL >= LOG_LEVEL_INFO
+	/*
+	 * Only print the output if LOG_LEVEL is higher or equal to
+	 * LOG_LEVEL_INFO, which is the default value for builds with DEBUG=1.
+	 */
 	/* Stash the parameters already in r0 and r1 */
 	mov	r5, r0
 	mov	r6, r1
@@ -147,6 +152,7 @@ dec_print_loop:
 	bl	plat_crash_console_flush
 
 1:
+#endif /* LOG_LEVEL >= LOG_LEVEL_INFO */
 	no_ret	plat_panic_handler
 endfunc asm_assert
 #endif

--- a/common/aarch32/debug.S
+++ b/common/aarch32/debug.S
@@ -90,7 +90,7 @@ func report_exception
 	no_ret	plat_panic_handler
 endfunc report_exception
 
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 .section .rodata.assert_str, "aS"
 assert_msg1:
 	.asciz "ASSERT: File "
@@ -155,7 +155,7 @@ dec_print_loop:
 #endif /* LOG_LEVEL >= LOG_LEVEL_INFO */
 	no_ret	plat_panic_handler
 endfunc asm_assert
-#endif
+#endif /* ENABLE_ASSERTIONS */
 
 /*
  * This function prints a string from address in r4

--- a/common/aarch64/debug.S
+++ b/common/aarch64/debug.S
@@ -41,7 +41,7 @@
 /* The offset to add to get ascii for numerals '0 - 9' */
 #define ASCII_OFFSET_NUM	0x30
 
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 .section .rodata.assert_str, "aS"
 assert_msg1:
 	.asciz "ASSERT: File "
@@ -106,7 +106,7 @@ _assert_loop:
 #endif /* LOG_LEVEL >= LOG_LEVEL_INFO */
 	no_ret	plat_panic_handler
 endfunc asm_assert
-#endif
+#endif /* ENABLE_ASSERTIONS */
 
 /*
  * This function prints a string from address in x4.

--- a/common/aarch64/debug.S
+++ b/common/aarch64/debug.S
@@ -78,6 +78,11 @@ dec_print_loop:
  * ---------------------------------------------------------------------------
  */
 func asm_assert
+#if LOG_LEVEL >= LOG_LEVEL_INFO
+	/*
+	 * Only print the output if LOG_LEVEL is higher or equal to
+	 * LOG_LEVEL_INFO, which is the default value for builds with DEBUG=1.
+	 */
 	mov	x5, x0
 	mov	x6, x1
 	/* Ensure the console is initialized */
@@ -98,6 +103,7 @@ func asm_assert
 	asm_print_line_dec
 	bl	plat_crash_console_flush
 _assert_loop:
+#endif /* LOG_LEVEL >= LOG_LEVEL_INFO */
 	no_ret	plat_panic_handler
 endfunc asm_assert
 #endif

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -203,11 +203,6 @@ performed.
     in MPIDR is set and access the bit-fields in MPIDR accordingly. Default
     value of this flag is 0.
 
-*   `ASM_ASSERTION`: This flag determines whether the assertion checks within
-    assembly source files are enabled or not. This option defaults to the
-    value of `DEBUG` - that is, by default this is only enabled for a debug
-    build of the firmware.
-
 *   `BL2`: This is an optional build option which specifies the path to BL2
     image for the `fip` target. In this case, the BL2 in the ARM Trusted
     Firmware will not be built.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -286,6 +286,14 @@ performed.
     payload. Please refer to the "Booting an EL3 payload" section for more
     details.
 
+*   `ENABLE_ASSERTIONS`: This option controls whether or not calls to `assert()`
+    are compiled out. For debug builds, this option defaults to 1, and calls to
+    `assert()` are left in place. For release builds, this option defaults to 0
+    and calls to `assert()` function are compiled out. This option can be set
+    independently of `DEBUG`. It can also be used to hide any auxiliary code
+    that is only required for the assertion and does not fit in the assertion
+    itself.
+
 *   `ENABLE_PMF`: Boolean option to enable support for optional Performance
      Measurement Framework(PMF). Default is 0.
 

--- a/drivers/arm/cci/cci.c
+++ b/drivers/arm/cci/cci.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -39,7 +39,7 @@ static uintptr_t g_cci_base;
 static unsigned int g_max_master_id;
 static const int *g_cci_slave_if_map;
 
-#if DEBUG
+#if ENABLE_ASSERTIONS
 static int validate_cci_map(const int *map)
 {
 	unsigned int valid_cci_map = 0;
@@ -73,7 +73,7 @@ static int validate_cci_map(const int *map)
 
 	return 1;
 }
-#endif /* DEBUG */
+#endif /* ENABLE_ASSERTIONS */
 
 void cci_init(uintptr_t cci_base,
 		const int *map,

--- a/drivers/arm/ccn/ccn.c
+++ b/drivers/arm/ccn/ccn.c
@@ -81,7 +81,7 @@ static inline void ccn_reg_write(uintptr_t periphbase,
 	mmio_write_64(region_base + register_offset, value);
 }
 
-#if DEBUG
+#if ENABLE_ASSERTIONS
 
 typedef struct rn_info {
 		unsigned char node_desc[MAX_RN_NODES];
@@ -224,7 +224,7 @@ static void ccn_validate_plat_params(const ccn_desc_t *plat_desc)
 		info.node_desc[node_id]--;
 	}
 }
-#endif /* DEBUG */
+#endif /* ENABLE_ASSERTIONS */
 
 /*******************************************************************************
  * This function validates parameters passed by the platform (in a debug build)
@@ -234,7 +234,7 @@ static void ccn_validate_plat_params(const ccn_desc_t *plat_desc)
  ******************************************************************************/
 void ccn_init(const ccn_desc_t *plat_desc)
 {
-#if DEBUG
+#if ENABLE_ASSERTIONS
 	ccn_validate_plat_params(plat_desc);
 #endif
 

--- a/drivers/arm/tzc/tzc400.c
+++ b/drivers/arm/tzc/tzc400.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -33,7 +33,7 @@
 #include <mmio.h>
 #include <stddef.h>
 #include <tzc400.h>
-#include "tzc_common_private.c"
+#include "tzc_common_private.h"
 
 /*
  * Macros which will be used by common core functions.

--- a/drivers/arm/tzc/tzc_common_private.h
+++ b/drivers/arm/tzc/tzc_common_private.h
@@ -193,7 +193,8 @@
 						nsaid_permissions);	\
 	}
 
-#if DEBUG
+#if ENABLE_ASSERTIONS
+
 static inline unsigned int _tzc_read_peripheral_id(uintptr_t base)
 {
 	unsigned int id;
@@ -235,6 +236,6 @@ static inline unsigned long long _tzc_get_max_top_addr(int addr_width)
 	(UINT64_MAX >> (64 - (addr_width)))
 #endif /* AARCH32 */
 
-#endif
+#endif /* ENABLE_ASSERTIONS */
 
 #endif /* __TZC_COMMON_PRIVATE_H__ */

--- a/drivers/arm/tzc/tzc_common_private.h
+++ b/drivers/arm/tzc/tzc_common_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -27,6 +27,9 @@
  * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
  * POSSIBILITY OF SUCH DAMAGE.
  */
+
+#ifndef __TZC_COMMON_PRIVATE_H__
+#define __TZC_COMMON_PRIVATE_H__
 
 #include <arch.h>
 #include <arch_helpers.h>
@@ -191,7 +194,7 @@
 	}
 
 #if DEBUG
-static unsigned int _tzc_read_peripheral_id(uintptr_t base)
+static inline unsigned int _tzc_read_peripheral_id(uintptr_t base)
 {
 	unsigned int id;
 
@@ -203,7 +206,7 @@ static unsigned int _tzc_read_peripheral_id(uintptr_t base)
 }
 
 #ifdef AARCH32
-static unsigned long long _tzc_get_max_top_addr(int addr_width)
+static inline unsigned long long _tzc_get_max_top_addr(int addr_width)
 {
 	/*
 	 * Assume at least 32 bit wide address and initialize the max.
@@ -233,3 +236,5 @@ static unsigned long long _tzc_get_max_top_addr(int addr_width)
 #endif /* AARCH32 */
 
 #endif
+
+#endif /* __TZC_COMMON_PRIVATE_H__ */

--- a/drivers/arm/tzc/tzc_dmc500.c
+++ b/drivers/arm/tzc/tzc_dmc500.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -33,7 +33,7 @@
 #include <mmio.h>
 #include <tzc_dmc500.h>
 #include "tzc_common.h"
-#include "tzc_common_private.c"
+#include "tzc_common_private.h"
 
 /*
  * Macros which will be used by common core functions.

--- a/drivers/arm/tzc/tzc_dmc500.c
+++ b/drivers/arm/tzc/tzc_dmc500.c
@@ -257,7 +257,7 @@ void tzc_dmc500_set_action(tzc_action_t action)
 static void validate_plat_driver_data(
 			const tzc_dmc500_driver_data_t *plat_driver_data)
 {
-#if DEBUG
+#if ENABLE_ASSERTIONS
 	int i;
 	unsigned int dmc_id;
 	uintptr_t dmc_base;
@@ -273,7 +273,7 @@ static void validate_plat_driver_data(
 		dmc_id = _tzc_read_peripheral_id(dmc_base);
 		assert(dmc_id == DMC500_PERIPHERAL_ID);
 	}
-#endif /* DEBUG */
+#endif /* ENABLE_ASSERTIONS */
 }
 
 

--- a/drivers/io/io_storage.c
+++ b/drivers/io/io_storage.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -51,8 +51,8 @@ static const io_dev_info_t *devices[MAX_IO_DEVICES];
 /* Number of currently registered devices */
 static unsigned int dev_count;
 
-
-#if DEBUG	/* Extra validation functions only used in debug builds */
+/* Extra validation functions only used when asserts are enabled */
+#if ENABLE_ASSERTIONS
 
 /* Return a boolean value indicating whether a device connector is valid */
 static int is_valid_dev_connector(const io_dev_connector_t *dev_con)
@@ -89,7 +89,8 @@ static int is_valid_seek_mode(io_seek_mode_t mode)
 	return ((mode != IO_SEEK_INVALID) && (mode < IO_SEEK_MAX));
 }
 
-#endif	/* End of debug-only validation functions */
+#endif /* ENABLE_ASSERTIONS */
+/* End of extra validation functions only used when asserts are enabled */
 
 
 /* Open a connection to a specific device */

--- a/include/common/aarch32/el3_common_macros.S
+++ b/include/common/aarch32/el3_common_macros.S
@@ -148,7 +148,7 @@
 		_init_memory, _init_c_runtime, _exception_vectors
 
 	/* Make sure we are in Secure Mode */
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	ldcopr	r0, SCR
 	tst	r0, #SCR_NS_BIT
 	ASM_ASSERT(eq)

--- a/include/lib/el3_runtime/context_mgmt.h
+++ b/include/lib/el3_runtime/context_mgmt.h
@@ -87,7 +87,7 @@ void cm_set_context_by_mpidr(uint64_t mpidr,
  ******************************************************************************/
 static inline void cm_set_next_context(void *context)
 {
-#if DEBUG
+#if ENABLE_ASSERTIONS
 	uint64_t sp_mode;
 
 	/*
@@ -98,7 +98,7 @@ static inline void cm_set_next_context(void *context)
 			 : "=r" (sp_mode));
 
 	assert(sp_mode == MODE_SP_EL0);
-#endif
+#endif /* ENABLE_ASSERTIONS */
 
 	__asm__ volatile("msr	spsel, #1\n"
 			 "mov	sp, %0\n"

--- a/include/lib/stdlib/assert.h
+++ b/include/lib/stdlib/assert.h
@@ -34,30 +34,27 @@
  *	@(#)assert.h	8.2 (Berkeley) 1/21/94
  * $FreeBSD$
  */
-
-#include <sys/cdefs.h>
-
 /*
- * Unlike other ANSI header files, <assert.h> may usefully be included
- * multiple times, with and without NDEBUG defined.
+ * Portions copyright (c) 2017, ARM Limited and Contributors.
+ * All rights reserved.
  */
-
-#undef assert
-#undef _assert
-
-#ifdef NDEBUG
-#define	assert(e)	((void)0)
-#define	_assert(e)	((void)0)
-#else
-#define	_assert(e)	assert(e)
-
-#define	assert(e)	((e) ? (void)0 : __assert(__func__, __FILE__, \
-			    __LINE__, #e))
-#endif /* NDEBUG */
 
 #ifndef _ASSERT_H_
 #define _ASSERT_H_
+
+#include <sys/cdefs.h>
+
+#if ENABLE_ASSERTIONS
+#define	_assert(e)	assert(e)
+#define	assert(e)	((e) ? (void)0 : __assert(__func__, __FILE__, \
+			    __LINE__, #e))
+#else
+#define	assert(e)	((void)0)
+#define	_assert(e)	((void)0)
+#endif /* ENABLE_ASSERTIONS */
+
 __BEGIN_DECLS
 void __assert(const char *, const char *, int, const char *) __dead2;
 __END_DECLS
+
 #endif /* !_ASSERT_H_ */

--- a/lib/aarch32/misc_helpers.S
+++ b/lib/aarch32/misc_helpers.S
@@ -162,7 +162,7 @@ endfunc zeromem
  * --------------------------------------------------------------------------
  */
 func memcpy4
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	orr	r3, r0, r1
 	tst	r3, #0x3
 	ASM_ASSERT(eq)

--- a/lib/aarch64/misc_helpers.S
+++ b/lib/aarch64/misc_helpers.S
@@ -215,7 +215,7 @@ func zeromem_dczva
 	tmp1         .req x4
 	tmp2         .req x5
 
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	/*
 	 * Check for M bit (MMU enabled) of the current SCTLR_EL(1|3)
 	 * register value and panic if the MMU is disabled.
@@ -228,7 +228,7 @@ func zeromem_dczva
 
 	tst	tmp1, #SCTLR_M_BIT
 	ASM_ASSERT(ne)
-#endif /* ASM_ASSERTION */
+#endif /* ENABLE_ASSERTIONS */
 
 	/* stop_address is the address past the last to zero */
 	add	stop_address, cursor, length
@@ -247,7 +247,7 @@ func zeromem_dczva
 	mov	tmp2, #(1 << 2)
 	lsl	block_size, tmp2, block_size
 
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	/*
 	 * Assumes block size is at least 16 bytes to avoid manual realignment
 	 * of the cursor at the end of the DCZVA loop.
@@ -444,7 +444,7 @@ endfunc zeromem_dczva
  * --------------------------------------------------------------------------
  */
 func memcpy16
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	orr	x3, x0, x1
 	tst	x3, #0xf
 	ASM_ASSERT(eq)

--- a/lib/cpus/aarch32/aem_generic.S
+++ b/lib/cpus/aarch32/aem_generic.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -35,7 +35,7 @@
 
 func aem_generic_core_pwr_dwn
 	/* Assert if cache is enabled */
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	ldcopr	r0, SCTLR
 	tst	r0, #SCTLR_C_BIT
 	ASM_ASSERT(eq)
@@ -51,7 +51,7 @@ endfunc aem_generic_core_pwr_dwn
 
 func aem_generic_cluster_pwr_dwn
 	/* Assert if cache is enabled */
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	ldcopr	r0, SCTLR
 	tst	r0, #SCTLR_C_BIT
 	ASM_ASSERT(eq)

--- a/lib/cpus/aarch32/cortex_a32.S
+++ b/lib/cpus/aarch32/cortex_a32.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -76,7 +76,7 @@ func cortex_a32_core_pwr_dwn
 	push	{r12, lr}
 
 	/* Assert if cache is enabled */
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	ldcopr	r0, SCTLR
 	tst	r0, #SCTLR_C_BIT
 	ASM_ASSERT(eq)
@@ -107,7 +107,7 @@ func cortex_a32_cluster_pwr_dwn
 	push	{r12, lr}
 
 	/* Assert if cache is enabled */
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	ldcopr	r0, SCTLR
 	tst	r0, #SCTLR_C_BIT
 	ASM_ASSERT(eq)

--- a/lib/cpus/aarch32/cpu_helpers.S
+++ b/lib/cpus/aarch32/cpu_helpers.S
@@ -53,7 +53,7 @@ func reset_handler
 	/* Get the matching cpu_ops pointer (clobbers: r0 - r5) */
 	bl	get_cpu_ops_ptr
 
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	cmp	r0, #0
 	ASM_ASSERT(ne)
 #endif
@@ -92,7 +92,7 @@ func prepare_cpu_pwr_dwn
 	pop	{r2, lr}
 
 	ldr	r0, [r0, #CPU_DATA_CPU_OPS_PTR]
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	cmp	r0, #0
 	ASM_ASSERT(ne)
 #endif
@@ -118,7 +118,7 @@ func init_cpu_ops
 	cmp	r1, #0
 	bne	1f
 	bl	get_cpu_ops_ptr
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	cmp	r0, #0
 	ASM_ASSERT(ne)
 #endif

--- a/lib/cpus/aarch64/cpu_helpers.S
+++ b/lib/cpus/aarch64/cpu_helpers.S
@@ -55,7 +55,7 @@ func reset_handler
 
 	/* Get the matching cpu_ops pointer */
 	bl	get_cpu_ops_ptr
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	cmp	x0, #0
 	ASM_ASSERT(ne)
 #endif
@@ -94,7 +94,7 @@ func prepare_cpu_pwr_dwn
 
 	mrs	x1, tpidr_el3
 	ldr	x0, [x1, #CPU_DATA_CPU_OPS_PTR]
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	cmp	x0, #0
 	ASM_ASSERT(ne)
 #endif
@@ -120,7 +120,7 @@ func init_cpu_ops
 	cbnz	x0, 1f
 	mov	x10, x30
 	bl	get_cpu_ops_ptr
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	cmp	x0, #0
 	ASM_ASSERT(ne)
 #endif

--- a/lib/stdlib/assert.c
+++ b/lib/stdlib/assert.c
@@ -32,15 +32,18 @@
 #include <debug.h>
 #include <platform.h>
 
-/*
- * This is a basic implementation. This could be improved.
- */
-void __assert (const char *function, const char *file, unsigned int line,
+void __assert(const char *function, const char *file, unsigned int line,
 		const char *assertion)
 {
+#if LOG_LEVEL >= LOG_LEVEL_INFO
+	/*
+	 * Only print the output if LOG_LEVEL is higher or equal to
+	 * LOG_LEVEL_INFO, which is the default value for builds with DEBUG=1.
+	 */
 	tf_printf("ASSERT: %s <%d> : %s\n", function, line, assertion);
 
 	console_flush();
+#endif
 
 	plat_panic_handler();
 }

--- a/lib/xlat_tables/aarch32/xlat_tables.c
+++ b/lib/xlat_tables/aarch32/xlat_tables.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -85,13 +85,13 @@
 static uint64_t base_xlation_table[NUM_BASE_LEVEL_ENTRIES]
 		__aligned(NUM_BASE_LEVEL_ENTRIES * sizeof(uint64_t));
 
-#if DEBUG
+#if ENABLE_ASSERTIONS
 static unsigned long long get_max_supported_pa(void)
 {
 	/* Physical address space size for long descriptor format. */
 	return (1ULL << 40) - 1ULL;
 }
-#endif
+#endif /* ENABLE_ASSERTIONS */
 
 void init_xlat_tables(void)
 {

--- a/lib/xlat_tables/aarch64/xlat_tables.c
+++ b/lib/xlat_tables/aarch64/xlat_tables.c
@@ -127,7 +127,7 @@ static unsigned long long calc_physical_addr_size_bits(
 	return TCR_PS_BITS_4GB;
 }
 
-#if DEBUG
+#if ENABLE_ASSERTIONS
 /* Physical Address ranges supported in the AArch64 Memory Model */
 static const unsigned int pa_range_bits_arr[] = {
 	PARANGE_0000, PARANGE_0001, PARANGE_0010, PARANGE_0011, PARANGE_0100,
@@ -144,7 +144,7 @@ static unsigned long long get_max_supported_pa(void)
 
 	return (1ULL << pa_range_bits_arr[pa_range]) - 1ULL;
 }
-#endif
+#endif /* ENABLE_ASSERTIONS */
 
 void init_xlat_tables(void)
 {

--- a/lib/xlat_tables/xlat_tables_common.c
+++ b/lib/xlat_tables/xlat_tables_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -109,7 +109,7 @@ void mmap_add_region(unsigned long long base_pa, uintptr_t base_va,
 	assert((base_pa + (unsigned long long)size - 1ULL) <=
 					(PLAT_PHY_ADDR_SPACE_SIZE - 1));
 
-#if DEBUG
+#if ENABLE_ASSERTIONS
 
 	/* Check for PAs and VAs overlaps with all other regions */
 	for (mm = mmap; mm->size; ++mm) {
@@ -154,7 +154,7 @@ void mmap_add_region(unsigned long long base_pa, uintptr_t base_va,
 
 	mm = mmap; /* Restore pointer to the start of the array */
 
-#endif /* DEBUG */
+#endif /* ENABLE_ASSERTIONS */
 
 	/* Find correct place in mmap to insert new region */
 	while (mm->base_va < base_va && mm->size)

--- a/lib/xlat_tables_v2/aarch32/xlat_tables_arch.c
+++ b/lib/xlat_tables_v2/aarch32/xlat_tables_arch.c
@@ -37,13 +37,13 @@
 #include <xlat_tables_v2.h>
 #include "../xlat_tables_private.h"
 
-#if DEBUG
+#if ENABLE_ASSERTIONS
 static unsigned long long xlat_arch_get_max_supported_pa(void)
 {
 	/* Physical address space size for long descriptor format. */
 	return (1ull << 40) - 1ull;
 }
-#endif /* DEBUG*/
+#endif /* ENABLE_ASSERTIONS*/
 
 int is_mmu_enabled(void)
 {

--- a/lib/xlat_tables_v2/aarch64/xlat_tables_arch.c
+++ b/lib/xlat_tables_v2/aarch64/xlat_tables_arch.c
@@ -77,7 +77,7 @@ static unsigned long long calc_physical_addr_size_bits(
 	return TCR_PS_BITS_4GB;
 }
 
-#if DEBUG
+#if ENABLE_ASSERTIONS
 /* Physical Address ranges supported in the AArch64 Memory Model */
 static const unsigned int pa_range_bits_arr[] = {
 	PARANGE_0000, PARANGE_0001, PARANGE_0010, PARANGE_0011, PARANGE_0100,
@@ -94,7 +94,7 @@ unsigned long long xlat_arch_get_max_supported_pa(void)
 
 	return (1ull << pa_range_bits_arr[pa_range]) - 1ull;
 }
-#endif /* DEBUG*/
+#endif /* ENABLE_ASSERTIONS*/
 
 int is_mmu_enabled(void)
 {

--- a/plat/common/aarch64/platform_mp_stack.S
+++ b/plat/common/aarch64/platform_mp_stack.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -131,7 +131,7 @@ endfunc platform_set_stack
 	 * -------------------------------------------------------
 	 */
 func_deprecated platform_get_stack
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	mrs	x1, mpidr_el1
 	cmp	x0, x1
 	ASM_ASSERT(eq)
@@ -150,7 +150,7 @@ endfunc_deprecated platform_get_stack
 	 * -----------------------------------------------------
 	 */
 func_deprecated platform_set_stack
-#if ASM_ASSERTION
+#if ENABLE_ASSERTIONS
 	mrs	x1, mpidr_el1
 	cmp	x0, x1
 	ASM_ASSERT(eq)


### PR DESCRIPTION
Add the new build option `ENABLE_ASSERTIONS` that controls whether or
not assert functions are compiled out. It defaults to 1 for debug builds
and to 0 for release builds.

Assert messages are now only printed if LOG_LEVEL >= LOG_LEVEL_INFO,
which is the default for debug builds.

All occurrences of `ASM_ASSERTION` in common code and ARM platforms have
been replaced by `ENABLE_ASSERTIONS`.