### PR TITLE
Hikey960: fix PSCI suspend stuck issue

### DIFF
--- a/plat/hisilicon/hikey960/hikey960_pm.c
+++ b/plat/hisilicon/hikey960/hikey960_pm.c
@@ -250,12 +250,17 @@ static void
 hikey960_pwr_domain_suspend_finish(const psci_power_state_t *target_state)
 {
 	unsigned long mpidr = read_mpidr_el1();
+	unsigned int core = mpidr & MPIDR_CPU_MASK;
 	unsigned int cluster =
 		(mpidr & MPIDR_CLUSTER_MASK) >> MPIDR_AFFINITY_BITS;
 
 	/* Nothing to be done on waking up from retention from CPU level */
 	if (CORE_PWR_STATE(target_state) != PLAT_MAX_OFF_STATE)
 		return;
+
+	hisi_cpuidle_lock(cluster, core);
+	hisi_clear_cpuidle_flag(cluster, core);
+	hisi_cpuidle_unlock(cluster, core);
 
 	if (hisi_test_ap_suspend_flag(cluster)) {
 		hikey960_sr_dma_reinit();


### PR DESCRIPTION
Hikey960: fix PSCI suspend stuck issue

Clear the cpuidle flag when resuming from idle. This flag is set when entering idle, and if it remains set when resuming, it can prevent the cluster from powering off during the next system suspend operation. During system suspend, all CPUs are plugged out except the last CPU, which is suspended. If any of the cpuidle flags are set at this point, the last CPU will be stuck in a WFI loop and will not be powered off.
This problem only occurs during system suspend.

fixes ARM-software/tf-issues#509

Signed-off-by: Tao Wang <kevin.wangtao@linaro.org>