### PR TITLE
Minor refactor of BL2 image load v2

### DIFF
--- a/bl2/bl2_image_load_v2.c
+++ b/bl2/bl2_image_load_v2.c
@@ -109,6 +109,10 @@ entry_point_info_t *bl2_load_images(void)
 	assert(bl2_to_next_bl_params->head);
 	assert(bl2_to_next_bl_params->h.type == PARAM_BL_PARAMS);
 	assert(bl2_to_next_bl_params->h.version >= VERSION_2);
+	assert(bl2_to_next_bl_params->head->ep_info);
+
+	/* Populate arg0 for the next BL image */
+	bl2_to_next_bl_params->head->ep_info->args.arg0 = (u_register_t)bl2_to_next_bl_params;
 
 	/* Flush the parameters to be passed to next image */
 	plat_flush_next_bl_params();

--- a/common/desc_image_load.c
+++ b/common/desc_image_load.c
@@ -47,8 +47,11 @@ static bl_params_t next_bl_params;
  ******************************************************************************/
 void flush_bl_params_desc(void)
 {
-	flush_dcache_range((unsigned long)bl_mem_params_desc_ptr,
+	flush_dcache_range((uintptr_t)bl_mem_params_desc_ptr,
 			sizeof(*bl_mem_params_desc_ptr) * bl_mem_params_desc_num);
+
+	flush_dcache_range((uintptr_t)&next_bl_params,
+			sizeof(next_bl_params));
 }
 
 /*******************************************************************************
@@ -208,13 +211,6 @@ bl_params_t *get_next_bl_params_from_mem_params_desc(void)
 
 	/* Invalid image is expected to terminate the loop */
 	assert(img_id == INVALID_IMAGE_ID);
-
-	/* Populate arg0 for the next BL image */
-	next_bl_params.head->ep_info->args.arg0 = (unsigned long)&next_bl_params;
-
-	/* Flush the parameters to be passed to the next BL image */
-	flush_dcache_range((unsigned long)&next_bl_params,
-			sizeof(next_bl_params));
 
 	return &next_bl_params;
 }


### PR DESCRIPTION
Previously, get_next_bl_params_from_mem_params_desc() populated arg0
in the EL3 runtime entrypoint with a bl_params_t pointer. This is the
responsibility of the generic LOAD_IMAGE_V2 framework instead of the
descriptor-based image loading utility functions. Therefore this patch
moves that code to bl2_load_images().

Also, this patch moves the code that flushes the bl_params structure to
flush_bl_params_desc(), together with the other descriptor-based image
loading flushing code.

Change-Id: I4541e3f50e3878dde7cf89e9e8f31fe0b173fb9d
Signed-off-by: Dan Handley <dan.handley@arm.com>