### PR TITLE
psci: minor fixes in lib

### DIFF
--- a/lib/psci/psci_stat.c
+++ b/lib/psci/psci_stat.c
@@ -72,7 +72,7 @@ static int get_stat_idx(plat_local_state_t local_state, int pwr_lvl)
 void psci_stats_update_pwr_down(unsigned int end_pwrlvl,
 			const psci_power_state_t *state_info)
 {
-	int lvl, parent_idx, cpu_idx = plat_my_core_pos();
+	unsigned int lvl, parent_idx, cpu_idx = plat_my_core_pos();
 
 	assert(end_pwrlvl <= PLAT_MAX_PWR_LVL);
 	assert(state_info);
@@ -104,8 +104,8 @@ void psci_stats_update_pwr_down(unsigned int end_pwrlvl,
 void psci_stats_update_pwr_up(unsigned int end_pwrlvl,
 			const psci_power_state_t *state_info)
 {
-	int parent_idx, cpu_idx = plat_my_core_pos();
-	int lvl, stat_idx;
+	unsigned int lvl, parent_idx, cpu_idx = plat_my_core_pos();
+	int stat_idx;
 	plat_local_state_t local_state;
 	u_register_t residency;
 
@@ -162,10 +162,11 @@ void psci_stats_update_pwr_up(unsigned int end_pwrlvl,
  * local state for the highest power level expressed in the `power_state`
  * for the node represented by `target_cpu`.
  ******************************************************************************/
-int psci_get_stat(u_register_t target_cpu, unsigned int power_state,
+static int psci_get_stat(u_register_t target_cpu, unsigned int power_state,
 			 psci_stat_t *psci_stat)
 {
-	int rc, pwrlvl, lvl, parent_idx, stat_idx, target_idx;
+	int rc;
+	unsigned int pwrlvl, lvl, parent_idx, stat_idx, target_idx;
 	psci_power_state_t state_info = { {PSCI_LOCAL_STATE_RUN} };
 	plat_local_state_t local_state;
 
@@ -216,8 +217,8 @@ u_register_t psci_stat_residency(u_register_t target_cpu,
 		unsigned int power_state)
 {
 	psci_stat_t psci_stat;
-
 	int rc = psci_get_stat(target_cpu, power_state, &psci_stat);
+
 	if (rc == PSCI_E_SUCCESS)
 		return psci_stat.residency;
 	else
@@ -229,8 +230,8 @@ u_register_t psci_stat_count(u_register_t target_cpu,
 	unsigned int power_state)
 {
 	psci_stat_t psci_stat;
-
 	int rc = psci_get_stat(target_cpu, power_state, &psci_stat);
+
 	if (rc == PSCI_E_SUCCESS)
 		return psci_stat.count;
 	else

--- a/lib/psci/psci_suspend.c
+++ b/lib/psci/psci_suspend.c
@@ -292,7 +292,7 @@ void psci_cpu_suspend_finish(unsigned int cpu_idx,
 	 * Dispatcher to let it do any bookeeping. If the handler encounters an
 	 * error, it's expected to assert within
 	 */
-	if (psci_spd_pm && psci_spd_pm->svc_suspend) {
+	if (psci_spd_pm && psci_spd_pm->svc_suspend_finish) {
 		max_off_lvl = psci_find_max_off_lvl(state_info);
 		assert (max_off_lvl != PSCI_INVALID_PWR_LVL);
 		psci_spd_pm->svc_suspend_finish(max_off_lvl);


### PR DESCRIPTION
This change fixes minor issues in the psci library:
- Call `svc_suspend_finish()` if registered.
- `psci_get_stat()` is static to psci_stat.c
- Fix types used in comparison.
- Fix coding style

Change-Id: I73e582f2c9e8504d1c567c6dcb7045c3684f4525
Signed-off-by: Etienne Carriere <etienne.carriere@st.com>