### PR TITLE
Apply workarounds for A53 Cat A Errata 835769 and 843419

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,7 @@ TF_CFLAGS		+=	$(CPPFLAGS) $(TF_CFLAGS_$(ARCH))		\
 				-ffreestanding -fno-builtin -Wall -std=gnu99	\
 				-Os -ffunction-sections -fdata-sections
 
+LDFLAGS			+=	$(LDFLAGS_$(ARCH))
 LDFLAGS			+=	--fatal-warnings -O1
 LDFLAGS			+=	--gc-sections
 

--- a/lib/cpus/aarch64/cortex_a53.S
+++ b/lib/cpus/aarch64/cortex_a53.S
@@ -138,6 +138,26 @@ func check_errata_855873
 	b	cpu_rev_var_hs
 endfunc check_errata_855873
 
+/*
+ * Errata workaround for Cortex A53 Errata #835769.
+ * This applies to revisions <= r0p4 of Cortex A53.
+ * This workaround is statically enabled at build time.
+ */
+func check_errata_835769
+	mov	x1, #0x04
+	b	cpu_rev_var_ls
+endfunc check_errata_835769
+
+/*
+ * Errata workaround for Cortex A53 Errata #843419.
+ * This applies to revisions <= r0p4 of Cortex A53.
+ * This workaround is statically enabled at build time.
+ */
+func check_errata_843419
+	mov	x1, #0x04
+	b	cpu_rev_var_ls
+endfunc check_errata_843419
+
 	/* -------------------------------------------------
 	 * The CPU Ops reset function for Cortex-A53.
 	 * Shall clobber: x0-x19
@@ -251,7 +271,9 @@ func cortex_a53_errata_report
 	 * checking functions of each errata.
 	 */
 	report_errata ERRATA_A53_826319, cortex_a53, 826319
+	report_errata ERRATA_A53_835769, cortex_a53, 835769
 	report_errata ERRATA_A53_836870, cortex_a53, disable_non_temporal_hint
+	report_errata ERRATA_A53_843419, cortex_a53, 843419
 	report_errata ERRATA_A53_855873, cortex_a53, 855873
 
 	ldp	x8, x30, [sp], #16

--- a/lib/cpus/cpu-ops.mk
+++ b/lib/cpus/cpu-ops.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2016, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2014-2017, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -37,10 +37,21 @@ $(eval $(call add_define,A57_DISABLE_NON_TEMPORAL_HINT))
 # only to revision <= r0p2 of the Cortex A53 cpu.
 ERRATA_A53_826319	?=0
 
+# Flag to apply erratum 835769 workaround at compile and link time.  This
+# erratum applies to revision <= r0p4 of the Cortex A53 cpu. Enabling this
+# workaround can lead the linker to create "*.stub" sections.
+ERRATA_A53_835769	?=0
+
 # Flag to apply erratum 836870 workaround during reset. This erratum applies
 # only to revision <= r0p3 of the Cortex A53 cpu. From r0p4 and onwards, this
 # erratum workaround is enabled by default in hardware.
 ERRATA_A53_836870	?=0
+
+# Flag to apply erratum 843419 workaround at link time.
+# This erratum applies to revision <= r0p4 of the Cortex A53 cpu. Enabling this
+# workaround could lead the linker to emit "*.stub" sections which are 4kB
+# aligned.
+ERRATA_A53_843419	?=0
 
 # Flag to apply errata 855873 during reset. This errata applies to all
 # revisions of the Cortex A53 CPU, but this firmware workaround only works
@@ -84,9 +95,17 @@ ERRATA_A57_833471	?=0
 $(eval $(call assert_boolean,ERRATA_A53_826319))
 $(eval $(call add_define,ERRATA_A53_826319))
 
+# Process ERRATA_A53_835769 flag
+$(eval $(call assert_boolean,ERRATA_A53_835769))
+$(eval $(call add_define,ERRATA_A53_835769))
+
 # Process ERRATA_A53_836870 flag
 $(eval $(call assert_boolean,ERRATA_A53_836870))
 $(eval $(call add_define,ERRATA_A53_836870))
+
+# Process ERRATA_A53_843419 flag
+$(eval $(call assert_boolean,ERRATA_A53_843419))
+$(eval $(call add_define,ERRATA_A53_843419))
 
 # Process ERRATA_A53_855873 flag
 $(eval $(call assert_boolean,ERRATA_A53_855873))
@@ -123,3 +142,13 @@ $(eval $(call add_define,ERRATA_A57_829520))
 # Process ERRATA_A57_833471 flag
 $(eval $(call assert_boolean,ERRATA_A57_833471))
 $(eval $(call add_define,ERRATA_A57_833471))
+
+# Errata build flags
+ifneq (${ERRATA_A53_843419},0)
+LDFLAGS_aarch64		+= --fix-cortex-a53-843419
+endif
+
+ifneq (${ERRATA_A53_835769},0)
+TF_CFLAGS_aarch64	+= -mfix-cortex-a53-835769
+LDFLAGS_aarch64		+= --fix-cortex-a53-835769
+endif

--- a/plat/arm/board/juno/platform.mk
+++ b/plat/arm/board/juno/platform.mk
@@ -56,6 +56,8 @@ BL31_SOURCES		+=	lib/cpus/aarch64/cortex_a53.S		\
 endif
 
 # Enable workarounds for selected Cortex-A53 and A57 errata.
+ERRATA_A53_835769		:=	1
+ERRATA_A53_843419		:=	1
 ERRATA_A53_855873		:=	1
 ERRATA_A57_806969		:=	0
 ERRATA_A57_813419		:=	1


### PR DESCRIPTION
These errata are only applicable to AArch64 state. See the errata notice
for more details:
http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.epm048406/index.html

Introduce the build options ERRATA_A53_835769 and ERRATA_A53_843419.
Enable both of them for Juno.

Apply the 835769 workaround as following:
* Compile with -mfix-cortex-a53-835769
* Link with --fix-cortex-a53-835769

Apply the 843419 workaround as following:
* Link with --fix-cortex-a53-843419

The erratum 843419 workaround can lead the linker to create new sections
suffixed with "*.stub*" and 4KB aligned. The erratum 835769 can lead the
linker to create new "*.stub" sections with no particular alignment.

Also add support for LDFLAGS_aarch32 and LDFLAGS_aarch64 in Makefile for
architecture-specific linker options.

Change-Id: Iab3337e338b7a0a16b0d102404d9db98c154f8f8
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>