### PR TITLE
plat: Hikey960: fix the CPU hotplug

### DIFF
--- a/plat/hisilicon/hikey960/hikey960_pm.c
+++ b/plat/hisilicon/hikey960/hikey960_pm.c
@@ -102,7 +102,7 @@ void hikey960_pwr_domain_off(const psci_power_state_t *target_state)
 	hisi_powerdn_core(cluster, core);
 
 	/* check if any core is powered up */
-	if (hisi_test_pwrdn_allcores(cluster, core)) {
+	if (hisi_test_cpu_down(cluster, core)) {
 
 		cci_disable_snoop_dvm_reqs(MPIDR_AFFLVL1_VAL(read_mpidr_el1()));
 


### PR DESCRIPTION
In CPU off callback function, the old code uses the function
hisi_test_pwrdn_allcores() to check if all CPUs in cluster have been
powered off and if it's valid then power off the whole cluster. But the
function hisi_test_pwrdn_allcores() only maintains the different power
states only for CPU suspend/resume flow, so it cannot return correct
states for CPU on/off flow.

This patch is to change use hisi_test_cpu_down() to check if all CPUs
have been powered off, so that can power off the whole cluster properly
when all CPUs in cluster have been hotplugged off.

Signed-off-by: Tao Wang <kevin.wangtao@hisilicon.com>
Signed-off-by: Leo Yan <leo.yan@linaro.org>