### PR TITLE
tegra: Fix build errors

### DIFF
--- a/plat/nvidia/tegra/common/tegra_bl31_setup.c
+++ b/plat/nvidia/tegra/common/tegra_bl31_setup.c
@@ -122,7 +122,7 @@ void bl31_early_platform_setup(bl31_params_t *from_bl2,
 {
 	plat_params_from_bl2_t *plat_params =
 		(plat_params_from_bl2_t *)plat_params_from_bl2;
-#if DEBUG
+#if LOG_LEVEL >= LOG_LEVEL_INFO
 	int impl = (read_midr() >> MIDR_IMPL_SHIFT) & MIDR_IMPL_MASK;
 #endif
 	image_info_t bl32_img_info = { {0} };


### PR DESCRIPTION
The 'impl' variable is guarded by the symbold DEBUG, but used in an INFO
level print statement. INFO is defined based on LOG_LEVEL. Hence, builds
would faile when
 - DEBUG=0 && LOG_LEVEL=>LOG_LEVEL_INFO with a variable used but not defined
 - DEBUG=1 && LOG_LEVEL<LOG_LEVEL_INFO with a defined but not used

Fixing this by guarding impl with the same condition that guards INFO.

Fixes ARM-software/tf-issues#490
Signed-off-by: Soren Brinkmann <soren.brinkmann@xilinx.com>