### PR TITLE
hikey: enable options to fix errata

### DIFF
--- a/plat/hisilicon/hikey/platform.mk
+++ b/plat/hisilicon/hikey/platform.mk
@@ -82,3 +82,7 @@ BL31_SOURCES		+=	plat/hisilicon/hikey/hisi_sip_svc.c			\
 				lib/pmf/pmf_smc.c
 endif
 
+# Enable workarounds for selected Cortex-A53 errata.
+ERRATA_A53_836870		:=	1
+ERRATA_A53_843419		:=	1
+ERRATA_A53_855873		:=	1


### PR DESCRIPTION
Fix cortex a53 errata issues: #836870, #843419, #855873.

Fix https://github.com/ARM-software/tf-issues/issues/498

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>