### PR TITLE
Juno: Fix AArch32 sp_min build

### DIFF
--- a/plat/arm/board/juno/sp_min/sp_min-juno.mk
+++ b/plat/arm/board/juno/sp_min/sp_min-juno.mk
@@ -8,7 +8,6 @@
 BL32_SOURCES	+=	lib/cpus/aarch32/cortex_a53.S		\
 			lib/cpus/aarch32/cortex_a57.S		\
 			lib/cpus/aarch32/cortex_a72.S		\
-			plat/arm/board/juno/juno_pm.c		\
 			plat/arm/board/juno/juno_topology.c	\
 			plat/arm/css/common/css_pm.c		\
 			plat/arm/css/common/css_topology.c	\


### PR DESCRIPTION
The commit abd2aba99ef108e0d0bb5d71c0b6e9c47ca26377 introduced a
regression to the AArch32 sp_min Juno build. This patch fixes that.

Change-Id: I4b141717684d6aee60c761ea17f23170aa6708c3
Signed-off-by: Soby Mathew <soby.mathew@arm.com>