### PR TITLE
xlat: Fix missing header file dependency

### DIFF
--- a/lib/xlat_tables_v2/aarch32/xlat_tables_arch.h
+++ b/lib/xlat_tables_v2/aarch32/xlat_tables_arch.h
@@ -10,6 +10,7 @@
 #include <arch.h>
 #include <platform_def.h>
 #include <xlat_tables_defs.h>
+#include "../xlat_tables_private.h"
 
 /*
  * In AArch32 state, the MMU only supports 4KB page granularity, which means

--- a/lib/xlat_tables_v2/aarch64/xlat_tables_arch.h
+++ b/lib/xlat_tables_v2/aarch64/xlat_tables_arch.h
@@ -10,6 +10,7 @@
 #include <arch.h>
 #include <platform_def.h>
 #include <xlat_tables_defs.h>
+#include "../xlat_tables_private.h"
 
 /*
  * In AArch64 state, the MMU may support 4 KB, 16 KB and 64 KB page


### PR DESCRIPTION
`xlat_tables_arch.h` uses the platform macro `PLAT_VIRT_ADDR_SPACE_SIZE`. This macro is defined in `xlat_tables_private.h` only if the platform still uses the deprecated `ADDR_SPACE_SIZE`.