### PR TITLE
Add note about SPDX identifiers in license.md

### DIFF
--- a/license.md
+++ b/license.md
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2014, ARM Limited and Contributors. All rights reserved.
+Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
@@ -24,3 +24,12 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---------------------------------------------------------------------------
+Note:
+Individual files contain the following tag instead of the full license text.
+
+	SPDX-License-Identifier:	BSD-3-Clause
+
+This enables machine processing of license information based on the SPDX
+License Identifiers that are here available: http://spdx.org/licenses/


### PR DESCRIPTION
Added note regarding use of SPDX identifiers following this example:
https://github.com/pocoproject/poco/blob/develop/LICENSE

Change-Id: I22a280bce57f9145e4786c5ad32f663c2c9c6545
Signed-off-by: Jilayne Lovejoy <jilayne.lovejoy@arm.com>
Signed-off-by: Dan Handley <dan.handley@arm.com>