### PR TITLE
Fix BL2U entrypoint possible parameter corruption

### DIFF
--- a/bl2u/aarch32/bl2u_entrypoint.S
+++ b/bl2u/aarch32/bl2u_entrypoint.S
@@ -32,7 +32,7 @@ func bl2u_entrypoint
 	 * ---------------------------------------------
 	 */
 	mov	r11, r1
-	mov	r12, r2
+	mov	r10, r2
 
 	/* ---------------------------------------------
 	 * Set the exception vector to something sane.
@@ -107,7 +107,7 @@ func bl2u_entrypoint
 	 * ---------------------------------------------
 	 */
 	mov	r0, r11
-	mov	r1, r12
+	mov	r1, r10
 	bl	bl2u_early_platform_setup
 	bl	bl2u_plat_arch_setup
 


### PR DESCRIPTION
Replace the use of r12 by r10 to save the value of a parameter of
bl2u_entrypoint to pass it to bl2u_early_platform_setup at the end of
the function. r10 is a callee saved register so it will not become
corrupted by C code, whereas r12 is the The Intra-Procedure-call scratch
register potentially used by veneers. See the ARM AAPCS document (ARM
IHI 0042F).

Change-Id: I4f37e54a6b550719edb40bb24cd8f498827e2749
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>