### PR TITLE
Adding coreboot support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,6 +276,11 @@ endif
 # This can be overridden by the platform.
 include lib/cpus/cpu-ops.mk
 
+ifeq (${COREBOOT},1)
+# Include coreboot support library when building with coreboot as BL2
+include lib/coreboot/coreboot.mk
+endif
+
 ifeq (${ARCH},aarch32)
 NEED_BL32 := yes
 
@@ -330,6 +335,12 @@ endif
 # use USE_COHERENT_MEM. Require that USE_COHERENT_MEM must be set to 0 too.
 ifeq ($(HW_ASSISTED_COHERENCY)-$(USE_COHERENT_MEM),1-1)
 $(error USE_COHERENT_MEM cannot be enabled with HW_ASSISTED_COHERENCY)
+endif
+
+ifeq (${COREBOOT},1)
+	ifneq (${ARCH},aarch64)
+	$(error "coreboot only supports Trusted Firmware on AArch64.")
+	endif
 endif
 
 ################################################################################
@@ -428,6 +439,7 @@ endif
 ################################################################################
 
 $(eval $(call assert_boolean,COLD_BOOT_SINGLE_CPU))
+$(eval $(call assert_boolean,COREBOOT))
 $(eval $(call assert_boolean,CREATE_KEYS))
 $(eval $(call assert_boolean,CTX_INCLUDE_AARCH32_REGS))
 $(eval $(call assert_boolean,CTX_INCLUDE_FPREGS))
@@ -470,6 +482,7 @@ $(eval $(call add_define,ARM_ARCH_MAJOR))
 $(eval $(call add_define,ARM_ARCH_MINOR))
 $(eval $(call add_define,ARM_GIC_ARCH))
 $(eval $(call add_define,COLD_BOOT_SINGLE_CPU))
+$(eval $(call add_define,COREBOOT))
 $(eval $(call add_define,CTX_INCLUDE_AARCH32_REGS))
 $(eval $(call add_define,CTX_INCLUDE_FPREGS))
 $(eval $(call add_define,ENABLE_ASSERTIONS))

--- a/bl31/aarch64/runtime_exceptions.S
+++ b/bl31/aarch64/runtime_exceptions.S
@@ -49,7 +49,8 @@
 	b.eq	smc_handler64
 
 	/* Other kinds of synchronous exceptions are not handled */
-	no_ret	report_unhandled_exception
+	ldr	x30, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_LR]
+	b	report_unhandled_exception
 	.endm
 
 
@@ -152,7 +153,7 @@ vector_base runtime_exceptions
 	 */
 vector_entry sync_exception_sp_el0
 	/* We don't expect any synchronous exceptions from EL3 */
-	no_ret	report_unhandled_exception
+	b	report_unhandled_exception
 	check_vector_size sync_exception_sp_el0
 
 vector_entry irq_sp_el0
@@ -160,17 +161,17 @@ vector_entry irq_sp_el0
 	 * EL3 code is non-reentrant. Any asynchronous exception is a serious
 	 * error. Loop infinitely.
 	 */
-	no_ret	report_unhandled_interrupt
+	b	report_unhandled_interrupt
 	check_vector_size irq_sp_el0
 
 
 vector_entry fiq_sp_el0
-	no_ret	report_unhandled_interrupt
+	b	report_unhandled_interrupt
 	check_vector_size fiq_sp_el0
 
 
 vector_entry serror_sp_el0
-	no_ret	report_unhandled_exception
+	b	report_unhandled_exception
 	check_vector_size serror_sp_el0
 
 	/* ---------------------------------------------------------------------
@@ -184,19 +185,19 @@ vector_entry sync_exception_sp_elx
 	 * synchronous exception. There is a high probability that SP_EL3 is
 	 * corrupted.
 	 */
-	no_ret	report_unhandled_exception
+	b	report_unhandled_exception
 	check_vector_size sync_exception_sp_elx
 
 vector_entry irq_sp_elx
-	no_ret	report_unhandled_interrupt
+	b	report_unhandled_interrupt
 	check_vector_size irq_sp_elx
 
 vector_entry fiq_sp_elx
-	no_ret	report_unhandled_interrupt
+	b	report_unhandled_interrupt
 	check_vector_size fiq_sp_elx
 
 vector_entry serror_sp_elx
-	no_ret	report_unhandled_exception
+	b	report_unhandled_exception
 	check_vector_size serror_sp_elx
 
 	/* ---------------------------------------------------------------------
@@ -226,7 +227,7 @@ vector_entry serror_aarch64
 	 * SError exceptions from lower ELs are not currently supported.
 	 * Report their occurrence.
 	 */
-	no_ret	report_unhandled_exception
+	b	report_unhandled_exception
 	check_vector_size serror_aarch64
 
 	/* ---------------------------------------------------------------------
@@ -256,7 +257,7 @@ vector_entry serror_aarch32
 	 * SError exceptions from lower ELs are not currently supported.
 	 * Report their occurrence.
 	 */
-	no_ret	report_unhandled_exception
+	b	report_unhandled_exception
 	check_vector_size serror_aarch32
 
 

--- a/bl32/tsp/aarch64/tsp_entrypoint.S
+++ b/bl32/tsp/aarch64/tsp_entrypoint.S
@@ -43,10 +43,7 @@
 	msr	spsr_el1, \reg2
 	.endm
 
-	.section	.text, "ax"
-	.align 3
-
-func tsp_entrypoint
+func tsp_entrypoint _align=3
 
 	/* ---------------------------------------------
 	 * Set the exception vector to something sane.

--- a/docs/porting-guide.rst
+++ b/docs/porting-guide.rst
@@ -2445,9 +2445,12 @@ of the CPU to enable quick crash analysis and debugging. It requires that a
 console is designated as the crash console by the platform which will be used to
 print the register dump.
 
-The following functions must be implemented by the platform if it wants crash
-reporting mechanism in BL31. The functions are implemented in assembly so that
-they can be invoked without a C Runtime stack.
+By default, the definitions in `plat/common/aarch64/platform\_helpers.S` will
+cause the crash output to be routed over the same console that was registered
+for boot messages. If necessary, platforms may supply their own definitions of
+the following functions to define special crash output behavior. The functions
+are implemented in assembly so that they can be invoked without a C Runtime
+stack.
 
 Function : plat\_crash\_console\_init
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2480,12 +2483,11 @@ Function : plat\_crash\_console\_flush
 ::
 
     Argument : void
-    Return   : int
+    Return   : void
 
 This API is used by the crash reporting mechanism to force write of all buffered
 data on the designated crash console. It should only use general purpose
-registers x0 and x1 to do its work. The return value is 0 on successful
-completion; otherwise the return value is -1.
+registers x0 and x1 to do its work.
 
 Build flags
 -----------

--- a/drivers/arm/pl011/aarch64/pl011_console.S
+++ b/drivers/arm/pl011/aarch64/pl011_console.S
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <arch.h>
-#include <asm_macros.S>
+#include <console_macros.S>
 #include <pl011.h>
 
 /*
@@ -13,15 +13,10 @@
  */
 #include "../../../console/aarch64/console.S"
 
-
-	.globl	console_core_init
-	.globl	console_core_putc
-	.globl	console_core_getc
-	.globl	console_core_flush
-
+	declare_console pl011
 
 	/* -----------------------------------------------
-	 * int console_core_init(uintptr_t base_addr,
+	 * int console_pl011_init(uintptr_t base_addr,
 	 * unsigned int uart_clk, unsigned int baud_rate)
 	 * Function to initialize the console without a
 	 * C Runtime to print debug information. This
@@ -34,7 +29,7 @@
 	 * Clobber list : x1, x2, x3, x4
 	 * -----------------------------------------------
 	 */
-func console_core_init
+func_console_init pl011
 	/* Check the input base address */
 	cbz	x0, core_init_fail
 #if !PL011_GENERIC_UART
@@ -71,19 +66,18 @@ func console_core_init
 core_init_fail:
 	mov	w0, wzr
 	ret
-endfunc console_core_init
+endfunc console_pl011_init
 
 	/* --------------------------------------------------------
-	 * int console_core_putc(int c, uintptr_t base_addr)
-	 * Function to output a character over the console. It
-	 * returns the character printed on success or -1 on error.
+	 * void console_core_putc(int c, uintptr_t base_addr)
+	 * Function to output a character over the console. Must
+	 * not change the value in x0.
 	 * In : w0 - character to be printed
 	 *      x1 - console base address
-	 * Out : return -1 on error else return character.
 	 * Clobber list : x2
 	 * --------------------------------------------------------
 	 */
-func console_core_putc
+func_console_putc pl011
 	/* Check the input parameter */
 	cbz	x1, putc_error
 	/* Prepend '\r' to '\n' */
@@ -100,45 +94,41 @@ func console_core_putc
 	ldr	w2, [x1, #UARTFR]
 	tbnz	w2, #PL011_UARTFR_TXFF_BIT, 2b
 	str	w0, [x1, #UARTDR]
-	ret
 putc_error:
-	mov	w0, #-1
 	ret
-endfunc console_core_putc
+endfunc console_pl011_putc
 
 	/* ---------------------------------------------
-	 * int console_core_getc(uintptr_t base_addr)
+	 * int console_pl011_getc(uintptr_t base_addr)
 	 * Function to get a character from the console.
 	 * It returns the character grabbed on success
-	 * or -1 on error.
+	 * or -1 if no character is available.
 	 * In : x0 - console base address
 	 * Clobber list : x0, x1
 	 * ---------------------------------------------
 	 */
-func console_core_getc
-	cbz	x0, getc_error
-1:
+func_console_getc pl011
+	cbz	x0, getc_no_char
 	/* Check if the receive FIFO is empty */
 	ldr	w1, [x0, #UARTFR]
-	tbnz	w1, #PL011_UARTFR_RXFE_BIT, 1b
+	tbnz	w1, #PL011_UARTFR_RXFE_BIT, getc_no_char
 	ldr	w1, [x0, #UARTDR]
 	mov	w0, w1
 	ret
-getc_error:
+getc_no_char:
 	mov	w0, #-1
 	ret
-endfunc console_core_getc
+endfunc console_pl011_getc
 
 	/* ---------------------------------------------
-	 * int console_core_flush(uintptr_t base_addr)
+	 * void console_core_flush(uintptr_t base_addr)
 	 * Function to force a write of all buffered
 	 * data that hasn't been output.
 	 * In : x0 - console base address
-	 * Out : return -1 on error else return 0.
 	 * Clobber list : x0, x1
 	 * ---------------------------------------------
 	 */
-func console_core_flush
+func_console_flush pl011
 	cbz	x0, flush_error
 
 1:
@@ -146,9 +136,6 @@ func console_core_flush
 	ldr	w1, [x0, #UARTFR]
 	tbnz	w1, #PL011_UARTFR_BUSY_BIT, 1b
 
-	mov	w0, #0
-	ret
 flush_error:
-	mov	w0, #-1
 	ret
-endfunc console_core_flush
+endfunc console_pl011_flush

--- a/drivers/cadence/uart/aarch64/cdns_console.S
+++ b/drivers/cadence/uart/aarch64/cdns_console.S
@@ -4,16 +4,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <arch.h>
-#include <asm_macros.S>
+#include <console_macros.S>
 #include <cadence/cdns_uart.h>
 
-	.globl  console_core_init
-	.globl  console_core_putc
-	.globl  console_core_getc
-	.globl	console_core_flush
+declare_console cadence
 
 	/* -----------------------------------------------
-	 * int console_core_init(unsigned long base_addr,
+	 * int console_cadence_init(unsigned long base_addr,
 	 * unsigned int uart_clk, unsigned int baud_rate)
 	 * Function to initialize the console without a
 	 * C Runtime to print debug information. This
@@ -29,7 +26,7 @@
 	 * Clobber list : x1, x2, x3
 	 * -----------------------------------------------
 	 */
-func console_core_init
+func_console_init cadence
 	/* Check the input base address */
 	cbz	x0, core_init_fail
 	/* Check baud rate and uart clock for sanity */
@@ -45,19 +42,18 @@ func console_core_init
 core_init_fail:
 	mov	w0, wzr
 	ret
-endfunc console_core_init
+endfunc console_cadence_init
 
 	/* --------------------------------------------------------
-	 * int console_core_putc(int c, unsigned long base_addr)
-	 * Function to output a character over the console. It
-	 * returns the character printed on success or -1 on error.
+	 * void console_cadence_putc(int c, unsigned long base_addr)
+	 * Function to output a character over the console. Must
+	 * not modify the value in x0.
 	 * In : w0 - character to be printed
 	 *      x1 - console base address
-	 * Out : return -1 on error else return character.
 	 * Clobber list : x2
 	 * --------------------------------------------------------
 	 */
-func console_core_putc
+func_console_putc cadence
 	/* Check the input parameter */
 	cbz	x1, putc_error
 	/* Prepend '\r' to '\n' */
@@ -76,44 +72,41 @@ func console_core_putc
 	str	w0, [x1, #R_UART_TX]
 	ret
 putc_error:
-	mov	w0, #-1
 	ret
-endfunc console_core_putc
+endfunc console_cadence_putc
 
 	/* ---------------------------------------------
-	 * int console_core_getc(unsigned long base_addr)
+	 * int console_cadence_getc(unsigned long base_addr)
 	 * Function to get a character from the console.
 	 * It returns the character grabbed on success
-	 * or -1 on error.
+	 * or -1 if no character is available.
 	 * In : x0 - console base address
 	 * Clobber list : x0, x1
 	 * ---------------------------------------------
 	 */
-func console_core_getc
-	cbz	x0, getc_error
-1:
+func_console_getc cadence
+	cbz	x0, getc_no_char
 	/* Check if the receive FIFO is empty */
 	ldr	w1, [x0, #R_UART_SR]
-	tbnz	w1, #UART_SR_INTR_REMPTY_BIT, 1b
+	tbnz	w1, #UART_SR_INTR_REMPTY_BIT, getc_no_char
 	ldr	w1, [x0, #R_UART_RX]
 	mov	w0, w1
 	ret
-getc_error:
+getc_no_char:
 	mov	w0, #-1
 	ret
-endfunc console_core_getc
+endfunc console_cadence_getc
 
 	/* ---------------------------------------------
-	 * int console_core_flush(uintptr_t base_addr)
+	 * void console_cadence_flush(uintptr_t base_addr)
 	 * Function to force a write of all buffered
 	 * data that hasn't been output.
 	 * In : x0 - console base address
-	 * Out : return -1 on error else return 0.
 	 * Clobber list : x0, x1
 	 * ---------------------------------------------
 	 */
-func console_core_flush
+func_console_flush cadence
 	/* Placeholder */
 	mov	w0, #0
 	ret
-endfunc console_core_flush
+endfunc console_cadence_flush

--- a/drivers/console/aarch64/console.S
+++ b/drivers/console/aarch64/console.S
@@ -3,103 +3,240 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#include <asm_macros.S>
 
-	.globl	console_init
+#include <console_macros.S>
+
+	.globl	console_register
+	.globl	console_unregister
 	.globl	console_uninit
+	.globl	console_start_crash
 	.globl	console_putc
 	.globl	console_getc
 	.globl	console_flush
 
 	/*
-	 *  The console base is in the data section and not in .bss
-	 *  even though it is zero-init. In particular, this allows
+	 *  The console list pointer is in the data section and not in
+	 *  .bss even though it is zero-init. In particular, this allows
 	 *  the console functions to start using this variable before
 	 *  the runtime memory is initialized for images which do not
 	 *  need to copy the .data section from ROM to RAM.
 	 */
-.section .data.console_base ; .align 3
-	console_base: .quad 0x0
+.section .data.console_list ; .align 3
+	console_list: .quad 0x0
+.section .data.console_state ; .align 0
+	console_state: .byte (1 << CONSOLE_FLAG_BOOT_SHIFT)
 
+	/* -----------------------------------------------
+	 * void console_register(console_info_t *console)
+	 * Function to insert a new console structure into
+	 * the console list. Should usually only be called
+	 * by declare_console expansions.
+	 * In : x0 - address of console structure
+	 * Clobber list: x0, x1, x14
+	 * -----------------------------------------------
+	 */
+func console_register
+	adrp	x14, console_list
+	ldr	x1, [x14, :lo12:console_list]	/* X1 = first struct in list */
+	str	x0, [x14, :lo12:console_list]	/* list head = new console */
+	str	x1, [x0]			/* new console next ptr = X1 */
+	ret
+endfunc console_register
+
+#if !ERROR_DEPRECATED
+	/* Set up compatiblity symbols for platforms using old console API. */
+	declare_console core
+
+	.globl	console_init
 	/* -----------------------------------------------
 	 * int console_init(uintptr_t base_addr,
 	 * unsigned int uart_clk, unsigned int baud_rate)
-	 * Function to initialize the console without a
-	 * C Runtime to print debug information. It saves
-	 * the console base to the data section.
+	 * Deprecated legacy function for initializing a
+	 * single console. Current platforms should call
+	 * console_<driver>_register for the relevant
+	 * driver instead. This needs to clear the console
+	 * list first because some legacy platforms called
+	 * console_init more than once and expect it to
+	 * overwrite previous console state.
 	 * In: x0 - console base address
 	 *     w1 - Uart clock in Hz
 	 *     w2 - Baud rate
-	 * out: return 1 on success else 0 on error
-	 * Clobber list : x1 - x4
+	 * Clobber list : x0 - x4, x14, x15
 	 * -----------------------------------------------
 	 */
 func console_init
-	/* Check the input base address */
-	cbz	x0, init_fail
-	adrp	x3, console_base
-	str	x0, [x3, :lo12:console_base]
-	b	console_core_init
-init_fail:
-	ret
+	adrp	x14, console_list
+	str	xzr, [x14, :lo12:console_list]
+	b	console_core_register
 endfunc console_init
+#endif
+
+	/* -----------------------------------------------
+	 * console_info_t *console_unregister(
+	 *                        console_info_t *console)
+	 * Function to find a specific console in the list
+	 * of currently active consoles and remove it.
+	 * Should usually only be called by
+	 * declare_console expansions.
+	 * In: x0 - address of console structure to remove
+	 * Out: x0 - removed address, or NULL if not found
+	 * Clobber list: x0, x1, x14
+	 * -----------------------------------------------
+	 */
+func console_unregister
+	adrp	x14, console_list
+	add	x14, x14, :lo12:console_list	/* X14 = ptr to first struct */
+	ldr	x1, [x14]			/* X3 = first struct */
+
+unregister_loop:
+	cbz	x1, unregister_not_found
+	cmp	x0, x1
+	b.eq	unregister_found
+	ldr	x14, [x14]			/* X14 = next ptr of struct */
+	ldr	x1, [x14]			/* X1 = next struct */
+	b	unregister_loop
+
+unregister_found:
+	ldr	x1, [x1]			/* X1 = next struct */
+	str	x1, [x14]			/* prev->next = cur->next */
+	ret
+
+unregister_not_found:
+	mov	x0, #0				/* return NULL if not found */
+	ret
+endfunc console_unregister
 
 	/* -----------------------------------------------
 	 * void console_uninit(void)
-	 * Function to finish the use of console driver.
-	 * It sets the console_base as NULL so that any
-	 * further invocation of `console_putc` or
-	 * `console_getc` APIs would return error.
+	 * Function to switch from boot to runtime state.
+	 * The name is misleading for compatibility with
+	 * the legacy API -- this used to uninitialize all
+	 * consoles, but now it just quiesces consoles
+	 * that are not marked as "runtime".
+	 * Clobber list: x0, x1
 	 * -----------------------------------------------
 	 */
 func console_uninit
-	mov	x0, #0
-	adrp	x3, console_base
-	str	x0, [x3, :lo12:console_base]
+	mov	w0, #(1 << CONSOLE_FLAG_RUNTIME_SHIFT)
+	adrp	x1, console_state
+	strb	w0, [x1, :lo12:console_state]
 	ret
 endfunc console_uninit
 
+	/* -----------------------------------------------
+	 * int console_start_crash(void)
+	 * Function to switch to crash state. Returns 1 in
+	 * x0 for convenience with plat_crash_console_init
+	 * Out: x0 - always 1
+	 * Clobber list: x0, x1
+	 * -----------------------------------------------
+	 */
+func console_start_crash
+	mov	w0, #(1 << CONSOLE_FLAG_CRASH_SHIFT)
+	adrp	x1, console_state
+	strb	w0, [x1, :lo12:console_state]
+	mov	x0, #1
+	ret
+endfunc console_start_crash
+
 	/* ---------------------------------------------
-	 * int console_putc(int c)
-	 * Function to output a character over the
-	 * console. It returns the character printed on
-	 * success or -1 on error.
+	 * void console_putc(int c)
+	 * Function to output a character. Calls all
+	 * console's putc() handlers in succession.
 	 * In : x0 - character to be printed
-	 * Out : return -1 on error else return character.
-	 * Clobber list : x1, x2
+	 * Clobber list : x1, x2, x14, x15
 	 * ---------------------------------------------
 	 */
 func console_putc
-	adrp	x2, console_base
-	ldr	x1, [x2, :lo12:console_base]
-	b	console_core_putc
+	mov	x15, x30
+	adrp	x14, console_list
+	ldr	x14, [x14, :lo12:console_list]	/* X14 = first console struct */
+
+putc_loop:
+	cbz	x14, putc_done
+	adrp	x1, console_state
+	ldrb	w1, [x1, :lo12:console_state]
+	ldr	x2, [x14, #CONSOLE_INFO_FLAGS]
+	tst	w1, w2
+	b.eq	putc_continue
+	ldr	x1, [x14, #CONSOLE_INFO_BASE]
+	ldr	x2, [x14, #CONSOLE_INFO_PUTC]
+	cbz	x2, putc_continue
+	blr	x2
+putc_continue:
+	ldr	x14, [x14]			/* X14 = next struct */
+	b	putc_loop
+
+putc_done:
+	ret	x15
 endfunc console_putc
 
 	/* ---------------------------------------------
 	 * int console_getc(void)
-	 * Function to get a character from the console.
-	 * It returns the character grabbed on success
-	 * or -1 on error.
-	 * Clobber list : x0, x1
+	 * Function to get a character from any console.
+	 * Keeps looping through all consoles' getc()
+	 * handlers until one of them returns a
+	 * character, then stops iterating and returns
+	 * that character to the caller.
+	 * Out : x0 - read character, or -1 if none
+	 * Clobber list : x0, x1, x14, x15
 	 * ---------------------------------------------
 	 */
 func console_getc
-	adrp	x1, console_base
-	ldr	x0, [x1, :lo12:console_base]
-	b	console_core_getc
+	mov	x15, x30
+getc_try_again:
+	adrp	x14, console_list
+	ldr	x14, [x14, :lo12:console_list]	/* X14 = first console struct */
+
+getc_loop:
+	cbz	x14, getc_try_again		/* if list ended, start again */
+	adrp	x0, console_state
+	ldrb	w0, [x0, :lo12:console_state]
+	ldr	x1, [x14, #CONSOLE_INFO_FLAGS]
+	tst	w0, w1
+	b.eq	getc_continue
+	ldr	x0, [x14, #CONSOLE_INFO_BASE]
+	ldr	x1, [x14, #CONSOLE_INFO_GETC]
+	cbz	x1, getc_continue
+	blr	x1
+	cmp	x0, #0				/* if X0 >= 0: return */
+	b.ge	getc_done
+getc_continue:
+	ldr	x14, [x14]			/* X14 = next struct */
+	b	getc_loop
+
+getc_found:
+	ret	x15
 endfunc console_getc
 
 	/* ---------------------------------------------
-	 * int console_flush(void)
+	 * void console_flush(void)
 	 * Function to force a write of all buffered
-	 * data that hasn't been output. It returns 0
-	 * upon successful completion, otherwise it
-	 * returns -1.
-	 * Clobber list : x0, x1
+	 * data that hasn't been output. Calls all
+	 * console's flush() handlers in succession.
+	 * Clobber list : x0, x1, x2, x3, x14, x15
 	 * ---------------------------------------------
 	 */
 func console_flush
-	adrp	x1, console_base
-	ldr	x0, [x1, :lo12:console_base]
-	b	console_core_flush
+	mov	x15, x30
+	adrp	x14, console_list
+	ldr	x14, [x14, :lo12:console_list]	/* X14 = first console struct */
+
+flush_loop:
+	cbz	x14, flush_done
+	adrp	x1, console_state
+	ldrb	w1, [x1, :lo12:console_state]
+	ldr	x2, [x14, #CONSOLE_INFO_FLAGS]
+	tst	w1, w2
+	b.eq	flush_continue
+	ldr	x1, [x14, #CONSOLE_INFO_BASE]
+	ldr	x2, [x14, #CONSOLE_INFO_FLUSH]
+	cbz	x2, flush_continue
+	blr	x2
+flush_continue:
+	ldr	x14, [x14]			/* X14 = next struct */
+	b	flush_loop
+
+flush_done:
+	ret	x15
 endfunc console_flush

--- a/drivers/console/aarch64/skeleton_console.S
+++ b/drivers/console/aarch64/skeleton_console.S
@@ -3,100 +3,97 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#include <asm_macros.S>
+#include <console_macros.S>
 
 	/*
 	 * This file contains a skeleton console implementation that can
 	 * be used as basis for a real console implementation by platforms
-	 * that do not contain PL011 hardware.
+	 * that do not contain PL011 hardware. Find and replace 'skeleton'
+	 * with your driver name. You only need to implement init(), all
+	 * other functions are optional and can be deleted.
+	 * See include/common/aarch64/console_macros.S for details.
 	 */
 
-	.globl	console_core_init
-	.globl	console_core_putc
-	.globl	console_core_getc
-	.globl	console_core_flush
+declare_console skeleton
 
 	/* -----------------------------------------------
-	 * int console_core_init(uintptr_t base_addr,
-	 * unsigned int uart_clk, unsigned int baud_rate)
+	 * int console_skeleton_init(uintptr_t base_addr,
+	 * ...additional arguments...)
 	 * Function to initialize the console without a
 	 * C Runtime to print debug information. This
 	 * function will be accessed by console_init and
 	 * crash reporting.
 	 * In: x0 - console base address
-	 *     w1 - Uart clock in Hz
-	 *     w2 - Baud rate
+	 *     x1...x7 - optional console-specific args
 	 * Out: return 1 on success else 0 on error
-	 * Clobber list : x1, x2
+	 * Clobber list : x0 - x7
 	 * -----------------------------------------------
 	 */
-func console_core_init
+func_console_init skeleton
 	/* Check the input base address */
 	cbz	x0, core_init_fail
-	/* Check baud rate and uart clock for sanity */
-	cbz	w1, core_init_fail
-	cbz	w2, core_init_fail
+
 	/* Insert implementation here */
+
 	mov	w0, #1
 	ret
 core_init_fail:
 	mov	w0, wzr
 	ret
-endfunc console_core_init
+endfunc console_skeleton_init
 
 	/* --------------------------------------------------------
-	 * int console_core_putc(int c, uintptr_t base_addr)
-	 * Function to output a character over the console. It
-	 * returns the character printed on success or -1 on error.
+	 * int console_skeleton_putc(int c, uintptr_t base_addr)
+	 * Function to output a character over the console. It must
+	 * preserve the value in x0 unchanged.
 	 * In : w0 - character to be printed
 	 *      x1 - console base address
-	 * Out : return -1 on error else return character.
-	 * Clobber list : x2
+	 * Clobber list : x1, x2 (NOT x0!!!)
 	 * --------------------------------------------------------
 	 */
-func console_core_putc
+func_console_putc skeleton
 	/* Check the input parameter */
 	cbz	x1, putc_error
+
 	/* Insert implementation here */
-	ret
+
 putc_error:
-	mov	w0, #-1
 	ret
-endfunc console_core_putc
+endfunc console_skeleton_putc
 
 	/* ---------------------------------------------
-	 * int console_core_getc(uintptr_t base_addr)
+	 * int console_skeleton_getc(uintptr_t base_addr)
 	 * Function to get a character from the console.
 	 * It returns the character grabbed on success
-	 * or -1 on error.
+	 * or -1 if no character available.
 	 * In : x0 - console base address
 	 * Clobber list : x0, x1
 	 * ---------------------------------------------
 	 */
-func console_core_getc
-	cbz	x0, getc_error
+func_console_getc skeleton
+	cbz	x0, getc_no_char
+
 	/* Insert implementation here */
+
 	ret
-getc_error:
+getc_no_char:
 	mov	w0, #-1
 	ret
-endfunc console_core_getc
+endfunc console_skeleton_getc
 
 	/* ---------------------------------------------
-	 * int console_core_flush(uintptr_t base_addr)
+	 * void console_skeleton_flush(uintptr_t base_addr)
 	 * Function to force a write of all buffered
 	 * data that hasn't been output.
 	 * In : x0 - console base address
-	 * Out : return -1 on error else return 0.
-	 * Clobber list : x0, x1
+	 * Clobber list : x0 - x3
 	 * ---------------------------------------------
 	 */
-func console_core_flush
+func_console_flush skeleton
 	cbz	x0, flush_error
+
 	/* Insert implementation here */
-	mov	w0, #0
-	ret
+
 flush_error:
-	mov	w0, #-1
 	ret
-endfunc console_core_flush
+endfunc console_skeleton_flush

--- a/drivers/coreboot/cbmem_console/aarch64/cbmem_console.S
+++ b/drivers/coreboot/cbmem_console/aarch64/cbmem_console.S
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <console_macros.S>
+
+/*
+ * This driver implements access to coreboot's in-memory console
+ * (CBMEM console). For the original implementation, see
+ * <coreboot>/src/lib/cbmem_console.c.
+ */
+
+declare_console cbmc _runtime=1
+
+.section .data.cbmc_size ; .align 2
+	cbmc_size: .word 0x0
+
+	/* -----------------------------------------------
+	 * int console_cbmc_init(uintptr_t base)
+	 * Reads the size field from the structure and
+	 * stores it in the data section. This is so that
+	 * we have a size we can trust later on, since a
+	 * malicious EL1 could manipulate the console
+	 * buffer (including the header) at runtime.
+	 * In: x0 - CBMEM console base address
+	 * Out: returns 1 to indicate success
+	 * Clobber list: x0, x2
+	 * -----------------------------------------------
+	 */
+func_console_init cbmc
+	ldr	w2, [x0]
+	adrp	x0, cbmc_size
+	str	w2, [x0, :lo12:cbmc_size]
+	mov	x0, #1
+	ret
+endfunc console_cbmc_init
+
+	/* -----------------------------------------------
+	 * int console_cbmc_puts(int c, uintptr_t base)
+	 * Writes a character to the CBMEM console buffer,
+	 * including overflow handling of the cursor field.
+	 * The character must be preserved in x0.
+	 * In: x0 - character to be stored
+	 *     x1 - CBMEM console base address
+	 * Clobber list: x1, x2, x16, x17
+	 * -----------------------------------------------
+	 */
+func_console_putc cbmc
+	add	x1, x1, #8		/* keep address of body in X1 */
+	adrp	x2, cbmc_size		/* keep known-good size in X2 */
+	ldr	w2, [x2, :lo12:cbmc_size]
+
+	ldr	w16, [x1, #-4]		/* load cursor (one u32 before body) */
+	and	w17, w16, #0xf0000000	/* keep flags part in W17 */
+	and	w16, w16, #0x0fffffff	/* keep actual cursor part in W16 */
+
+	cmp	w16, w2			/* if cursor >= size... */
+	b.hs	putc_return		/* ...return (must be malicious!) */
+
+	strb	w0, [x1, w16, uxtw]	/* body[cursor] = character */
+	add	w16, w16, #1		/* cursor++ */
+	cmp	w16, w2			/* if cursor < size... */
+	b.lt	putc_write_back		/* skip overflow handling */
+
+	mov	w16, #0			/* on overflow, set cursor back to 0 */
+	orr	w17, w17, #(1 << 31)	/* and set overflow flag */
+
+putc_write_back:
+	orr	w16, w16, w17		/* merge cursor and flags back */
+	str	w16, [x1, #-4]		/* write back cursor to memory */
+
+putc_return:
+	ret
+endfunc	console_cbmc_putc
+
+	/* -----------------------------------------------
+	 * int console_cbmc_flush(uintptr_t base)
+	 * Flushes the CBMEM console by flushing the
+	 * console buffer from the cache.
+	 * In: x0 - CBMEM console base address
+	 * Clobber list: x0, x1, x2, x3
+	 * -----------------------------------------------
+	 */
+func coreboot_cbmc_flush
+	adrp	x1, cbmc_size		/* load size of console body */
+	ldr	w1, [x1, :lo12:cbmc_size]
+	add	x1, x1, #8		/* add size of console header */
+	b	clean_dcache_range	/* (clobbers x2 and x3) */
+endfunc coreboot_cbmc_flush

--- a/drivers/ti/uart/aarch64/16550_console.S
+++ b/drivers/ti/uart/aarch64/16550_console.S
@@ -5,16 +5,13 @@
  */
 
 #include <arch.h>
-#include <asm_macros.S>
+#include <console_macros.S>
 #include <uart_16550.h>
 
-	.globl	console_core_init
-	.globl	console_core_putc
-	.globl	console_core_getc
-	.globl	console_core_flush
+declare_console 16550
 
 	/* -----------------------------------------------
-	 * int console_core_init(unsigned long base_addr,
+	 * int console_16550_init(unsigned long base_addr,
 	 * unsigned int uart_clk, unsigned int baud_rate)
 	 * Function to initialize the console without a
 	 * C Runtime to print debug information. This
@@ -27,7 +24,7 @@
 	 * Clobber list : x1, x2, x3
 	 * -----------------------------------------------
 	 */
-func console_core_init
+func_console_init 16550
 	/* Check the input base address */
 	cbz	x0, init_fail
 	/* Check baud rate and uart clock for sanity */
@@ -65,22 +62,18 @@ func console_core_init
 	mov	w0, #1
 init_fail:
 	ret
-endfunc console_core_init
+endfunc console_16550_init
 
 	/* --------------------------------------------------------
-	 * int console_core_putc(int c, unsigned int base_addr)
-	 * Function to output a character over the console. It
-	 * returns the character printed on success or -1 on error.
+	 * void console_16550_putc(int c, unsigned int base_addr)
+	 * Function to output a character over the console. Does
+	 * not overwrite x0.
 	 * In : w0 - character to be printed
 	 *      x1 - console base address
-	 * Out : return -1 on error else return character.
 	 * Clobber list : x2
 	 * --------------------------------------------------------
 	 */
-func console_core_putc
-	/* Check the input parameter */
-	cbz	x1, putc_error
-
+func_console_putc 16550
 	/* Prepend '\r' to '\n' */
 	cmp	w0, #0xA
 	b.ne	2f
@@ -98,44 +91,41 @@ func console_core_putc
 	cmp	w2, #(UARTLSR_TEMT | UARTLSR_THRE)
 	b.ne	2b
 	str	w0, [x1, #UARTTX]
-	ret
 putc_error:
-	mov	w0, #-1
 	ret
-endfunc console_core_putc
+endfunc console_16550_putc
 
 	/* ---------------------------------------------
-	 * int console_core_getc(void)
+	 * int console_16550_getc(void)
 	 * Function to get a character from the console.
 	 * It returns the character grabbed on success
 	 * or -1 on error.
 	 * In : w0 - console base address
-	 * Out : return -1 on error else return character.
+	 * Out : return character if available, else -1
 	 * Clobber list : x0, x1
 	 * ---------------------------------------------
 	 */
-func console_core_getc
+func_console_getc 16550
 	/* Check if the receive FIFO is empty */
 1:	ldr	w1, [x0, #UARTLSR]
-	tbz	w1, #UARTLSR_RDR_BIT, 1b
+	tbz	w1, #UARTLSR_RDR_BIT, no_char
 	ldr	w0, [x0, #UARTRX]
 	ret
-getc_error:
+no_char:
 	mov	w0, #-1
 	ret
-endfunc console_core_getc
+endfunc console_16550_getc
 
 	/* ---------------------------------------------
-	 * int console_core_flush(uintptr_t base_addr)
+	 * void console_16550_flush(uintptr_t base_addr)
 	 * Function to force a write of all buffered
 	 * data that hasn't been output.
 	 * In : x0 - console base address
-	 * Out : return -1 on error else return 0.
 	 * Clobber list : x0, x1
 	 * ---------------------------------------------
 	 */
-func console_core_flush
+func_console_flush 16550
 	/* Placeholder */
 	mov	w0, #0
 	ret
-endfunc console_core_flush
+endfunc console_16550_flush

--- a/include/common/aarch64/console_macros.S
+++ b/include/common/aarch64/console_macros.S
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#ifndef __CONSOLE_MACROS_S__
+#define __CONSOLE_MACROS_S__
+
+#include <asm_macros.S>
+#include <console.h>
+
+/*
+ * This file defines macros for use by console drivers that want to hook into
+ * the generic console API. Each console driver needs to include this file, add
+ * a declare_console directive and implement at least func_console_init. All
+ * other functions are optional. Functions need to be declared through these
+ * macros to provide backwards-compatiblity with the previous console API for
+ * older platform code. All functions need to take care to obey the register
+ * restrictions outlined below and not change any register not explicitly listed
+ * in the clobber list. In addition to the listed registers, implementations are
+ * always allowed to use the intra-procedure-call registers (X16 and X17) as
+ * temporary scratch registers within a single function.
+ */
+
+	/* ------------------------------------------------
+	 * int console_<driver>_init(uintptr_t baseaddr,
+	 *                           ...args...)
+	 * Initializes the console. Will be called directly
+	 * from console_<driver>_register and receive any
+	 * arguments in x0-x7 unchanged from it. x0 is
+	 * intended to be a base address pointer, but can
+	 * be used for any purpose. It will be stored in
+	 * the console structure and passed in to every
+	 * other callback for this console.
+	 * In: x0 - driver-specific base address
+	 *     x1...x7 - optional extra arguments
+	 * Out: x0 - 1 for success, 0 for error
+	 * Clobber list: x0 - x7
+	 * ------------------------------------------------
+	 */
+.macro func_console_init _driver
+	func console_\_driver\()_init
+	.globl console_core_init
+	.weak console_core_init
+	console_core_init:
+.endm
+
+	/* ------------------------------------------------
+	 * void console_<driver>_putc(int c, uintptr_t base)
+	 * Outputs the character c on the console. Has no
+	 * return value and must preserve x0 even on error.
+	 * In: x0 - character to output
+	 *     x1 - baseaddr passed in on initialization
+	 * Clobber list: x1, x2 (NOT x0!!!)
+	 * ------------------------------------------------
+	 */
+.macro func_console_putc _driver
+	func console_\_driver\()_putc
+	.globl console_core_putc
+	.weak console_core_putc
+	console_core_putc:
+.endm
+
+	/* ------------------------------------------------
+	 * int console_<driver>_getc(uintptr_t baseaddr)
+	 * Reads a character from the console.
+	 * In: x0 - baseaddr passed in on initialization
+	 * Out: x0 - read character, or -1 if not available
+	 * Clobber list: x0, x1
+	 * ------------------------------------------------
+	 */
+.macro func_console_getc _driver
+	func console_\_driver\()_getc
+	.globl console_core_getc
+	.weak console_core_getc
+	console_core_getc:
+.endm
+
+	/* ------------------------------------------------
+	 * void console_<driver>_flush(uintptr_t baseaddr)
+	 * Write out all buffered data. Should only return
+	 * after the buffers have been completely flushed
+	 * (or on an unrecoverable error condition).
+	 * In: x0 - baseaddr passed in on initialization
+	 * Clobber list: x0, x1, x2, x3
+	 * ------------------------------------------------
+	 */
+.macro func_console_flush _driver
+	func console_\_driver\()_flush
+	.globl console_core_flush
+	.weak console_core_flush
+	console_core_flush:
+.endm
+
+.macro declare_console _driver _boot=1 _runtime=0 _crash=1
+	.section .data.console_\_driver\()_info
+	.align 3
+	console_\_driver\()_info:
+	.quad 0x0
+	.quad (\_boot << CONSOLE_FLAG_BOOT_SHIFT) | \
+	      (\_runtime << CONSOLE_FLAG_RUNTIME_SHIFT) | \
+	      (\_crash << CONSOLE_FLAG_CRASH_SHIFT)
+	.quad 0x0
+	.quad console_\_driver\()_putc
+	.quad console_\_driver\()_getc
+	.quad console_\_driver\()_flush
+
+	/* --------------------------------------------------
+	 * int console_<driver>_register(uintptr_t base, ...)
+	 * Registers the <driver> console in the list of
+	 * active consoles. Calls console_<driver>_init and
+	 * passes all arguments in x0-x7 through to it
+	 * unchanged. The meaning of the arguments depends
+	 * on the implementation of console_<driver>_init.
+	 * In: x0...x7 - arguments for console_<driver>_init
+	 * Out: x0 - return value from console_<driver>_init
+	 * Clobber list: x0 - x7, x14, x15
+	 * --------------------------------------------------
+	 */
+	.globl console_\_driver\()_register
+	func console_\_driver\()_register
+		mov	x15, x30
+		adrp	x14, console_\_driver\()_info
+		add	x14, x14, :lo12:console_\_driver\()_info
+		str	x0, [x14, #CONSOLE_INFO_BASE]
+		bl	console_\_driver\()_init
+		cbz	x0, 1f
+		mov	x0, x14
+		bl	console_register
+		mov	x0, #1
+	1:	ret	x15
+	endfunc console_\_driver\()_register
+
+	/* --------------------------------------------------
+	 * struct console_info *console_<driver>_unregister(void)
+	 * Removes the <driver> console from the list of
+	 * active consoles.
+	 * Out: x0 - address of removed console_info struct,
+	 *           or NULL if the console wasn't in the list
+	 * Clobber list: x0, x1, x14
+	 * --------------------------------------------------
+	 */
+	.globl console_\_driver\()_unregister
+	func console_\_driver\()_unregister
+		adrp	x0, console_\_driver\()_info
+		add	x0, x0, :lo12:console_\_driver\()_info
+		b	console_unregister
+	endfunc console_\_driver\()_unregister
+
+	/* Mark all callbacks as weak so their implementation is optional. */
+	.weak console_\_driver\()_putc
+	.weak console_\_driver\()_getc
+	.weak console_\_driver\()_flush
+	.weak console_\_driver\()_uninit
+.endm
+
+#endif /* __CONSOLE_MACROS_S__ */

--- a/include/common/asm_macros_common.S
+++ b/include/common/asm_macros_common.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -11,9 +11,12 @@
 	 * code into a separate text section based on the function name
 	 * to enable elimination of unused code during linking. It also adds
 	 * basic debug information to enable call stack printing most of the
-	 * time.
+	 * time. The optional _align parameter can be used to force a
+	 * non-standard alignment (indicated in powers of 2). Do *not* try to
+	 * use a raw .align directive. Since func switches to a new section,
+	 * this would not have the desired effect.
 	 */
-	.macro func _name
+	.macro func _name, _align=-1
 	/*
 	 * Add Call Frame Information entry in the .debug_frame section for
 	 * debugger consumption. This enables callstack printing in debuggers.
@@ -33,6 +36,9 @@
 	 * .debug_frame
 	 */
 	.cfi_startproc
+	.if (\_align) != -1
+		.align \_align
+	.endif
 	\_name:
 	.endm
 

--- a/include/drivers/arm/pl011.h
+++ b/include/drivers/arm/pl011.h
@@ -79,4 +79,12 @@
 
 #endif /* !PL011_GENERIC_UART */
 
+#ifndef __ASSEMBLY__
+
+#include <types.h>
+
+int console_pl011_register(uint64_t baseaddr, uint64_t clock, uint64_t baud);
+
+#endif /*__ASSEMBLY__*/
+
 #endif	/* __PL011_H__ */

--- a/include/drivers/cadence/cdns_uart.h
+++ b/include/drivers/cadence/cdns_uart.h
@@ -23,4 +23,12 @@
 #define R_UART_TX	0x30
 #define R_UART_RX	0x30
 
+#ifndef __ASSEMBLY__
+
+#include <types.h>
+
+int console_cadence_register(uint64_t baseaddr, uint64_t clock, uint64_t baud);
+
+#endif /*__ASSEMBLY__*/
+
 #endif

--- a/include/drivers/console.h
+++ b/include/drivers/console.h
@@ -7,14 +7,64 @@
 #ifndef __CONSOLE_H__
 #define __CONSOLE_H__
 
-#include <stdint.h>
+#include <utils_def.h>
 
-int console_init(uintptr_t base_addr,
-		unsigned int uart_clk, unsigned int baud_rate);
+#ifdef AARCH32
+#define REGSZ U(4)
+#else
+#define REGSZ U(8)
+#endif
+
+#define CONSOLE_INFO_NEXT	(U(0) * REGSZ)
+#define CONSOLE_INFO_FLAGS	(U(1) * REGSZ)
+#define CONSOLE_INFO_BASE	(U(2) * REGSZ)
+#define CONSOLE_INFO_PUTC	(U(3) * REGSZ)
+#define CONSOLE_INFO_GETC	(U(4) * REGSZ)
+#define CONSOLE_INFO_FLUSH	(U(5) * REGSZ)
+
+#define CONSOLE_FLAG_BOOT_SHIFT			U(0)
+#define CONSOLE_FLAG_RUNTIME_SHIFT		U(1)
+#define CONSOLE_FLAG_CRASH_SHIFT		U(2)
+
+#ifndef __ASSEMBLY__
+
+#include <cassert.h>
+#include <types.h>
+
+typedef struct console_info {
+	struct console_info *next;
+	u_register_t flags;
+	uintptr_t baseaddr;
+	void (*putc)(int character, uintptr_t baseaddr);
+	int (*getc)(uintptr_t baseaddr);
+	int (*flush)(uintptr_t baseaddr);
+} console_info_t;
+
+void console_register(console_info_t *console);
+console_info_t *console_unregister(console_info_t *console);
 void console_uninit(void);
 int console_putc(int c);
 int console_getc(void);
 int console_flush(void);
+
+/* DEPRECATED on AArch64 -- use console_<driver>_register() instead! */
+int console_init(uintptr_t base_addr,
+		unsigned int uart_clk, unsigned int baud_rate);
+
+CASSERT(CONSOLE_INFO_NEXT == __builtin_offsetof(console_info_t, next),
+	assert_console_info_next_offset_mismatch);
+CASSERT(CONSOLE_INFO_FLAGS == __builtin_offsetof(console_info_t, flags),
+	assert_console_info_flags_offset_mismatch);
+CASSERT(CONSOLE_INFO_BASE == __builtin_offsetof(console_info_t, baseaddr),
+	assert_console_info_base_offset_mismatch);
+CASSERT(CONSOLE_INFO_PUTC == __builtin_offsetof(console_info_t, putc),
+	assert_console_info_putc_offset_mismatch);
+CASSERT(CONSOLE_INFO_GETC == __builtin_offsetof(console_info_t, getc),
+	assert_console_info_getc_offset_mismatch);
+CASSERT(CONSOLE_INFO_FLUSH == __builtin_offsetof(console_info_t, flush),
+	assert_console_info_flush_offset_mismatch);
+
+#endif /* __ASSEMBLY__ */
 
 #endif /* __CONSOLE_H__ */
 

--- a/include/drivers/ti/uart/uart_16550.h
+++ b/include/drivers/ti/uart/uart_16550.h
@@ -67,4 +67,12 @@
 #define UARTLSR_RDR_BIT		(0)		/* Rx Data Ready Bit */
 #define UARTLSR_RDR		(1 << UARTLSR_RDR_BIT)	/* Rx Data Ready */
 
+#ifndef __ASSEMBLY__
+
+#include <types.h>
+
+int console_16550_register(uint64_t baseaddr, uint64_t clock, uint64_t baud);
+
+#endif /*__ASSEMBLY__*/
+
 #endif	/* __UART_16550_H__ */

--- a/include/lib/coreboot.h
+++ b/include/lib/coreboot.h
@@ -7,6 +7,8 @@
 #ifndef __COREBOOT_H__
 #define __COREBOOT_H__
 
+#include <types.h>
+
 typedef struct {
 	uint32_t type;			/* always 2 (memory-mapped) on ARM */
 	uint32_t baseaddr;
@@ -18,5 +20,7 @@ typedef struct {
 extern coreboot_serial_t coreboot_serial;
 
 void coreboot_table_setup(void *base);
+
+int console_cbmc_register(uintptr_t base);
 
 #endif /* __COREBOOT_TABLES_H__ */

--- a/include/lib/coreboot.h
+++ b/include/lib/coreboot.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __COREBOOT_H__
+#define __COREBOOT_H__
+
+typedef struct {
+	uint32_t type;			/* always 2 (memory-mapped) on ARM */
+	uint32_t baseaddr;
+	uint32_t baud;
+	uint32_t regwidth;		/* in bytes, i.e. usually 4 */
+	uint32_t input_hertz;
+	uint32_t uart_pci_addr;		/* unused on current ARM systems */
+} coreboot_serial_t;
+extern coreboot_serial_t coreboot_serial;
+
+void coreboot_table_setup(void *base);
+
+#endif /* __COREBOOT_TABLES_H__ */

--- a/lib/coreboot/coreboot.mk
+++ b/lib/coreboot/coreboot.mk
@@ -6,3 +6,5 @@
 
 BL31_SOURCES	+=	$(addprefix lib/coreboot/,	\
 			coreboot_table.c)
+
+BL31_SOURCES	+=	drivers/coreboot/cbmem_console/${ARCH}/cbmem_console.S

--- a/lib/coreboot/coreboot.mk
+++ b/lib/coreboot/coreboot.mk
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+
+BL31_SOURCES	+=	$(addprefix lib/coreboot/,	\
+			coreboot_table.c)

--- a/lib/coreboot/coreboot_table.c
+++ b/lib/coreboot/coreboot_table.c
@@ -9,6 +9,7 @@
 #include <debug.h>
 #include <mmio.h>
 #include <string.h>
+#include <xlat_tables_v2.h>
 
 /*
  * Structures describing coreboot's in-memory descriptor tables. See
@@ -27,6 +28,7 @@ typedef struct {
 
 typedef enum {
 	CB_TAG_SERIAL = 0xf,
+	CB_TAG_CBMEM_CONSOLE = 0x17,
 } cb_tag_t;
 
 typedef struct {
@@ -34,6 +36,7 @@ typedef struct {
 	uint32_t size;
 	union {
 		coreboot_serial_t serial;
+		uint64_t uint64;
 	};
 } cb_entry_t;
 
@@ -53,6 +56,26 @@ static uint32_t read_le32(uint32_t *p)
 	       mmio_read_8(addr + 1) << 8	|
 	       mmio_read_8(addr + 2) << 16	|
 	       mmio_read_8(addr + 3) << 24;
+}
+static uint64_t read_le64(uint64_t *p)
+{
+	return read_le32((void *)p) | (uint64_t)read_le32((void *)p + 4) << 32;
+}
+
+static void expand_and_mmap(uintptr_t baseaddr, size_t size)
+{
+	uintptr_t pageaddr = round_down(baseaddr, PAGE_SIZE);
+	size_t expanded = round_up(baseaddr - pageaddr + size, PAGE_SIZE);
+	mmap_add_region(pageaddr, pageaddr, expanded,
+			MT_MEMORY | MT_RW | MT_NS | MT_EXECUTE_NEVER);
+}
+
+static void setup_cbmem_console(uintptr_t baseaddr)
+{
+	/* CBMEM console structure stores its size in first header field. */
+	uint32_t size = *(uint32_t *)baseaddr;
+	expand_and_mmap(baseaddr, size);
+	console_cbmc_register(baseaddr);
 }
 
 void coreboot_table_setup(void *base)
@@ -79,6 +102,9 @@ void coreboot_table_setup(void *base)
 		case CB_TAG_SERIAL:
 			memcpy(&coreboot_serial, &entry->serial,
 			       sizeof(coreboot_serial));
+			break;
+		case CB_TAG_CBMEM_CONSOLE:
+			setup_cbmem_console(read_le64(&entry->uint64));
 			break;
 		default:
 			/* There are many tags TF doesn't need to care about. */

--- a/lib/coreboot/coreboot_table.c
+++ b/lib/coreboot/coreboot_table.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <console.h>
+#include <coreboot.h>
+#include <debug.h>
+#include <mmio.h>
+#include <string.h>
+
+/*
+ * Structures describing coreboot's in-memory descriptor tables. See
+ * <coreboot>/src/commonlib/include/commonlib/coreboot_tables.h for
+ * canonical implementation.
+ */
+
+typedef struct {
+	char signature[4];
+	uint32_t header_bytes;
+	uint32_t header_checksum;
+	uint32_t table_bytes;
+	uint32_t table_checksum;
+	uint32_t table_entries;
+} cb_header_t;
+
+typedef enum {
+	CB_TAG_SERIAL = 0xf,
+} cb_tag_t;
+
+typedef struct {
+	uint32_t tag;
+	uint32_t size;
+	union {
+		coreboot_serial_t serial;
+	};
+} cb_entry_t;
+
+coreboot_serial_t coreboot_serial;
+
+/*
+ * The coreboot table is parsed before the MMU is enabled (i.e. with strongly
+ * ordered memory), so we cannot make unaligned accesses. The table entries
+ * immediately follow one another without padding, so nothing after the header
+ * is guaranteed to be naturally aligned. Therefore, we need to define safety
+ * functions that can read an unaligned integers.
+ */
+static uint32_t read_le32(uint32_t *p)
+{
+	uintptr_t addr = (uintptr_t)p;
+	return mmio_read_8(addr)		|
+	       mmio_read_8(addr + 1) << 8	|
+	       mmio_read_8(addr + 2) << 16	|
+	       mmio_read_8(addr + 3) << 24;
+}
+
+void coreboot_table_setup(void *base)
+{
+	cb_header_t *header = base;
+	void *ptr;
+	int i;
+
+	if (strncmp(header->signature, "LBIO", 4)) {
+		ERROR("coreboot table signature corrupt!\n");
+		return;
+	}
+
+	ptr = base + header->header_bytes;
+	for (i = 0; i < header->table_entries; i++) {
+		cb_entry_t *entry = ptr;
+
+		if (ptr - base >= header->header_bytes + header->table_bytes) {
+			ERROR("coreboot table exceeds its bounds!\n");
+			break;
+		}
+
+		switch (read_le32(&entry->tag)) {
+		case CB_TAG_SERIAL:
+			memcpy(&coreboot_serial, &entry->serial,
+			       sizeof(coreboot_serial));
+			break;
+		default:
+			/* There are many tags TF doesn't need to care about. */
+			break;
+		}
+
+		ptr += read_le32(&entry->size);
+	}
+}

--- a/make_helpers/defaults.mk
+++ b/make_helpers/defaults.mk
@@ -38,6 +38,10 @@ BASE_COMMIT			:= origin/master
 # The platform Makefile is free to override this value.
 COLD_BOOT_SINGLE_CPU		:= 0
 
+# Flag to compile in coreboot support code. Exclude by default. The coreboot
+# Makefile system will set this when compiling TF as part of a coreboot image.
+COREBOOT			:= 0
+
 # For Chain of Trust
 CREATE_KEYS			:= 1
 

--- a/plat/common/aarch64/platform_helpers.S
+++ b/plat/common/aarch64/platform_helpers.S
@@ -55,31 +55,31 @@ func plat_report_exception
 endfunc plat_report_exception
 
 	/* -----------------------------------------------------
-	 * Placeholder function which should be redefined by
-	 * each platform.
+	 * int plat_crash_console_init(void)
+	 * Use normal console by default. Switch it to crash
+	 * mode so serial consoles become active again.
 	 * -----------------------------------------------------
 	 */
 func plat_crash_console_init
-	mov	x0, #0
-	ret
+	b	console_start_crash
 endfunc plat_crash_console_init
 
 	/* -----------------------------------------------------
-	 * Placeholder function which should be redefined by
-	 * each platform.
+	 * void plat_crash_console_putc(int character)
+	 * Output through the normal console by default.
 	 * -----------------------------------------------------
 	 */
 func plat_crash_console_putc
-	ret
+	b	console_putc
 endfunc plat_crash_console_putc
 
 	/* -----------------------------------------------------
-	 * Placeholder function which should be redefined by
-	 * each platform.
+	 * void plat_crash_console_flush(void)
+	 * Flush normal console by default.
 	 * -----------------------------------------------------
 	 */
 func plat_crash_console_flush
-	ret
+	b	console_flush
 endfunc plat_crash_console_flush
 
 	/* -----------------------------------------------------

--- a/plat/hisilicon/hikey/hisi_pwrc_sram.S
+++ b/plat/hisilicon/hikey/hisi_pwrc_sram.S
@@ -15,8 +15,7 @@
 	.global v7_asm
 	.global v7_asm_end
 
-	.align	3
-func pm_asm_code
+func pm_asm_code _align=3
 	mov	x0, 0
 	msr	oslar_el1, x0
 

--- a/plat/nvidia/tegra/common/aarch64/tegra_helpers.S
+++ b/plat/nvidia/tegra/common/aarch64/tegra_helpers.S
@@ -307,8 +307,7 @@ endfunc plat_reset_handler
 	 * Secure entrypoint function for CPU boot
 	 * ----------------------------------------
 	 */
-	.align 6
-func tegra_secure_entrypoint
+func tegra_secure_entrypoint _align=6
 
 #if ERRATA_TEGRA_INVALIDATE_BTB_AT_BOOT
 

--- a/plat/nvidia/tegra/soc/t186/plat_trampoline.S
+++ b/plat/nvidia/tegra/soc/t186/plat_trampoline.S
@@ -12,11 +12,10 @@
 
 #define TEGRA186_SMMU_CTX_SIZE		0x420
 
-	.align 4
 	.globl	tegra186_cpu_reset_handler
 
 /* CPU reset handler routine */
-func tegra186_cpu_reset_handler
+func tegra186_cpu_reset_handler _align=4
 	/*
 	 * The TZRAM loses state during System Suspend. We use this
 	 * information to decide if the reset handler is running after a

--- a/plat/rockchip/common/aarch64/plat_helpers.S
+++ b/plat/rockchip/common/aarch64/plat_helpers.S
@@ -19,8 +19,6 @@
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_report_exception
 	.globl	platform_is_primary_cpu
-	.globl	plat_crash_console_init
-	.globl	plat_crash_console_putc
 	.globl	plat_my_core_pos
 	.globl	plat_reset_handler
 	.globl	plat_panic_handler
@@ -81,32 +79,6 @@ func platform_is_primary_cpu
 	cset	x0, eq
 	ret
 endfunc platform_is_primary_cpu
-
-	/* --------------------------------------------------------------------
-	 * int plat_crash_console_init(void)
-	 * Function to initialize the crash console
-	 * without a C Runtime to print crash report.
-	 * Clobber list : x0, x1, x2
-	 * --------------------------------------------------------------------
-	 */
-func plat_crash_console_init
-	mov_imm	x0, PLAT_RK_UART_BASE
-	mov_imm	x1, PLAT_RK_UART_CLOCK
-	mov_imm	x2, PLAT_RK_UART_BAUDRATE
-	b	console_core_init
-endfunc plat_crash_console_init
-
-	/* --------------------------------------------------------------------
-	 * int plat_crash_console_putc(void)
-	 * Function to print a character on the crash
-	 * console without a C Runtime.
-	 * Clobber list : x1, x2
-	 * --------------------------------------------------------------------
-	 */
-func plat_crash_console_putc
-	mov_imm x1, PLAT_RK_UART_BASE
-	b	console_core_putc
-endfunc plat_crash_console_putc
 
 	/* --------------------------------------------------------------------
 	 * void plat_panic_handler(void)

--- a/plat/rockchip/common/aarch64/plat_helpers.S
+++ b/plat/rockchip/common/aarch64/plat_helpers.S
@@ -23,6 +23,7 @@
 	.globl	plat_crash_console_putc
 	.globl	plat_my_core_pos
 	.globl	plat_reset_handler
+	.globl	plat_panic_handler
 
 	/*
 	 * void plat_reset_handler(void);
@@ -106,6 +107,19 @@ func plat_crash_console_putc
 	mov_imm x1, PLAT_RK_UART_BASE
 	b	console_core_putc
 endfunc plat_crash_console_putc
+
+	/* --------------------------------------------------------------------
+	 * void plat_panic_handler(void)
+	 * Call system reset function on panic. Set up an emergency stack so we
+	 * can run C functions (it only needs to last for a few calls until we
+	 * reboot anyway).
+	 * --------------------------------------------------------------------
+	 */
+func plat_panic_handler
+	msr	spsel, #0
+	bl	plat_set_my_stack
+	b	rockchip_soc_soft_reset
+endfunc plat_panic_handler
 
 	/* --------------------------------------------------------------------
 	 * void platform_cpu_warmboot (void);

--- a/plat/rockchip/common/aarch64/plat_helpers.S
+++ b/plat/rockchip/common/aarch64/plat_helpers.S
@@ -112,8 +112,7 @@ endfunc plat_crash_console_putc
 	 * cpus online or resume enterpoint
 	 * --------------------------------------------------------------------
 	 */
-	.align	16
-func platform_cpu_warmboot
+func platform_cpu_warmboot _align=16
 	mrs	x0, MPIDR_EL1
 	and	x19, x0, #MPIDR_CPU_MASK
 	and	x20, x0, #MPIDR_CLUSTER_MASK

--- a/plat/rockchip/common/bl31_plat_setup.c
+++ b/plat/rockchip/common/bl31_plat_setup.c
@@ -8,12 +8,14 @@
 #include <assert.h>
 #include <bl_common.h>
 #include <console.h>
+#include <coreboot.h>
 #include <debug.h>
 #include <generic_delay_timer.h>
 #include <mmio.h>
 #include <plat_private.h>
 #include <platform.h>
 #include <platform_def.h>
+#include <uart_16550.h>
 
 /*******************************************************************************
  * Declarations of linker defined symbols which will help us find the layout
@@ -69,8 +71,16 @@ void params_early_setup(void *plat_param_from_bl2)
 void bl31_early_platform_setup(bl31_params_t *from_bl2,
 			       void *plat_params_from_bl2)
 {
-	console_init(PLAT_RK_UART_BASE, PLAT_RK_UART_CLOCK,
-		     PLAT_RK_UART_BAUDRATE);
+	params_early_setup(plat_params_from_bl2);
+
+#if COREBOOT
+	if (coreboot_serial.type)
+		console_16550_register(coreboot_serial.baseaddr,
+			coreboot_serial.input_hertz, coreboot_serial.baud);
+#else
+	console_16550_register(PLAT_RK_UART_BASE, PLAT_RK_UART_CLOCK,
+			       PLAT_RK_UART_BAUDRATE);
+#endif
 
 	VERBOSE("bl31_setup\n");
 
@@ -82,9 +92,6 @@ void bl31_early_platform_setup(bl31_params_t *from_bl2,
 
 	bl32_ep_info = *from_bl2->bl32_ep_info;
 	bl33_ep_info = *from_bl2->bl33_ep_info;
-
-	/* there may have some board sepcific message need to initialize */
-	params_early_setup(plat_params_from_bl2);
 }
 
 /*******************************************************************************

--- a/plat/rockchip/common/include/plat_macros.S
+++ b/plat/rockchip/common/include/plat_macros.S
@@ -38,14 +38,14 @@ cci_iface_regs:
 	 * The below utility macro prints out relevant GIC
 	 * and CCI registers whenever an unhandled
 	 * exception is taken in BL31.
-	 * Expects: GICD base in x16, GICC base in x17
+	 * Expects: GICD base in x26, GICC base in x27
 	 * Clobbers: x0 - x10, sp
 	 * ---------------------------------------------
 	 */
 	.macro plat_crash_print_regs
 
-	mov_imm	x16, PLAT_RK_GICD_BASE
-	mov_imm	x17, PLAT_RK_GICC_BASE
+	mov_imm	x26, PLAT_RK_GICD_BASE
+	mov_imm	x27, PLAT_RK_GICC_BASE
 
 	/* Check for GICv3 system register access */
 	mrs	x7, id_aa64pfr0_el1
@@ -72,19 +72,19 @@ print_gicv2:
 	/* Load the gicc reg list to x6 */
 	adr	x6, gicc_regs
 	/* Load the gicc regs to gp regs used by str_in_crash_buf_print */
-	ldr	w8, [x17, #GICC_HPPIR]
-	ldr	w9, [x17, #GICC_AHPPIR]
-	ldr	w10, [x17, #GICC_CTLR]
+	ldr	w8, [x27, #GICC_HPPIR]
+	ldr	w9, [x27, #GICC_AHPPIR]
+	ldr	w10, [x27, #GICC_CTLR]
 	/* Store to the crash buf and print to console */
 	bl	str_in_crash_buf_print
 
 print_gic_common:
 	/* Print the GICD_ISPENDR regs */
-	add	x7, x16, #GICD_ISPENDR
+	add	x7, x26, #GICD_ISPENDR
 	adr	x4, gicd_pend_reg
 	bl	asm_print_str
 gicd_ispendr_loop:
-	sub	x4, x7, x16
+	sub	x4, x7, x26
 	cmp	x4, #0x280
 	b.eq	exit_print_gic_regs
 	bl	asm_print_hex

--- a/plat/rockchip/common/include/plat_params.h
+++ b/plat/rockchip/common/include/plat_params.h
@@ -56,6 +56,7 @@ enum {
 	PARAM_POWEROFF,
 	PARAM_SUSPEND_GPIO,
 	PARAM_SUSPEND_APIO,
+	PARAM_COREBOOT_TABLE,
 };
 
 struct apio_info {
@@ -87,6 +88,11 @@ struct bl31_gpio_param {
 struct bl31_apio_param {
 	struct bl31_plat_param h;
 	struct apio_info apio;
+};
+
+struct bl31_u64_param {
+	struct bl31_plat_param h;
+	uint64_t value;
 };
 
 #endif /* __PLAT_PARAMS_H__ */

--- a/plat/rockchip/common/params_setup.c
+++ b/plat/rockchip/common/params_setup.c
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <bl_common.h>
 #include <console.h>
+#include <coreboot.h>
 #include <debug.h>
 #include <gpio.h>
 #include <mmio.h>
@@ -84,6 +85,12 @@ void params_early_setup(void *plat_param_from_bl2)
 			       sizeof(struct bl31_apio_param));
 			suspend_apio = &param_apio.apio;
 			break;
+#if COREBOOT
+		case PARAM_COREBOOT_TABLE:
+			coreboot_table_setup((void *)
+				((struct bl31_u64_param *)bl2_param)->value);
+			break;
+#endif
 		default:
 			ERROR("not expected type found %ld\n",
 			      bl2_param->type);


### PR DESCRIPTION
This patch series adds code that allows Trusted Firmware to more deeply integrate with coreboot on platforms where coreboot is acting as BL2. The most important feature for now is access to coreboot's in-memory firmware console to log boot messages and crash dumps, which helps triaging issues on systems that don't have a serial console hooked up. It is only used by the Rockchip platform for now, but most of the code is generic and can be used by all future coreboot-based platforms.