### PR TITLE
Fix x30 reporting for unhandled exceptions

### DIFF
--- a/bl31/aarch64/runtime_exceptions.S
+++ b/bl31/aarch64/runtime_exceptions.S
@@ -49,7 +49,8 @@
 	b.eq	smc_handler64
 
 	/* Other kinds of synchronous exceptions are not handled */
-	no_ret	report_unhandled_exception
+	ldr	x30, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_LR]
+	b	report_unhandled_exception
 	.endm
 
 
@@ -152,7 +153,7 @@ vector_base runtime_exceptions
 	 */
 vector_entry sync_exception_sp_el0
 	/* We don't expect any synchronous exceptions from EL3 */
-	no_ret	report_unhandled_exception
+	b	report_unhandled_exception
 	check_vector_size sync_exception_sp_el0
 
 vector_entry irq_sp_el0
@@ -160,17 +161,17 @@ vector_entry irq_sp_el0
 	 * EL3 code is non-reentrant. Any asynchronous exception is a serious
 	 * error. Loop infinitely.
 	 */
-	no_ret	report_unhandled_interrupt
+	b	report_unhandled_interrupt
 	check_vector_size irq_sp_el0
 
 
 vector_entry fiq_sp_el0
-	no_ret	report_unhandled_interrupt
+	b	report_unhandled_interrupt
 	check_vector_size fiq_sp_el0
 
 
 vector_entry serror_sp_el0
-	no_ret	report_unhandled_exception
+	b	report_unhandled_exception
 	check_vector_size serror_sp_el0
 
 	/* ---------------------------------------------------------------------
@@ -184,19 +185,19 @@ vector_entry sync_exception_sp_elx
 	 * synchronous exception. There is a high probability that SP_EL3 is
 	 * corrupted.
 	 */
-	no_ret	report_unhandled_exception
+	b	report_unhandled_exception
 	check_vector_size sync_exception_sp_elx
 
 vector_entry irq_sp_elx
-	no_ret	report_unhandled_interrupt
+	b	report_unhandled_interrupt
 	check_vector_size irq_sp_elx
 
 vector_entry fiq_sp_elx
-	no_ret	report_unhandled_interrupt
+	b	report_unhandled_interrupt
 	check_vector_size fiq_sp_elx
 
 vector_entry serror_sp_elx
-	no_ret	report_unhandled_exception
+	b	report_unhandled_exception
 	check_vector_size serror_sp_elx
 
 	/* ---------------------------------------------------------------------
@@ -226,7 +227,7 @@ vector_entry serror_aarch64
 	 * SError exceptions from lower ELs are not currently supported.
 	 * Report their occurrence.
 	 */
-	no_ret	report_unhandled_exception
+	b	report_unhandled_exception
 	check_vector_size serror_aarch64
 
 	/* ---------------------------------------------------------------------
@@ -256,7 +257,7 @@ vector_entry serror_aarch32
 	 * SError exceptions from lower ELs are not currently supported.
 	 * Report their occurrence.
 	 */
-	no_ret	report_unhandled_exception
+	b	report_unhandled_exception
 	check_vector_size serror_aarch32
 
 

--- a/bl32/tsp/aarch64/tsp_exceptions.S
+++ b/bl32/tsp/aarch64/tsp_exceptions.S
@@ -81,19 +81,19 @@ vector_base tsp_exceptions
 	 * -----------------------------------------------------
 	 */
 vector_entry sync_exception_sp_el0
-	no_ret	plat_panic_handler
+	b	plat_panic_handler
 	check_vector_size sync_exception_sp_el0
 
 vector_entry irq_sp_el0
-	no_ret	plat_panic_handler
+	b	plat_panic_handler
 	check_vector_size irq_sp_el0
 
 vector_entry fiq_sp_el0
-	no_ret	plat_panic_handler
+	b	plat_panic_handler
 	check_vector_size fiq_sp_el0
 
 vector_entry serror_sp_el0
-	no_ret	plat_panic_handler
+	b	plat_panic_handler
 	check_vector_size serror_sp_el0
 
 
@@ -103,7 +103,7 @@ vector_entry serror_sp_el0
 	 * -----------------------------------------------------
 	 */
 vector_entry sync_exception_sp_elx
-	no_ret	plat_panic_handler
+	b	plat_panic_handler
 	check_vector_size sync_exception_sp_elx
 
 vector_entry irq_sp_elx
@@ -115,7 +115,7 @@ vector_entry fiq_sp_elx
 	check_vector_size fiq_sp_elx
 
 vector_entry serror_sp_elx
-	no_ret	plat_panic_handler
+	b	plat_panic_handler
 	check_vector_size serror_sp_elx
 
 
@@ -125,19 +125,19 @@ vector_entry serror_sp_elx
 	 * -----------------------------------------------------
 	 */
 vector_entry sync_exception_aarch64
-	no_ret	plat_panic_handler
+	b	plat_panic_handler
 	check_vector_size sync_exception_aarch64
 
 vector_entry irq_aarch64
-	no_ret	plat_panic_handler
+	b	plat_panic_handler
 	check_vector_size irq_aarch64
 
 vector_entry fiq_aarch64
-	no_ret	plat_panic_handler
+	b	plat_panic_handler
 	check_vector_size fiq_aarch64
 
 vector_entry serror_aarch64
-	no_ret	plat_panic_handler
+	b	plat_panic_handler
 	check_vector_size serror_aarch64
 
 
@@ -147,17 +147,17 @@ vector_entry serror_aarch64
 	 * -----------------------------------------------------
 	 */
 vector_entry sync_exception_aarch32
-	no_ret	plat_panic_handler
+	b	plat_panic_handler
 	check_vector_size sync_exception_aarch32
 
 vector_entry irq_aarch32
-	no_ret	plat_panic_handler
+	b	plat_panic_handler
 	check_vector_size irq_aarch32
 
 vector_entry fiq_aarch32
-	no_ret	plat_panic_handler
+	b	plat_panic_handler
 	check_vector_size fiq_aarch32
 
 vector_entry serror_aarch32
-	no_ret	plat_panic_handler
+	b	plat_panic_handler
 	check_vector_size serror_aarch32

--- a/common/aarch32/debug.S
+++ b/common/aarch32/debug.S
@@ -51,7 +51,7 @@ func do_panic
 
 1:
 	mov	lr, r6
-	no_ret	plat_panic_handler
+	b	plat_panic_handler
 endfunc do_panic
 
 	/***********************************************************

--- a/common/aarch64/debug.S
+++ b/common/aarch64/debug.S
@@ -175,6 +175,6 @@ el3_panic:
 _panic_handler:
 	/* Pass to plat_panic_handler the address from where el3_panic was
 	 * called, not the address of the call from el3_panic. */
-	mov	x30,x6
-	no_ret	plat_panic_handler
+	mov	x30, x6
+	b	plat_panic_handler
 endfunc do_panic


### PR DESCRIPTION
Some error paths that lead to a crash dump will overwrite the value in
the x30 register by calling functions with the no_ret macro, which
resolves to a BL instruction. This is not very useful and not what the
reader would expect, since a crash dump should usually show all
registers in the state they were in when the exception happened. This
patch replaces the offending function calls with a B instruction to
preserve the value in x30.

Change-Id: I2a3636f2943f79bab0cd911f89d070012e697c2a
Signed-off-by: Julius Werner <jwerner@chromium.org>