### PR TITLE
Fix broken link in documentation

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -1090,7 +1090,7 @@ _Copyright (c) 2013-2016, ARM Limited and Contributors. All rights reserved._
 
 [OP-TEE Dispatcher]:                  optee-dispatcher.md
 [Power Domain Topology Design]:       psci-pd-tree.md
-[TF Image Terminology]:               https://github.com/ARM-software/arm-trusted-firmware/wiki/Trusted-Firmware-Image-Terminology
+[TF Image Terminology]:               https://github.com/ARM-software/arm-trusted-firmware/wiki/ARM-Trusted-Firmware-Image-Terminology
 [Authentication Framework]:           auth-framework.md
 [Firmware Update]:                    firmware-update.md
 [TF Reset Design]:                    reset-design.md

--- a/docs/firmware-update.md
+++ b/docs/firmware-update.md
@@ -384,5 +384,5 @@ _Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved._
 [Porting Guide]:        ./porting-guide.md
 [Auth Framework]:       ./auth-framework.md
 [Trusted Board Boot]:   ./trusted-board-boot.md
-[TF Image Terminology]: https://github.com/ARM-software/arm-trusted-firmware/wiki/Trusted-Firmware-Image-Terminology
+[TF Image Terminology]: https://github.com/ARM-software/arm-trusted-firmware/wiki/ARM-Trusted-Firmware-Image-Terminology
 [UUID]:                 https://tools.ietf.org/rfc/rfc4122.txt "A Universally Unique IDentifier (UUID) URN Namespace"


### PR DESCRIPTION
Fix link in docs/firmware-update.md and docs/change-log.md:
https://github.com/ARM-software/arm-trusted-firmware/wiki/ARM-Trusted-Firmware-Image-Terminology

Change-Id: I2d51d373fd0f7da59b548cd6bed52c47772014fd
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>