### PR TITLE
hikey960: migrate to use A53 specific defines

### DIFF
--- a/plat/hisilicon/hikey960/aarch64/hikey960_helpers.S
+++ b/plat/hisilicon/hikey960/aarch64/hikey960_helpers.S
@@ -144,10 +144,10 @@ endfunc plat_reset_handler
 	 * -----------------------------------------------------
 	 */
 func set_retention_ticks
-	mrs	x0, CPUECTLR_EL1
-	bic	x0, x0, #CPUECTLR_CPU_RET_CTRL_MASK
+	mrs	x0, CORTEX_A53_ECTLR_EL1
+	bic	x0, x0, #CORTEX_A53_ECTLR_CPU_RET_CTRL_MASK
 	orr	x0, x0, #RETENTION_ENTRY_TICKS_8
-	msr	CPUECTLR_EL1, x0
+	msr	CORTEX_A53_ECTLR_EL1, x0
 	isb
 	dsb	sy
 	ret
@@ -159,9 +159,9 @@ endfunc set_retention_ticks
 	 * -----------------------------------------------------
 	 */
 func clr_retention_ticks
-	mrs	x0, CPUECTLR_EL1
-	bic	x0, x0, #CPUECTLR_CPU_RET_CTRL_MASK
-	msr	CPUECTLR_EL1, x0
+	mrs	x0, CORTEX_A53_ECTLR_EL1
+	bic	x0, x0, #CORTEX_A53_ECTLR_CPU_RET_CTRL_MASK
+	msr	CORTEX_A53_ECTLR_EL1, x0
 	isb
 	dsb	sy
 	ret


### PR DESCRIPTION
The patch fb7d32e5881ef2445e8fe2305005f5590d4a7cfa migrated the CPU
libraries to have unique defines, prefixing them with the CPU name.

This patch migrates the hikey960 platform port to use the A53 specific
defines.

Change-Id: Id76f544b0b236bbd4974ab5ffa1203f073c20021
Signed-off-by: David Cunado <david.cunado@arm.com>