### PR TITLE
Use standard UNIX file:line format in assert

### DIFF
--- a/lib/stdlib/assert.c
+++ b/lib/stdlib/assert.c
@@ -17,14 +17,14 @@
 #if PLAT_LOG_LEVEL_ASSERT >= LOG_LEVEL_VERBOSE
 void __assert(const char *file, unsigned int line, const char *assertion)
 {
-	tf_printf("ASSERT: %s <%d> : %s\n", file, line, assertion);
+	tf_printf("ASSERT: %s:%d:%s\n", file, line, assertion);
 	console_flush();
 	plat_panic_handler();
 }
 #elif PLAT_LOG_LEVEL_ASSERT >= LOG_LEVEL_INFO
 void __assert(const char *file, unsigned int line)
 {
-	tf_printf("ASSERT: %s <%d>\n", file, line);
+	tf_printf("ASSERT: %s:%d\n", file, line);
 	console_flush();
 	plat_panic_handler();
 }


### PR DESCRIPTION
This format is understood by almost all the UNIX tools (vi, emacs, acme, ...),
and it allows these tools to jump directly to the line where the assert
failed.

Change-Id: I648fa93c7cc65f911a17dcad5e1a775ac1ae5ed4
Signed-off-by: Roberto Vargas <roberto.vargas@arm.com>