### PR TITLE
Add new alignment parameter to func assembler macro

### DIFF
--- a/bl32/tsp/aarch64/tsp_entrypoint.S
+++ b/bl32/tsp/aarch64/tsp_entrypoint.S
@@ -43,10 +43,7 @@
 	msr	spsr_el1, \reg2
 	.endm
 
-	.section	.text, "ax"
-	.align 3
-
-func tsp_entrypoint
+func tsp_entrypoint _align=3
 
 	/* ---------------------------------------------
 	 * Set the exception vector to something sane.

--- a/include/common/asm_macros_common.S
+++ b/include/common/asm_macros_common.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -11,9 +11,12 @@
 	 * code into a separate text section based on the function name
 	 * to enable elimination of unused code during linking. It also adds
 	 * basic debug information to enable call stack printing most of the
-	 * time.
+	 * time. The optional _align parameter can be used to force a
+	 * non-standard alignment (indicated in powers of 2). Do *not* try to
+	 * use a raw .align directive. Since func switches to a new section,
+	 * this would not have the desired effect.
 	 */
-	.macro func _name
+	.macro func _name, _align=-1
 	/*
 	 * Add Call Frame Information entry in the .debug_frame section for
 	 * debugger consumption. This enables callstack printing in debuggers.
@@ -33,6 +36,9 @@
 	 * .debug_frame
 	 */
 	.cfi_startproc
+	.if (\_align) != -1
+		.align \_align
+	.endif
 	\_name:
 	.endm
 

--- a/plat/hisilicon/hikey/hisi_pwrc_sram.S
+++ b/plat/hisilicon/hikey/hisi_pwrc_sram.S
@@ -15,8 +15,7 @@
 	.global v7_asm
 	.global v7_asm_end
 
-	.align	3
-func pm_asm_code
+func pm_asm_code _align=3
 	mov	x0, 0
 	msr	oslar_el1, x0
 

--- a/plat/nvidia/tegra/common/aarch64/tegra_helpers.S
+++ b/plat/nvidia/tegra/common/aarch64/tegra_helpers.S
@@ -307,8 +307,7 @@ endfunc plat_reset_handler
 	 * Secure entrypoint function for CPU boot
 	 * ----------------------------------------
 	 */
-	.align 6
-func tegra_secure_entrypoint
+func tegra_secure_entrypoint _align=6
 
 #if ERRATA_TEGRA_INVALIDATE_BTB_AT_BOOT
 

--- a/plat/nvidia/tegra/soc/t186/plat_trampoline.S
+++ b/plat/nvidia/tegra/soc/t186/plat_trampoline.S
@@ -12,11 +12,10 @@
 
 #define TEGRA186_SMMU_CTX_SIZE		0x420
 
-	.align 4
 	.globl	tegra186_cpu_reset_handler
 
 /* CPU reset handler routine */
-func tegra186_cpu_reset_handler
+func tegra186_cpu_reset_handler _align=4
 	/*
 	 * The TZRAM loses state during System Suspend. We use this
 	 * information to decide if the reset handler is running after a

--- a/plat/rockchip/common/aarch64/plat_helpers.S
+++ b/plat/rockchip/common/aarch64/plat_helpers.S
@@ -112,8 +112,7 @@ endfunc plat_crash_console_putc
 	 * cpus online or resume enterpoint
 	 * --------------------------------------------------------------------
 	 */
-	.align	16
-func platform_cpu_warmboot
+func platform_cpu_warmboot _align=16
 	mrs	x0, MPIDR_EL1
 	and	x19, x0, #MPIDR_CPU_MASK
 	and	x20, x0, #MPIDR_CLUSTER_MASK


### PR DESCRIPTION
Assembler programmers are used to being able to define functions with a
specific aligment with a pattern like this:

    .align X
  myfunction:

However, this pattern is subtly broken when instead of a direct label
like 'myfunction:', you use the 'func myfunction' macro that's standard
in Trusted Firmware. Since the func macro declares a new section for the
function, the .align directive written above it actually applies to the
*previous* section in the assembly file, and the function it was
supposed to apply to is linked with default alignment.

An extreme case can be seen in Rockchip's plat_helpers.S which contains
this code:

  [...]
  endfunc plat_crash_console_putc

  .align 16
  func platform_cpu_warmboot
  [...]

This assembles into the following plat_helpers.o:

  Sections:
  Idx Name                             Size  [...]  Algn
   9 .text.plat_crash_console_putc 00010000  [...]  2**16
  10 .text.platform_cpu_warmboot   00000080  [...]  2**3

As can be seen, the *previous* function actually got the alignment
constraint, and it is also 64KB big even though it contains only two
instructions, because the .align directive at the end of its section
forces the assembler to insert a giant sled of NOPs. The function we
actually wanted to align has the default constraint. This code only
works at all because the linker just happens to put the two functions
right behind each other when linking the final image, and since the end
of plat_crash_console_putc is aligned the start of platform_cpu_warmboot
will also be. But it still wastes almost 64KB of image space
unnecessarily, and it will break under certain circumstances (e.g. if
the plat_crash_console_putc function becomes unused and its section gets
garbage-collected out).

There's no real way to fix this with the existing func macro. Code like

 func myfunc
 .align X

happens to do the right thing, but is still not really correct code
(because the function label is inserted before the .align directive, so
the assembler is technically allowed to insert padding at the beginning
of the function which would then get executed as instructions if the
function was called). Therefore, this patch adds a new parameter with a
default value to the func macro that allows overriding its alignment.

Also fix up all existing instances of this dangerous antipattern.

Signed-off-by: Julius Werner <jwerner@chromium.org>