### PR TITLE
CSS:Fix scpi "get_power_state" when ARM_PLAT_MT is set

### DIFF
--- a/plat/arm/css/drivers/scp/css_pm_scpi.c
+++ b/plat/arm/css/drivers/scp/css_pm_scpi.c
@@ -93,7 +93,16 @@ int css_scp_get_power_state(u_register_t mpidr, unsigned int power_level)
 		 * The CPU state returned by SCP is an 8-bit bit mask
 		 * corresponding to each CPU in the cluster
 		 */
+#if ARM_PLAT_MT
+		/*
+		 * The current SCPI driver only caters for single-threaded
+		 * platforms. Hence we ignore the thread ID (which is always 0)
+		 * for such platforms.
+		 */
+		element = (mpidr >> MPIDR_AFF1_SHIFT) & MPIDR_AFFLVL_MASK;
+#else
 		element = mpidr & MPIDR_AFFLVL_MASK;
+#endif  /* ARM_PLAT_MT */
 		return CSS_CPU_PWR_STATE(cpu_state, element) ==
 			CSS_CPU_PWR_STATE_ON ? HW_ON : HW_OFF;
 	} else {

--- a/plat/arm/css/drivers/scpi/css_scpi.c
+++ b/plat/arm/css/drivers/scpi/css_scpi.c
@@ -183,8 +183,17 @@ int scpi_get_css_power_state(unsigned int mpidr, unsigned int *cpu_state_p,
 	 * Extract CPU and cluster membership of the given MPIDR. SCPI caters
 	 * for only up to 0xf clusters, and 8 CPUs per cluster
 	 */
+#if ARM_PLAT_MT
+	/*
+	 * The current SCPI driver only caters for single-threaded platforms.
+	 * Hence we ignore the thread ID (which is always 0) for such platforms.
+	 */
+	cpu = (mpidr >> MPIDR_AFF1_SHIFT) & MPIDR_AFFLVL_MASK;
+	cluster = (mpidr >> MPIDR_AFF2_SHIFT) & MPIDR_AFFLVL_MASK;
+#else
 	cpu = mpidr & MPIDR_AFFLVL_MASK;
 	cluster = (mpidr >> MPIDR_AFF1_SHIFT) & MPIDR_AFFLVL_MASK;
+#endif  /* ARM_PLAT_MT */
 	if (cpu >= 8 || cluster >= 0xf)
 		return -1;
 


### PR DESCRIPTION
The ARM_PLAT_MT bit enables the support for MT bit in
MPIDR format. This means that the level 0 affinity
represents the thread and CPU / Cluster levels are
at affinity level 1 and 2 respectively.
This was not catered for in the scpi 'css_scp_get_power_state, API.
Since the SCPI driver can only cater for single threaded CPUs,
this patch fixes the problem by catering for this shift by
effectively ignoring the Thread (level 0) affinity level.

Change-Id: If44f55c9fb2773c8d3f8a9bbcf5420a6f7409dfe
Signed-off-by: jagadeesh ujja <jagadeesh.ujja@arm.com>