### PR TITLE
FWU: Check for overlaps when loading images, introduce `FWU_SMC_IMAGE_RESET`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,11 +336,6 @@ endif
 # Process platform overrideable behaviour
 ################################################################################
 
-# Check if -pedantic option should be used
-ifeq (${DISABLE_PEDANTIC},0)
-        TF_CFLAGS	+= 	-pedantic
-endif
-
 # Using the ARM Trusted Firmware BL2 implies that a BL33 image also needs to be
 # supplied for the FIP and Certificate generation tools. This flag can be
 # overridden by the platform.

--- a/docs/firmware-update.md
+++ b/docs/firmware-update.md
@@ -211,6 +211,7 @@ for BL1 to pass execution control to BL31.
         if (source block is in secure memory) return -ENOMEM
         if (source block is not mapped into BL1) return -ENOMEM
         if (image_size > free secure memory) return -ENOMEM
+        if (image overlaps another image) return -EPERM
 
 This SMC copies the secure image indicated by `image_id` from non-secure memory
 to secure memory for later authentication. The image may be copied in a single

--- a/docs/firmware-update.md
+++ b/docs/firmware-update.md
@@ -117,6 +117,7 @@ The following is a brief description of the supported states:
 *   RESET:         This is the initial state of every image at the start of FWU.
                    Authentication failure also leads to this state. A secure
                    image may yield to this state if it has completed execution.
+                   It can also be reached by using `FWU_SMC_IMAGE_RESET`.
 
 *   COPYING:       This is the state of a secure image while BL1 is copying it
                    in blocks from non-secure to secure memory.
@@ -356,9 +357,28 @@ function `bl1_plat_fwu_done`, passing the optional argument `client_cookie` as
 a `void *`. The SMC does not return.
 
 
+### FWU_SMC_IMAGE_RESET
+
+    Arguments:
+        uint32_t     function ID : 0x16
+        unsigned int image_id
+
+    Return:
+        int : 0 (Success)
+            : -EPERM
+
+    Pre-conditions:
+        if (secure world caller) return -EPERM
+        if (image in EXECUTED) return -EPERM
+
+This SMC sets the state of an image to RESET and zeroes the memory used by it.
+
+This is only allowed if the image is not being executed.
+
+
 - - - - - - - - - - - - - - - - - - - - - - - - - -
 
-_Copyright (c) 2015-2016, ARM Limited and Contributors. All rights reserved._
+_Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved._
 
 
 [Porting Guide]:        ./porting-guide.md

--- a/docs/porting-guide.md
+++ b/docs/porting-guide.md
@@ -354,6 +354,13 @@ be defined:
     NS_BL2U image identifier, used by BL1 to fetch an image descriptor
     corresponding to NS_BL2U.
 
+For the the Firmware update capability of TRUSTED BOARD BOOT, the following
+macros may also be defined:
+
+*   **#define : PLAT_FWU_MAX_SIMULTANEOUS_IMAGES**
+
+    Total number of images that can be loaded simultaneously. If the platform
+    doesn't specify any value, it defaults to 10.
 
 If a SCP_BL2 image is supported by the platform, the following constants must
 also be defined:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -300,9 +300,6 @@ performed.
 *   `DEBUG`: Chooses between a debug and release build. It can take either 0
     (release) or 1 (debug) as values. 0 is the default.
 
-*   `DISABLE_PEDANTIC`: When set to 1 it will disable the -pedantic option in
-    the GCC command line. Default is 0.
-
 *   `EL3_PAYLOAD_BASE`: This option enables booting an EL3 payload instead of
     the normal boot flow. It must specify the entry point address of the EL3
     payload. Please refer to the "Booting an EL3 payload" section for more

--- a/include/bl1/bl1.h
+++ b/include/bl1/bl1.h
@@ -39,11 +39,12 @@
 #define FWU_SMC_IMAGE_RESUME		0x13
 #define FWU_SMC_SEC_IMAGE_DONE		0x14
 #define FWU_SMC_UPDATE_DONE		0x15
+#define FWU_SMC_IMAGE_RESET		0x16
 
 /*
  * Number of FWU calls (above) implemented
  */
-#define FWU_NUM_SMC_CALLS		6
+#define FWU_NUM_SMC_CALLS		7
 
 #if TRUSTED_BOARD_BOOT
 # define BL1_NUM_SMC_CALLS		(FWU_NUM_SMC_CALLS + 4)
@@ -56,7 +57,7 @@
  * calls from the SMC function ID
  */
 #define FWU_SMC_FID_START		FWU_SMC_IMAGE_COPY
-#define FWU_SMC_FID_END			FWU_SMC_UPDATE_DONE
+#define FWU_SMC_FID_END			FWU_SMC_IMAGE_RESET
 #define is_fwu_fid(_fid) \
     ((_fid >= FWU_SMC_FID_START) && (_fid <= FWU_SMC_FID_END))
 

--- a/make_helpers/defaults.mk
+++ b/make_helpers/defaults.mk
@@ -54,9 +54,6 @@ DEBUG				:= 0
 # Build platform
 DEFAULT_PLAT			:= fvp
 
-# By default, use the -pedantic option in the gcc command line
-DISABLE_PEDANTIC		:= 0
-
 # Flag to enable Performance Measurement Framework
 ENABLE_PMF			:= 0
 


### PR DESCRIPTION
Added checks to `FWU_SMC_IMAGE_COPY` to prevent loading data into a memory region where another image data is already loaded.

Without this check, if two images are configured to be loaded in overlapping memory regions, one of them can be loaded and authenticated and the copy function is still able to load data from the second image on top of the first one. Since the first image is still in authenticated state, it can be executed, which could lead to the execution of unauthenticated arbitrary code of the second image.

The new SMC is a means for the image loading state machine to go from `COPYING`, `COPIED` or `AUTHENTICATED` states to `RESET` state. Previously, this was only done when the authentication of an image failed or when the execution of the image finished.

Firmware update documentation updated.