### PR TITLE
Introduce TF_LDFLAGS and improve CFLAGS documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,10 +151,9 @@ TF_CFLAGS		+=	$(CPPFLAGS) $(TF_CFLAGS_$(ARCH))		\
 				-ffreestanding -fno-builtin -Wall -std=gnu99	\
 				-Os -ffunction-sections -fdata-sections
 
-LDFLAGS			+=	$(LDFLAGS_$(ARCH))
-LDFLAGS			+=	--fatal-warnings -O1
-LDFLAGS			+=	--gc-sections
-
+TF_LDFLAGS		+=	--fatal-warnings -O1
+TF_LDFLAGS		+=	--gc-sections
+TF_LDFLAGS		+=	$(TF_LDFLAGS_$(ARCH))
 
 ################################################################################
 # Common sources and include directories

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -385,6 +385,9 @@ performed.
     AArch64 and facilitates the loading of `SP_MIN` and BL33 as AArch32 executable
     images.
 
+*   `LDFLAGS`: Extra user options appended to the linkers' command line in
+    addition to the one set by the build system.
+
 *   `LOAD_IMAGE_V2`: Boolean option to enable support for new version (v2) of
     image loading, which provides more flexibility and scalability around what
     images are loaded and executed during boot. Default is 0.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -269,6 +269,9 @@ performed.
 *   `BUILD_STRING`: Input string for VERSION_STRING, which allows the TF build
     to be uniquely identified. Defaults to the current git commit id.
 
+*   `CFLAGS`: Extra user options appended on the compiler's command line in
+    addition to the options set by the build system.
+
 *   `COLD_BOOT_SINGLE_CPU`: This option indicates whether the platform may
     release several CPUs out of reset. It can take either 0 (several CPUs may be
     brought up) or 1 (only one CPU will ever be brought up during cold reset).
@@ -687,10 +690,14 @@ NOTE: Using `-O0` could cause output images to be larger and base addresses
 might need to be recalculated (see the **Memory layout on ARM development
 platforms** section in the [Firmware Design]).
 
-Extra debug options can be passed to the build system by setting `CFLAGS`:
+Extra debug options can be passed to the build system by setting `CFLAGS` or
+`LDFLAGS`:
 
     CFLAGS='-O0 -gdwarf-2'                                     \
     make PLAT=<platform> DEBUG=1 V=1 all
+
+Note that using `-Wl,` style compilation driver options in `CFLAGS` will be
+ignored as the linker is called directly.
 
 It is also possible to introduce an infinite loop to help in debugging the
 post-BL2 phase of the Trusted Firmware. This can be done by rebuilding BL1 with

--- a/lib/cpus/cpu-ops.mk
+++ b/lib/cpus/cpu-ops.mk
@@ -145,10 +145,10 @@ $(eval $(call add_define,ERRATA_A57_833471))
 
 # Errata build flags
 ifneq (${ERRATA_A53_843419},0)
-LDFLAGS_aarch64		+= --fix-cortex-a53-843419
+TF_LDFLAGS_aarch64	+= --fix-cortex-a53-843419
 endif
 
 ifneq (${ERRATA_A53_835769},0)
 TF_CFLAGS_aarch64	+= -mfix-cortex-a53-835769
-LDFLAGS_aarch64		+= --fix-cortex-a53-835769
+TF_LDFLAGS_aarch64	+= --fix-cortex-a53-835769
 endif

--- a/make_helpers/build_macros.mk
+++ b/make_helpers/build_macros.mk
@@ -313,8 +313,8 @@ else
 	       const char version_string[] = "${VERSION_STRING}";' | \
 		$$(CC) $$(TF_CFLAGS) $$(CFLAGS) -xc -c - -o $(BUILD_DIR)/build_message.o
 endif
-	$$(Q)$$(LD) -o $$@ $$(LDFLAGS) -Map=$(MAPFILE) --script $(LINKERFILE) \
-					$(BUILD_DIR)/build_message.o $(OBJS)
+	$$(Q)$$(LD) -o $$@ $$(TF_LDFLAGS) $$(LDFLAGS) -Map=$(MAPFILE) \
+		--script $(LINKERFILE) $(BUILD_DIR)/build_message.o $(OBJS)
 
 $(DUMP): $(ELF)
 	@echo "  OD      $$@"


### PR DESCRIPTION
Use TF_LDFLAGS from the Makefiles, and still append LDFLAGS as well to
the compiler's invocation. This allows passing extra options from the
make command line using LDFLAGS.

Document new LDFLAGS Makefile option.

Change-Id: I88c5ac26ca12ac2b2d60a6f150ae027639991f27
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>