### PR TITLE
CPU_DATA_LOG2SIZE depends on cache line size

### DIFF
--- a/include/common/aarch32/asm_macros.S
+++ b/include/common/aarch32/asm_macros.S
@@ -80,6 +80,19 @@
 	.endm
 
 	/*
+	 * Helper macro to generate the best mov/movw/movt combinations
+	 * according to the value to be moved.
+	 */
+	.macro mov_imm _reg, _val
+		.if ((\_val) & 0xffff0000) == 0
+			mov	\_reg, #(\_val)
+		.else
+			movw	\_reg, #((\_val) & 0xffff)
+			movt	\_reg, #((\_val) >> 16)
+		.endif
+	.endm
+
+	/*
 	 * Macro to mark instances where we're jumping to a function and don't
 	 * expect a return. To provide the function being jumped to with
 	 * additional information, we use 'bl' instruction to jump rather than

--- a/include/lib/el3_runtime/cpu_data.h
+++ b/include/lib/el3_runtime/cpu_data.h
@@ -7,12 +7,15 @@
 #ifndef __CPU_DATA_H__
 #define __CPU_DATA_H__
 
+#include <platform_def.h>	/* CACHE_WRITEBACK_GRANULE required */
+
 #ifdef AARCH32
 
 #if CRASH_REPORTING
 #error "Crash reporting is not supported in AArch32"
 #endif
 #define CPU_DATA_CPU_OPS_PTR		0x0
+#define CPU_DATA_CRASH_BUF_OFFSET	0x4
 
 #else /* AARCH32 */
 
@@ -25,13 +28,17 @@
 #endif /* AARCH32 */
 
 #if CRASH_REPORTING
-#define CPU_DATA_LOG2SIZE		7
 #define CPU_DATA_CRASH_BUF_END		(CPU_DATA_CRASH_BUF_OFFSET + \
 						CPU_DATA_CRASH_BUF_SIZE)
 #else
-#define CPU_DATA_LOG2SIZE		6
 #define CPU_DATA_CRASH_BUF_END		CPU_DATA_CRASH_BUF_OFFSET
 #endif
+
+/* cpu_data size is the data size rounded up to the platform cache line size */
+#define CPU_DATA_SIZE			(((CPU_DATA_CRASH_BUF_END + \
+					CACHE_WRITEBACK_GRANULE - 1) / \
+						CACHE_WRITEBACK_GRANULE) * \
+							CACHE_WRITEBACK_GRANULE)
 
 #if ENABLE_RUNTIME_INSTRUMENTATION
 /* Temporary space to store PMF timestamps from assembly code */
@@ -98,8 +105,8 @@ CASSERT(CPU_DATA_CRASH_BUF_OFFSET == __builtin_offsetof
 	assert_cpu_data_crash_stack_offset_mismatch);
 #endif
 
-CASSERT((1 << CPU_DATA_LOG2SIZE) == sizeof(cpu_data_t),
-	assert_cpu_data_log2size_mismatch);
+CASSERT(CPU_DATA_SIZE == sizeof(cpu_data_t),
+		assert_cpu_data_size_mismatch);
 
 CASSERT(CPU_DATA_CPU_OPS_PTR == __builtin_offsetof
 		(cpu_data_t, cpu_ops_ptr),

--- a/lib/el3_runtime/aarch32/cpu_data.S
+++ b/lib/el3_runtime/aarch32/cpu_data.S
@@ -34,7 +34,9 @@ endfunc _cpu_data
  * -----------------------------------------------------------------
  */
 func _cpu_data_by_index
+	mov_imm	r1, CPU_DATA_SIZE
+	mul	r0, r0, r1
 	ldr	r1, =percpu_data
-	add	r0, r1, r0, LSL #CPU_DATA_LOG2SIZE
+	add	r0, r0, r1
 	bx	lr
 endfunc _cpu_data_by_index

--- a/lib/el3_runtime/aarch64/cpu_data.S
+++ b/lib/el3_runtime/aarch64/cpu_data.S
@@ -39,7 +39,9 @@ endfunc init_cpu_data_ptr
  * -----------------------------------------------------------------
  */
 func _cpu_data_by_index
+	mov_imm	x1, CPU_DATA_SIZE
+	mul	x0, x0, x1
 	adr	x1, percpu_data
-	add	x0, x1, x0, LSL #CPU_DATA_LOG2SIZE
+	add	x0, x0, x1
 	ret
 endfunc _cpu_data_by_index


### PR DESCRIPTION
Platform may use specific cache sizes. Since CPU_DATA_LOG2SIZE
depends on the cache line size, this change sets CPU_DATA_LOG2SIZE
according to CACHE_WRITEBACK_SHIFT which is already set by several
platforms. In case the platform does not specify the cache line size,
ATF assumes the legacy value of 64 byte large cache lines.

Change-Id: Ic2d49ffe0c3e51649425fd9c8c99559c582ac5a1
Signed-off-by: Etienne Carriere <etienne.carriere@st.com>