### PR TITLE
tspd:FWU:Fix usage of SMC_RET0

### DIFF
--- a/bl1/bl1_fwu.c
+++ b/bl1/bl1_fwu.c
@@ -109,7 +109,7 @@ register_t bl1_fwu_smc_handler(unsigned int smc_fid,
 		break;
 	}
 
-	SMC_RET0(handle);
+	SMC_RET1(handle, SMC_UNK);
 }
 
 /*******************************************************************************

--- a/include/lib/smcc.h
+++ b/include/lib/smcc.h
@@ -58,6 +58,7 @@
 
 #define SMC_64				1
 #define SMC_32				0
+#define SMC_OK				0
 #define SMC_UNK				0xffffffff
 #define SMC_TYPE_FAST			ULL(1)
 #define SMC_TYPE_STD			0

--- a/services/spd/tspd/tspd_main.c
+++ b/services/spd/tspd/tspd_main.c
@@ -631,7 +631,7 @@ uint64_t tspd_smc_handler(uint32_t smc_fid,
 
 		cm_el1_sysregs_context_restore(NON_SECURE);
 		cm_set_next_eret_context(NON_SECURE);
-		SMC_RET0(handle);
+		SMC_RET1(handle, SMC_OK);
 
 		/*
 		 * Request from non secure world to resume the preempted


### PR DESCRIPTION
SMC_RET0 should only be used when the SMC code works as a function that
returns void. If the code of the SMC uses SMC_RET1 to return a value to
signify success and doesn't return anything in case of an error (or the
other way around) SMC_RET1 should always be used to return clearly
identifiable values.

This patch fixes two cases in which the code used SMC_RET0 instead of
SMC_RET1.

It also introduces the define SMC_OK to use when an SMC must return a
value to tell that it succeeded, the same way as SMC_UNK is used in case
of failure.