### PR TITLE
mbedtls: Define optimized mbed TLS heap size

### DIFF
--- a/drivers/auth/mbedtls/mbedtls_common.c
+++ b/drivers/auth/mbedtls/mbedtls_common.c
@@ -16,7 +16,7 @@
 #if (TF_MBEDTLS_KEY_ALG_ID == TF_MBEDTLS_ECDSA)
 #define MBEDTLS_HEAP_SIZE		(14*1024)
 #elif (TF_MBEDTLS_KEY_ALG_ID == TF_MBEDTLS_RSA)
-#define MBEDTLS_HEAP_SIZE		(8*1024)
+#define MBEDTLS_HEAP_SIZE		(6*1024)
 #endif
 static unsigned char heap[MBEDTLS_HEAP_SIZE];
 


### PR DESCRIPTION
mbed TLS provides the debug API `mbedtls_memory_buffer_alloc_status()` to analyse the RAM usage of the library.

When RSA is selected as algorithm, the maximum heap usage in FVP and Juno has been determined empirically to be approximately 5.5 KiB. However, The default heap size used when RSA is selected is 8 KiB.

This patch reduces the buffer from 8 KiB to 6 KiB so that the BSS sections of both BL1 and BL2 are 2 KiB smaller when the firmware is compiled with Trusted Board Boot support.