### PR TITLE
Fix sign of variable in xlat_tables_print()

### DIFF
--- a/lib/xlat_tables_v2/xlat_tables_internal.c
+++ b/lib/xlat_tables_v2/xlat_tables_internal.c
@@ -1123,7 +1123,7 @@ void xlat_tables_print(xlat_ctx_t *ctx)
 	int used_page_tables;
 #if PLAT_XLAT_TABLES_DYNAMIC
 	used_page_tables = 0;
-	for (int i = 0; i < ctx->tables_num; ++i) {
+	for (unsigned int i = 0; i < ctx->tables_num; ++i) {
 		if (ctx->tables_mapped_regions[i] != 0)
 			++used_page_tables;
 	}


### PR DESCRIPTION
This patch changes the sign of the loop variable used in
xlat_tables_print(). It needs to be unsigned because it is compared
against another unsigned int.
