### PR TITLE
aarch32: Apply workaround for errata 813419 of Cortex-A57

### DIFF
--- a/lib/xlat_tables/aarch32/xlat_tables.c
+++ b/lib/xlat_tables/aarch32/xlat_tables.c
@@ -149,7 +149,7 @@ void enable_mmu_secure(unsigned int flags)
 	 * and translation register writes are committed
 	 * before enabling the MMU
 	 */
-	dsb();
+	dsbish();
 	isb();
 
 	sctlr = read_sctlr();

--- a/lib/xlat_tables_v2/aarch32/xlat_tables_arch.c
+++ b/lib/xlat_tables_v2/aarch32/xlat_tables_arch.c
@@ -141,7 +141,7 @@ void enable_mmu_internal_secure(unsigned int flags, uint64_t *base_table)
 	 * and translation register writes are committed
 	 * before enabling the MMU
 	 */
-	dsb();
+	dsbish();
 	isb();
 
 	sctlr = read_sctlr();


### PR DESCRIPTION
TLBI instructions for monitor mode won't have the desired effect under
specific circumstances in Cortex-A57 r0p0. The workaround is to
execute DSB and TLBI twice each time.

Even though this errata is only needed in r0p0, the current errata
framework is not prepared to apply run-time workarounds. The current one
is always applied if compiled in, regardless of the CPU or its revision.

The `DSB` instruction used when initializing the translation tables has
been changed to `DSB ISH` as an optimization and to be consistent with
the barriers used for the workaround.

NOTE: This workaround is present in AArch64 TF and already enabled by
default on Juno.

Change-Id: I10b0baa304ed64b13b7b26ea766e61461e759dfa
Signed-off-by: Dimitris Papastamos <dimitris.papastamos@arm.com>