### PR TITLE
Tegra: Control inclusion of helper code used for asserts

### DIFF
--- a/plat/nvidia/tegra/common/tegra_common.mk
+++ b/plat/nvidia/tegra/common/tegra_common.mk
@@ -31,8 +31,8 @@
 CRASH_REPORTING		:=	1
 $(eval $(call add_define,CRASH_REPORTING))
 
-ASM_ASSERTION		:=	1
-$(eval $(call add_define,ASM_ASSERTION))
+ENABLE_ASSERTIONS	:=	1
+$(eval $(call add_define,ENABLE_ASSERTIONS))
 
 USE_COHERENT_MEM	:=	0
 

--- a/plat/nvidia/tegra/soc/t132/plat_psci_handlers.c
+++ b/plat/nvidia/tegra/soc/t132/plat_psci_handlers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -132,7 +132,7 @@ int tegra_soc_pwr_domain_off(const psci_power_state_t *target_state)
 
 int tegra_soc_pwr_domain_suspend(const psci_power_state_t *target_state)
 {
-#if DEBUG
+#if ENABLE_ASSERTIONS
 	int cpu = read_mpidr() & MPIDR_CPU_MASK;
 
 	/* SYSTEM_SUSPEND only on CPU0 */


### PR DESCRIPTION
One assert depends on code that is conditionally compiled based on the
DEBUG define. This patch modifies the conditional inclusion of such code
so that it is based on the ENABLE_ASSERTIONS build option.

Platform Makefile changed to set `ENABLE_ASSERTIONS` to 1 instead of
the deprecated option `ASM_ASSERTION`. This also pulls in C assertions
in release mode.

This patch has to be applied on top of the changes of https://github.com/ARM-software/arm-trusted-firmware/pull/906