### PR TITLE
zynqmp: Remove duplicate 'const' declaration

### DIFF
--- a/plat/xilinx/zynqmp/pm_service/pm_client.c
+++ b/plat/xilinx/zynqmp/pm_service/pm_client.c
@@ -31,7 +31,7 @@ DEFINE_BAKERY_LOCK(pm_client_secure_lock);
 extern const struct pm_ipi apu_ipi;
 
 /* Order in pm_procs_all array must match cpu ids */
-static const struct pm_proc const pm_procs_all[] = {
+static const struct pm_proc pm_procs_all[] = {
 	{
 		.node_id = NODE_APU_0,
 		.pwrdn_mask = APU_0_PWRCTL_CPUPWRDWNREQ_MASK,


### PR DESCRIPTION
Fixing compilation errors due to duplicate 'const' keyword:
  plat/xilinx/zynqmp/pm_service/pm_client.c:39:29: error: duplicate 'const' declaration specifier [-Werror=duplicate-decl-specifier]
   static const struct pm_proc const pm_procs_all[] = {
                               ^~~~~

Signed-off-by: Soren Brinkmann <soren.brinkmann@xilinx.com>