### PR TITLE
rockchip: enable A53's erratum 855873 for rk3399

### DIFF
--- a/plat/rockchip/rk3399/platform.mk
+++ b/plat/rockchip/rk3399/platform.mk
@@ -65,6 +65,9 @@ ENABLE_PLAT_COMPAT	:=	0
 
 $(eval $(call add_define,PLAT_EXTRA_LD_SCRIPT))
 
+# Enable workarounds for selected Cortex-A53 erratas.
+ERRATA_A53_855873	:=	1
+
 # M0 source build
 PLAT_M0                 :=      ${PLAT}m0
 BUILD_M0		:=	${BUILD_PLAT}/m0


### PR DESCRIPTION
For rk3399, the L2ACTLR[14] is 0 by default, as ACE CCI-500 doesn't
support WriteEvict. and you will hit the condition L2ACTLR[3] with 0,
as the Evict transactions should propagate to CCI-500 since it has
snoop filters.

Maybe this erratum applies to all Cortex-A53 cores so far, especially
if RK3399's A53 is a r0p4. we should enable it to avoid data corruption,

Change-Id: Ib86933f1fc84f8919c8e43dac41af60fd0c3ce2f
Signed-off-by: Caesar Wang <wxt@rock-chips.com>