### PR TITLE
hikey: fix uninitialized variable in ddr code

### DIFF
--- a/plat/hisilicon/hikey/hikey_ddr.c
+++ b/plat/hisilicon/hikey/hikey_ddr.c
@@ -385,7 +385,7 @@ static void ddrx_rdet(void)
 
 static void ddrx_wdet(void)
 {
-	unsigned int data, wdet, zero_bdl, dq[4];
+	unsigned int data, wdet, zero_bdl = 0, dq[4];
 	int i;
 
 	data = mmio_read_32((0xf712c000 + 0x0d0));
@@ -454,11 +454,11 @@ static void ddrx_wdet(void)
 		for (i = 0; i < 4; i++) {
 			data = mmio_read_32((0xf712c000 + 0x210 + i * 0x80));
 			if ((!(data & 0x1f)) || (!(data & 0x1f00)) ||
-					(!(data & 0x1f0000)) || (!(data & 0x1f000000)))
+			    (!(data & 0x1f0000)) || (!(data & 0x1f000000)))
 				zero_bdl = 1;
 			data = mmio_read_32((0xf712c000 + 0x214 + i * 0x80));
 			if ((!(data & 0x1f)) || (!(data & 0x1f00)) ||
-					(!(data & 0x1f0000)) || (!(data & 0x1f000000)))
+			    (!(data & 0x1f0000)) || (!(data & 0x1f000000)))
 				zero_bdl = 1;
 			data = mmio_read_32((0xf712c000 + 0x218 + i * 0x80));
 			if (!(data & 0x1f))


### PR DESCRIPTION
Fix issue in https://github.com/ARM-software/tf-issues/issues/483

Fix uninitliazed variable in ddr driver code.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>