### PR TITLE
Migrate to Linaro Release 17.01

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -38,7 +38,7 @@ the different software components required to boot a Linux system:
 *   Root filesystem
 
 Note: the ARM TF v1.3 release was tested with Linaro Release 16.06, and the
-latest version of ARM TF is tested with Linaro Release 16.12.
+latest version of ARM TF is tested with Linaro Release 17.01.
 
 This document also assumes that the user is familiar with the FVP models and
 the different command line options available to launch the model.


### PR DESCRIPTION
This Linaro release updates just the binaries:

Linaro binaries upgraded 16.12 --> 17.01

The toolchain remains at 5.3-2015.05 (gcc 5.3) for both AArch64
and AArch32.

The ARM TF codebase has been tested against these new binaries. This patch
updates the User Guide to reflect that the 17.01 release is now a supported
Linaro Release.

Change-Id: I83c579dabd3fa9861ba0d41507036efbd87abcb5
Signed-off-by: David Cunado <david.cunado@arm.com>