### PR TITLE
build: reverse header include path priority

### DIFF
--- a/tools/fiptool/Makefile
+++ b/tools/fiptool/Makefile
@@ -27,7 +27,7 @@ else
   Q :=
 endif
 
-INCLUDE_PATHS := -I. -I../../include/tools_share
+INCLUDE_PATHS := -I../../include/tools_share -I.
 
 HOSTCC ?= gcc
 


### PR DESCRIPTION
When build fip tool, makefile includes the headers from pathes "./"
and "../../include/tools_share". In this two directories both have
header file "uuid.h", by default it includes ./uuid.h header file;
this header file has not defined macro _UUID_STR_LEN so report
building errors when build fip:

In file included from fiptool.c:10:0:
fiptool.c: In function ‘uuid_to_str’:
fiptool.c:244:17: error: ‘_UUID_STR_LEN’ undeclared (first use in this function)
  assert(len >= (_UUID_STR_LEN + 1));
                 ^

This patch reverses include paths, so give higher priority to path
"../../include/tools_share", finally can include correct uuid header
file and dismiss build error.

Signed-off-by: Leo Yan <leo.yan@linaro.org>