### PR TITLE
Fix Tegra CFLAGS usage

### DIFF
--- a/plat/nvidia/tegra/platform.mk
+++ b/plat/nvidia/tegra/platform.mk
@@ -36,4 +36,4 @@ include ${SOC_DIR}/platform_${TARGET_SOC}.mk
 BUILD_PLAT	:=	${BUILD_BASE}/${PLAT}/${TARGET_SOC}/${BUILD_TYPE}
 
 # enable signed comparison checks
-CFLAGS		+= -Wsign-compare
+TF_CFLAGS	+= -Wsign-compare


### PR DESCRIPTION
Use TF_CFLAGS instead of CFLAGS, to allow CFLAGS to be overriden from
the make command line.

Change-Id: I3e5726c04bcd0176f232581b8be2c94413374ac7
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>