### PR TITLE
qemu: use translation tables library v2 as default.

### DIFF
--- a/plat/qemu/platform.mk
+++ b/plat/qemu/platform.mk
@@ -11,11 +11,23 @@ PLAT_INCLUDES		:=	-Iinclude/plat/arm/common/		\
 				-Iplat/qemu/include			\
 				-Iinclude/common/tbbr
 
+# Use translation tables library v2 by default
+ARM_XLAT_TABLES_LIB_V1		:=	0
+$(eval $(call assert_boolean,ARM_XLAT_TABLES_LIB_V1))
+$(eval $(call add_define,ARM_XLAT_TABLES_LIB_V1))
+
 
 PLAT_BL_COMMON_SOURCES	:=	plat/qemu/qemu_common.c			\
-				drivers/arm/pl011/aarch64/pl011_console.S \
-				lib/xlat_tables/xlat_tables_common.c	\
+				drivers/arm/pl011/aarch64/pl011_console.S
+
+ifeq (${ARM_XLAT_TABLES_LIB_V1}, 1)
+PLAT_BL_COMMON_SOURCES	+=	lib/xlat_tables/xlat_tables_common.c		\
 				lib/xlat_tables/aarch64/xlat_tables.c
+else
+include lib/xlat_tables_v2/xlat_tables.mk
+
+PLAT_BL_COMMON_SOURCES	+=	${XLAT_TABLES_LIB_SRCS}
+endif
 
 BL1_SOURCES		+=	drivers/io/io_semihosting.c		\
 				drivers/io/io_storage.c			\

--- a/plat/qemu/qemu_common.c
+++ b/plat/qemu/qemu_common.c
@@ -7,7 +7,7 @@
 #include <arch_helpers.h>
 #include <bl_common.h>
 #include <platform_def.h>
-#include <xlat_tables.h>
+#include <arm_xlat_tables.h>
 #include "qemu_private.h"
 
 #define MAP_DEVICE0	MAP_REGION_FLAT(DEVICE0_BASE,			\


### PR DESCRIPTION
Almost all the arm platform has switch to translation tables library v2 as
default. Because qemu platform doesn't use arm_common.mk like other arm
platforms, QEMU haven't switched to v2 yet.

This patch adds all the necessary code for adding translation tables
library v2 support on QEMU and use it as default.

Fixes ARM-software/tf-issues#508

Signed-off-by: Fu Wei <fu.wei@linaro.org>