### PR TITLE
Resolve signed-unsigned comparison issues

### DIFF
--- a/lib/cpus/errata_report.c
+++ b/lib/cpus/errata_report.c
@@ -72,7 +72,7 @@ void errata_print_msg(unsigned int status, const char *cpu, const char *id)
 	const char *msg __unused;
 
 
-	assert(status >= 0 && status < ARRAY_SIZE(errata_status_str));
+	assert(status < ARRAY_SIZE(errata_status_str));
 	assert(cpu);
 	assert(id);
 

--- a/lib/xlat_tables/xlat_tables_common.c
+++ b/lib/xlat_tables/xlat_tables_common.c
@@ -23,9 +23,9 @@
 #define LVL2_SPACER "    "
 #define LVL3_SPACER "      "
 #define get_level_spacer(level)		\
-			(((level) == 0) ? LVL0_SPACER : \
-			(((level) == 1) ? LVL1_SPACER : \
-			(((level) == 2) ? LVL2_SPACER : LVL3_SPACER)))
+			(((level) == U(0)) ? LVL0_SPACER : \
+			(((level) == U(1)) ? LVL1_SPACER : \
+			(((level) == U(2)) ? LVL2_SPACER : LVL3_SPACER)))
 #define debug_print(...) tf_printf(__VA_ARGS__)
 #else
 #define debug_print(...) ((void)0)
@@ -36,7 +36,7 @@
 static uint64_t xlat_tables[MAX_XLAT_TABLES][XLAT_TABLE_ENTRIES]
 			__aligned(XLAT_TABLE_SIZE) __section("xlat_table");
 
-static unsigned next_xlat;
+static unsigned int next_xlat;
 static unsigned long long xlat_max_pa;
 static uintptr_t xlat_max_va;
 
@@ -178,7 +178,7 @@ void mmap_add(const mmap_region_t *mm)
 }
 
 static uint64_t mmap_desc(mmap_attr_t attr, unsigned long long addr_pa,
-							int level)
+							unsigned int level)
 {
 	uint64_t desc;
 	int mem_type;
@@ -309,7 +309,7 @@ static int mmap_region_attr(mmap_region_t *mm, uintptr_t base_va,
 static mmap_region_t *init_xlation_table_inner(mmap_region_t *mm,
 					uintptr_t base_va,
 					uint64_t *table,
-					int level)
+					unsigned int level)
 {
 	assert(level >= XLAT_TABLE_LEVEL_MIN && level <= XLAT_TABLE_LEVEL_MAX);
 
@@ -378,7 +378,7 @@ static mmap_region_t *init_xlation_table_inner(mmap_region_t *mm,
 }
 
 void init_xlation_table(uintptr_t base_va, uint64_t *table,
-			int level, uintptr_t *max_va,
+			unsigned int level, uintptr_t *max_va,
 			unsigned long long *max_pa)
 {
 	execute_never_mask = xlat_arch_get_xn_desc(xlat_arch_current_el());

--- a/lib/xlat_tables/xlat_tables_private.h
+++ b/lib/xlat_tables/xlat_tables_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -77,7 +77,7 @@ int xlat_arch_current_el(void);
 uint64_t xlat_arch_get_xn_desc(int el);
 
 void init_xlation_table(uintptr_t base_va, uint64_t *table,
-			int level, uintptr_t *max_va,
+			unsigned int level, uintptr_t *max_va,
 			unsigned long long *max_pa);
 
 #endif /* __XLAT_TABLES_PRIVATE_H__ */

--- a/plat/compat/plat_topology_compat.c
+++ b/plat/compat/plat_topology_compat.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -88,8 +88,8 @@ void sort_mpidr_by_cpu_idx(unsigned int aff_count, unsigned long mpidr_list[])
  ******************************************************************************/
 static unsigned int init_pwr_domain_tree_desc(unsigned long mpidr,
 					unsigned int affmap_idx,
-					int cur_afflvl,
-					int tgt_afflvl)
+					unsigned int cur_afflvl,
+					unsigned int tgt_afflvl)
 {
 	unsigned int ctr, aff_count;
 
@@ -137,18 +137,20 @@ static unsigned int init_pwr_domain_tree_desc(unsigned long mpidr,
  ******************************************************************************/
 const unsigned char *plat_get_power_domain_tree_desc(void)
 {
-	int afflvl, affmap_idx;
+	int afflvl;
+	unsigned int affmap_idx;
 
 	/*
 	 * We assume that the platform allocates affinity instance ids from
 	 * 0 onwards at each affinity level in the mpidr. FIRST_MPIDR = 0.0.0.0
 	 */
 	affmap_idx = 0;
-	for (afflvl = PLATFORM_MAX_AFFLVL; afflvl >= MPIDR_AFFLVL0; afflvl--) {
+	for (afflvl = (int) PLATFORM_MAX_AFFLVL;
+			afflvl >= (int) MPIDR_AFFLVL0; afflvl--) {
 		affmap_idx = init_pwr_domain_tree_desc(FIRST_MPIDR,
 					       affmap_idx,
 					       PLATFORM_MAX_AFFLVL,
-					       afflvl);
+					       (unsigned int) afflvl);
 	}
 
 	assert(affmap_idx == (PLATFORM_NUM_AFFS - PLATFORM_CORE_COUNT + 1));


### PR DESCRIPTION
A recent commit 030567e6f51731982a7e71cbd387de93bc0e35fd added U()/ULL()
macro to TF constants. This has caused some signed-unsigned comparison
warnings / errors in the TF static analysis.

This patch addresses these issues by migrating impacted variables from
signed ints to unsigned ints and vice verse where applicable.

Change-Id: I4b4c739a3fa64aaf13b69ad1702c66ec79247e53
Signed-off-by: David Cunado <david.cunado@arm.com>