### PR TITLE
mbedtls: Don't use tf_snprintf if option not defined

### DIFF
--- a/drivers/auth/mbedtls/mbedtls_common.c
+++ b/drivers/auth/mbedtls/mbedtls_common.c
@@ -9,6 +9,7 @@
 /* mbed TLS headers */
 #include <mbedtls/memory_buffer_alloc.h>
 #include <mbedtls/platform.h>
+#include <mbedtls_config.h>
 
 /*
  * mbed TLS heap
@@ -31,8 +32,10 @@ void mbedtls_init(void)
 		/* Initialize the mbed TLS heap */
 		mbedtls_memory_buffer_alloc_init(heap, MBEDTLS_HEAP_SIZE);
 
+#ifdef MBEDTLS_PLATFORM_SNPRINTF_ALT
 		/* Use reduced version of snprintf to save space. */
 		mbedtls_platform_set_snprintf(tf_snprintf);
+#endif
 
 		ready = 1;
 	}


### PR DESCRIPTION
If `MBEDTLS_PLATFORM_SNPRINTF_ALT` isn't used, the function `mbedtls_platform_set_snprintf()` isn't defined.

In case a platform uses a different mbed TLS configuration file than the one provided by the Trusted Firmware, and it doesn't define the mentioned build option, this will result in a build error.

This patch modifies the initialization code so that `mbedtls_platform_set_snprintf()` is only used if `MBEDTLS_PLATFORM_SNPRINTF_ALT` is defined, allowing platforms to use it or not depending on their needs.

Fixes ARM-software/tf-issues#487