### PR TITLE
Power down the CPU after platforms complete their power down sequence

### DIFF
--- a/lib/psci/psci_off.c
+++ b/lib/psci/psci_off.c
@@ -83,6 +83,12 @@ int psci_do_cpu_off(unsigned int end_pwrlvl)
 	psci_stats_update_pwr_down(end_pwrlvl, &state_info);
 #endif
 
+	/*
+	 * Plat. management: Perform platform specific actions to turn this
+	 * cpu off e.g. exit cpu coherency, program the power controller etc.
+	 */
+	psci_plat_pm_ops->pwr_domain_off(&state_info);
+
 #if ENABLE_RUNTIME_INSTRUMENTATION
 
 	/*
@@ -104,12 +110,6 @@ int psci_do_cpu_off(unsigned int end_pwrlvl)
 		RT_INSTR_EXIT_CFLUSH,
 		PMF_NO_CACHE_MAINT);
 #endif
-
-	/*
-	 * Plat. management: Perform platform specific actions to turn this
-	 * cpu off e.g. exit cpu coherency, program the power controller etc.
-	 */
-	psci_plat_pm_ops->pwr_domain_off(&state_info);
 
 #if ENABLE_PSCI_STAT
 	plat_psci_stat_accounting_start(&state_info);

--- a/lib/psci/psci_suspend.c
+++ b/lib/psci/psci_suspend.c
@@ -173,9 +173,6 @@ void psci_cpu_suspend_start(entry_point_info_t *ep,
 	psci_stats_update_pwr_down(end_pwrlvl, state_info);
 #endif
 
-	if (is_power_down_state)
-		psci_suspend_to_pwrdown_start(end_pwrlvl, ep, state_info);
-
 	/*
 	 * Plat. management: Allow the platform to perform the
 	 * necessary actions to turn off this cpu e.g. set the
@@ -183,6 +180,9 @@ void psci_cpu_suspend_start(entry_point_info_t *ep,
 	 * program the power controller etc.
 	 */
 	psci_plat_pm_ops->pwr_domain_suspend(state_info);
+
+	if (is_power_down_state)
+		psci_suspend_to_pwrdown_start(end_pwrlvl, ep, state_info);
 
 #if ENABLE_PSCI_STAT
 	plat_psci_stat_accounting_start(state_info);


### PR DESCRIPTION
This patch moves the actual CPU power down code after the platform's power down
handler during the CPU_OFF and CPU_SUSPEND sequence. This allows platforms to
work with Dcache and MMU enabled for the power down sequence. Platforms usually
power down other hardware components, save context to memory from theri power
down handlers. Once they are done with their sequence, the core can be prepared
for power down - exit SMP, flush dcache, disable dcache, etc.

Platforms like Tegra will definitely benefit from this change in policy.

Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>