### PR TITLE
tools: Use exported quiet flag from top-level Makefile

### DIFF
--- a/tools/cert_create/Makefile
+++ b/tools/cert_create/Makefile
@@ -6,7 +6,7 @@
 
 PROJECT		:= cert_create
 PLAT		:= none
-V		:= 0
+V		?= 0
 DEBUG		:= 0
 BINARY		:= ${PROJECT}${BIN_EXT}
 OPENSSL_DIR	:= /usr
@@ -50,9 +50,9 @@ else
   CFLAGS += -O2 -DLOG_LEVEL=20
 endif
 ifeq (${V},0)
-	Q := @
+  Q := @
 else
-	Q :=
+  Q :=
 endif
 
 $(eval $(call add_define,USE_TBBR_DEFS))

--- a/tools/fiptool/Makefile
+++ b/tools/fiptool/Makefile
@@ -10,7 +10,7 @@ include ${MAKE_HELPERS_DIRECTORY}build_env.mk
 
 PROJECT := fiptool${BIN_EXT}
 OBJECTS := fiptool.o tbbr_config.o
-V := 0
+V ?= 0
 
 override CPPFLAGS += -D_GNU_SOURCE -D_XOPEN_SOURCE=700
 CFLAGS := -Wall -Werror -pedantic -std=c99


### PR DESCRIPTION
When V is set from the command line, the value is passed to the tools'
Makefiles as well.

Change-Id: I91a1f66de5c1ae6f36b6c9f0a9bd550d4a30f092
Signed-off-by: dp-arm <dimitris.papastamos@arm.com>