### PR TITLE
xlat_tables_v2: fix signed/unsigned comparisons

### DIFF
--- a/lib/xlat_tables_v2/xlat_tables_internal.c
+++ b/lib/xlat_tables_v2/xlat_tables_internal.c
@@ -953,7 +953,7 @@ static const char *invalid_descriptors_ommited =
  */
 static void xlat_tables_print_internal(const uintptr_t table_base_va,
 		uint64_t *const table_base, const int table_entries,
-		const int level, const uint64_t execute_never_mask)
+		const unsigned int level, const uint64_t execute_never_mask)
 {
 	assert(level <= XLAT_TABLE_LEVEL_MAX);
 


### PR DESCRIPTION
This patch changes input param level in xlat_tables_print_internal() to
an unsigned int to fix the signed/unsigned comparison warnings. The
compiler complains about these warnings, thus halting the build flow
for Tegra platforms.

Change-Id: Ieccc262a63daca7a26ca6a14d81466397af8b89f
Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>
Signed-off-by: David Cunado <david.cunado@arm.com>