### PR TITLE
xlat lib: Use mmap_attr_t type consistently

### DIFF
--- a/include/lib/xlat_tables/xlat_tables.h
+++ b/include/lib/xlat_tables/xlat_tables.h
@@ -108,7 +108,7 @@ typedef struct mmap_region {
 /* Generic translation table APIs */
 void init_xlat_tables(void);
 void mmap_add_region(unsigned long long base_pa, uintptr_t base_va,
-				size_t size, unsigned int attr);
+				size_t size, mmap_attr_t attr);
 void mmap_add(const mmap_region_t *mm);
 
 #endif /*__ASSEMBLY__*/

--- a/include/lib/xlat_tables/xlat_tables_v2.h
+++ b/include/lib/xlat_tables/xlat_tables_v2.h
@@ -114,7 +114,7 @@ void init_xlat_tables(void);
  * be added before initializing the MMU and cannot be removed later.
  */
 void mmap_add_region(unsigned long long base_pa, uintptr_t base_va,
-				size_t size, unsigned int attr);
+				size_t size, mmap_attr_t attr);
 
 /*
  * Add a region with defined base PA and base VA. This type of region can be
@@ -128,7 +128,7 @@ void mmap_add_region(unsigned long long base_pa, uintptr_t base_va,
  *    EPERM: It overlaps another region in an invalid way.
  */
 int mmap_add_dynamic_region(unsigned long long base_pa, uintptr_t base_va,
-				size_t size, unsigned int attr);
+				size_t size, mmap_attr_t attr);
 
 /*
  * Add an array of static regions with defined base PA and base VA. This type

--- a/lib/xlat_tables/xlat_tables_common.c
+++ b/lib/xlat_tables/xlat_tables_common.c
@@ -87,7 +87,7 @@ void print_mmap(void)
 }
 
 void mmap_add_region(unsigned long long base_pa, uintptr_t base_va,
-			size_t size, unsigned int attr)
+			size_t size, mmap_attr_t attr)
 {
 	mmap_region_t *mm = mmap;
 	mmap_region_t *mm_last = mm + ARRAY_SIZE(mmap) - 1;
@@ -199,7 +199,7 @@ void mmap_add(const mmap_region_t *mm)
 	}
 }
 
-static uint64_t mmap_desc(unsigned attr, unsigned long long addr_pa,
+static uint64_t mmap_desc(mmap_attr_t attr, unsigned long long addr_pa,
 							int level)
 {
 	uint64_t desc;
@@ -277,11 +277,11 @@ static uint64_t mmap_desc(unsigned attr, unsigned long long addr_pa,
  * attributes of the innermost region that contains it. If there are partial
  * overlaps, it returns -1, as a smaller size is needed.
  */
-static int mmap_region_attr(mmap_region_t *mm, uintptr_t base_va,
+static mmap_attr_t mmap_region_attr(mmap_region_t *mm, uintptr_t base_va,
 					size_t size)
 {
 	/* Don't assume that the area is contained in the first region */
-	int attr = -1;
+	mmap_attr_t attr = -1;
 
 	/*
 	 * Get attributes from last (innermost) region that contains the
@@ -360,7 +360,8 @@ static mmap_region_t *init_xlation_table_inner(mmap_region_t *mm,
 			 * there are partially overlapping regions. On success,
 			 * it will return the innermost region's attributes.
 			 */
-			int attr = mmap_region_attr(mm, base_va, level_size);
+			mmap_attr_t attr = mmap_region_attr(mm, base_va,
+							level_size);
 			if (attr >= 0) {
 				desc = mmap_desc(attr,
 					base_va - mm->base_va + mm->base_pa,

--- a/lib/xlat_tables_v2/xlat_tables_common.c
+++ b/lib/xlat_tables_v2/xlat_tables_common.c
@@ -92,7 +92,7 @@ xlat_ctx_t tf_xlat_ctx = {
 };
 
 void mmap_add_region(unsigned long long base_pa, uintptr_t base_va,
-			size_t size, unsigned int attr)
+			size_t size, mmap_attr_t attr)
 {
 	mmap_region_t mm = {
 		.base_va = base_va,
@@ -114,7 +114,7 @@ void mmap_add(const mmap_region_t *mm)
 #if PLAT_XLAT_TABLES_DYNAMIC
 
 int mmap_add_dynamic_region(unsigned long long base_pa,
-			    uintptr_t base_va, size_t size, unsigned int attr)
+			    uintptr_t base_va, size_t size, mmap_attr_t attr)
 {
 	mmap_region_t mm = {
 		.base_va = base_va,

--- a/lib/xlat_tables_v2/xlat_tables_internal.c
+++ b/lib/xlat_tables_v2/xlat_tables_internal.c
@@ -115,7 +115,7 @@ static uint64_t *xlat_table_get_empty(xlat_ctx_t *ctx)
 #endif /* PLAT_XLAT_TABLES_DYNAMIC */
 
 /* Returns a block/page table descriptor for the given level and attributes. */
-static uint64_t xlat_desc(unsigned int attr, unsigned long long addr_pa,
+static uint64_t xlat_desc(mmap_attr_t attr, unsigned long long addr_pa,
 			  int level)
 {
 	uint64_t desc;
@@ -609,7 +609,7 @@ void print_mmap(mmap_region_t *const mmap)
  */
 static int mmap_add_region_check(xlat_ctx_t *ctx, unsigned long long base_pa,
 				 uintptr_t base_va, size_t size,
-				 unsigned int attr)
+				 mmap_attr_t attr)
 {
 	mmap_region_t *mm = ctx->mmap;
 	unsigned long long end_pa = base_pa + size - 1;


### PR DESCRIPTION
This patch modifies both versions of the translation table library
to use the mmap_attr_t type consistently wherever it is manipulating
MT_* attributes variables. It used to use mmap_attr_t or plain integer
types interchangeably, which compiles fine because an enumeration type
can be silently converted to an integer, but which is semantically
incorrect.

This patch removes this assumption by using the abstract type
'mmap_attr_t' all the time.
