### PR TITLE
Fix order of #includes

### DIFF
--- a/tools/fiptool/fiptool.c
+++ b/tools/fiptool/fiptool.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 
 #include <openssl/sha.h>
+
 #include <firmware_image_package.h>
 
 #include "fiptool.h"

--- a/tools/fiptool/fiptool.h
+++ b/tools/fiptool/fiptool.h
@@ -7,11 +7,10 @@
 #ifndef __FIPTOOL_H__
 #define __FIPTOOL_H__
 
-#include <firmware_image_package.h>
-
 #include <stddef.h>
 #include <stdint.h>
 
+#include <firmware_image_package.h>
 #include <uuid.h>
 
 #define NELEM(x) (sizeof (x) / sizeof *(x))

--- a/tools/fiptool/tbbr_config.c
+++ b/tools/fiptool/tbbr_config.c
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <firmware_image_package.h>
 #include <stddef.h>
+
+#include <firmware_image_package.h>
 
 #include "tbbr_config.h"
 


### PR DESCRIPTION
This fix modifies the order of system includes to meet the ARM TF coding
standard whilst retaining header groupings.

Change-Id: Ib91968f8e2cac9e96033d73d3ad9d0a2ae228b13
Signed-off-by: Isla Mitchell <isla.mitchell@arm.com>