### PR TITLE
Resolve build errors flagged by GCC 6.2

### DIFF
--- a/plat/mediatek/mt6795/include/mcucfg.h
+++ b/plat/mediatek/mt6795/include/mcucfg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -104,12 +104,10 @@ struct mt6795_mcucfg_regs {
 static struct mt6795_mcucfg_regs *const mt6795_mcucfg = (void *)MCUCFG_BASE;
 
 /* cpu boot mode */
-enum {
-	MP0_CPUCFG_64BIT_SHIFT = 12,
-	MP1_CPUCFG_64BIT_SHIFT = 28,
-	MP0_CPUCFG_64BIT = 0xf << MP0_CPUCFG_64BIT_SHIFT,
-	MP1_CPUCFG_64BIT = 0xf << MP1_CPUCFG_64BIT_SHIFT
-};
+#define	MP0_CPUCFG_64BIT_SHIFT	12
+#define	MP1_CPUCFG_64BIT_SHIFT	28
+#define	MP0_CPUCFG_64BIT	(U(0xf) << MP0_CPUCFG_64BIT_SHIFT)
+#define	MP1_CPUCFG_64BIT	(U(0xf) << MP1_CPUCFG_64BIT_SHIFT)
 
 /* scu related */
 enum {

--- a/plat/mediatek/mt8173/include/mcucfg.h
+++ b/plat/mediatek/mt8173/include/mcucfg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2017, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -103,12 +103,10 @@ struct mt8173_mcucfg_regs {
 static struct mt8173_mcucfg_regs *const mt8173_mcucfg = (void *)MCUCFG_BASE;
 
 /* cpu boot mode */
-enum {
-	MP0_CPUCFG_64BIT_SHIFT = 12,
-	MP1_CPUCFG_64BIT_SHIFT = 28,
-	MP0_CPUCFG_64BIT = 0xf << MP0_CPUCFG_64BIT_SHIFT,
-	MP1_CPUCFG_64BIT = 0xf << MP1_CPUCFG_64BIT_SHIFT
-};
+#define	MP0_CPUCFG_64BIT_SHIFT	12
+#define	MP1_CPUCFG_64BIT_SHIFT	28
+#define	MP0_CPUCFG_64BIT	(U(0xf) << MP0_CPUCFG_64BIT_SHIFT)
+#define	MP1_CPUCFG_64BIT	(U(0xf) << MP1_CPUCFG_64BIT_SHIFT)
 
 /* scu related */
 enum {


### PR DESCRIPTION
With GCC 6.2 compiler, more C undefined behaviour is being flagged as
warnings, which result in build errors in ARM TF build.

This patch addresses issue caused by enums with values that exceed
maximum value for an int. For these cases the enum is converted to
a set of defines.

Change-Id: I5114164be10d86d5beef3ea1ed9be5863855144d
Signed-off-by: David Cunado <david.cunado@arm.com>