### PR TITLE
fiptool: Support non-decimal --align arguments

### DIFF
--- a/tools/fiptool/fiptool.c
+++ b/tools/fiptool/fiptool.c
@@ -646,7 +646,7 @@ static unsigned long get_image_align(char *arg)
 	unsigned long align;
 
 	errno = 0;
-	align = strtoul(arg, &endptr, 10);
+	align = strtoul(arg, &endptr, 0);
 	if (*endptr != '\0' || !is_power_of_2(align) || errno != 0)
 		log_errx("Invalid alignment: %s", arg);
 


### PR DESCRIPTION
An alignment value of 0x4000 is much easier to type than 16384,
so enhance get_image_align() to recognize a 0x prefix.

Signed-off-by: Andreas Färber <afaerber@suse.de>