### PR TITLE
Revert "rockchip: Remove unused rockchip_pd_pwr_down_wfi function"

### DIFF
--- a/plat/rockchip/common/plat_pm.c
+++ b/plat/rockchip/common/plat_pm.c
@@ -367,6 +367,15 @@ static void __dead2 rockchip_system_poweroff(void)
 	rockchip_soc_system_off();
 }
 
+static void __dead2 rockchip_pd_pwr_down_wfi(
+		const psci_power_state_t *target_state)
+{
+	if (RK_SYSTEM_PWR_STATE(target_state) == PLAT_MAX_OFF_STATE)
+		rockchip_soc_sys_pd_pwr_dn_wfi();
+	else
+		rockchip_soc_cores_pd_pwr_dn_wfi(target_state);
+}
+
 /*******************************************************************************
  * Export the platform handlers via plat_rockchip_psci_pm_ops. The rockchip
  * standard


### PR DESCRIPTION
This reverts commit b6dcbf588af442fa87721dc707ff9e54d04ff504.

This function wasn't used when it was removed, but it is needed to compile the new changes proposed for Rockchip platforms.

The commit was introduced in this PR: https://github.com/ARM-software/arm-trusted-firmware/pull/889
It prevents the following PR to be successfully merged: https://github.com/ARM-software/arm-trusted-firmware/pull/918