### PR TITLE
[RFC] Support ARMv7 architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,20 +126,28 @@ OD			:=	${CROSS_COMPILE}objdump
 NM			:=	${CROSS_COMPILE}nm
 PP			:=	${CROSS_COMPILE}gcc -E
 
+ifeq (${ARM_ARCH_MAJOR},7)
+march32 			= 	armv7-a
+target32 			= 	armv7a-none-eabi
+else
+march32 			= 	armv8-a
+target32 			= 	armv8a-none-eabi
+endif
+
 ifeq ($(notdir $(CC)),armclang)
-TF_CFLAGS_aarch32	=	-target arm-arm-none-eabi -march=armv8-a
+TF_CFLAGS_aarch32	=	-target arm-arm-none-eabi -march=$(march32)
 TF_CFLAGS_aarch64	=	-target aarch64-arm-none-eabi -march=armv8-a
 else ifneq ($(findstring clang,$(notdir $(CC))),)
-TF_CFLAGS_aarch32	=	-target armv8a-none-eabi
+TF_CFLAGS_aarch32	=	-target $(target32)
 TF_CFLAGS_aarch64	=	-target aarch64-elf
 else
-TF_CFLAGS_aarch32	=	-march=armv8-a
+TF_CFLAGS_aarch32	=	-march=$(march32)
 TF_CFLAGS_aarch64	=	-march=armv8-a
 endif
 
 TF_CFLAGS_aarch64	+=	-mgeneral-regs-only -mstrict-align
 
-ASFLAGS_aarch32		=	-march=armv8-a
+ASFLAGS_aarch32		=	-march=$(march32)
 ASFLAGS_aarch64		=	-march=armv8-a
 
 CPPFLAGS		=	${DEFINES} ${INCLUDES} -nostdinc		\
@@ -458,6 +466,12 @@ $(eval $(call assert_boolean,WARMBOOT_ENABLE_DCACHE_EARLY))
 
 $(eval $(call assert_numeric,ARM_ARCH_MAJOR))
 $(eval $(call assert_numeric,ARM_ARCH_MINOR))
+
+ifeq (${ARM_ARCH_MAJOR},7)
+ifneq (${ARCH},aarch32)
+$(error ARM_ARCH_MAJOR=7 mandates ARCH=aarch32)
+endif
+endif
 
 ################################################################################
 # Add definitions to the cpp preprocessor based on the current build options.

--- a/bl32/sp_min/aarch32/entrypoint.S
+++ b/bl32/sp_min/aarch32/entrypoint.S
@@ -133,6 +133,12 @@ func handle_smc
 	smcc_save_gp_mode_regs
 
 	/*
+	 * AArch32 architectures need to clear the exclusive access when
+	 * entering Monitor mode.
+	 */
+	clrex
+
+	/*
 	 * `sp` still points to `smc_ctx_t`. Save it to a register
 	 * and restore the C runtime stack pointer to `sp`.
 	 */

--- a/common/aarch32/debug.S
+++ b/common/aarch32/debug.S
@@ -71,7 +71,11 @@ endfunc report_exception
 assert_msg1:
 	.asciz "ASSERT: File "
 assert_msg2:
+#if ARCH_IS_ARMV7_WITHOUT_VE
+	.asciz " Line 0x"
+#else
 	.asciz " Line "
+#endif
 
 /* ---------------------------------------------------------------------------
  * Assertion support in assembly.
@@ -113,6 +117,10 @@ func asm_assert
 	bne	1f
 	mov	r4, r6
 
+#if ARCH_IS_ARMV7_WITHOUT_VE
+	/* FIXME: find a trick for getting a decimal value, until then print in hex */
+	bl	asm_print_hex
+#else
 	/* Print line number in decimal */
 	mov	r6, #10			/* Divide by 10 after every loop iteration */
 	ldr	r5, =MAX_DEC_DIVISOR
@@ -124,6 +132,7 @@ dec_print_loop:
 	udiv	r5, r5, r6			/* Reduce divisor */
 	cmp	r5, #0
 	bne	dec_print_loop
+#endif
 
 	bl	plat_crash_console_flush
 

--- a/docs/firmware-design.rst
+++ b/docs/firmware-design.rst
@@ -2366,6 +2366,18 @@ This Architecture Extension is targeted when ``ARM_ARCH_MAJOR`` >= 8, or when
 -  The Compare and Swap instruction is used to implement spinlocks. Otherwise,
    the load-/store-exclusive instruction pair is used.
 
+ARMv7
+~~~~~
+
+This Architecture Extension is targeted when ``ARM_ARCH_MAJOR`` == 7.
+
+Several ARMv7 extensions are supported. Obviously the TrustZone extension
+is mandatory to support ARM Trusted Firmware. Other ARMv7 extensions are
+identified through the ``ARM_ARCH_MINOR`` which is used as a flag bit field:
+
+* ``ARM_ARCH_MINOR`` & 0x01 == 0x01 : supports Large Page Addressing Extension
+* ``ARM_ARCH_MINOR`` & 0x02 == 0x02 : supports Virtualization Extension
+
 Code Structure
 --------------
 

--- a/docs/porting-guide.rst
+++ b/docs/porting-guide.rst
@@ -473,6 +473,36 @@ constants must also be defined:
    Defines the total size of the physical address space in bytes. For example,
    for a 32 bit physical address space, this value should be ``(1ull << 32)``.
 
+If the platform port uses the translation table library code, the following
+constants can be defined:
+
+-  **#define : PLAT\_BASE\_XLAT\_BASE**
+
+   Defines the identity map base address of the translation level 1 base table
+   which memory location is common to all BLs. This feature is useful only for
+   AArch32 only architectures where all BL do share the very same MMU resources
+   since all core modes rely on a single MMU support contrary to AArch64 aware
+   architectures where EL3 and secure EL1 each rely on their specific MMU
+   configuration resources.
+
+-  **#define : PLAT\_BASE\_XLAT\_SIZE**
+
+   Defines the byte size reserved for translation level 1 base table
+   **PLAT\_BASE\_XLAT\_BASE**.
+
+-  **#define : PLAT\_XLAT\_BASE**
+
+   Defines the identity map base address of the translation table array which
+   is common to all BLs. This feature is useful only for AArch32 only
+   architectures where all BL do share the very same MMU resources since
+   all core modes rely on a single MMU support contrary to AArch64 aware
+   architectures where EL3 and secure EL1 each rely on their specific MMU
+   configuration resources.
+
+-  **#define : PLAT\_XLAT\_SIZE**
+
+   Defines the byte size reserved for translation tables **PLAT\__XLAT\_BASE**.
+
 If the platform port uses the IO storage framework, the following constants
 must also be defined:
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -219,11 +219,13 @@ Common build options
 
 -  ``ARM_ARCH_MAJOR``: The major version of ARM Architecture to target when
    compiling ARM Trusted Firmware. Its value must be numeric, and defaults to
-   8 . See also, *ARMv8 Architecture Extensions* in `Firmware Design`_.
+   8 . See also, *ARMv8 Architecture Extensions* and
+   *ARMv7 Architecture Extensions* in `Firmware Design`_.
 
 -  ``ARM_ARCH_MINOR``: The minor version of ARM Architecture to target when
    compiling ARM Trusted Firmware. Its value must be a numeric, and defaults
-   to 0. See also, *ARMv8 Architecture Extensions* in `Firmware Design`_.
+   to 0. See also, *ARMv8 Architecture Extensions* and
+   *ARMv7 Architecture Extensions* in `Firmware Design`_.
 
 -  ``ARM_GIC_ARCH``: Choice of ARM GIC architecture version used by the ARM
    Legacy GIC driver for implementing the platform GIC API. This API is used

--- a/drivers/arm/gic/v2/gicv2_main.c
+++ b/drivers/arm/gic/v2/gicv2_main.c
@@ -130,7 +130,12 @@ void gicv2_driver_init(const gicv2_driver_data_t *plat_driver_data)
 	gic_version = gicd_read_pidr2(plat_driver_data->gicd_base);
 	gic_version = (gic_version >> PIDR2_ARCH_REV_SHIFT)
 					& PIDR2_ARCH_REV_MASK;
-	assert(gic_version == ARCH_REV_GICV2);
+
+	/*
+	 * GICv1 with security extension complies with A-TF GICv2 driver
+	 * as far as virtualization and few tricky power features are not used.
+	 */
+	assert(gic_version == ARCH_REV_GICV2 || gic_version == ARCH_REV_GICV1);
 
 	driver_data = plat_driver_data;
 

--- a/drivers/arm/pl310/pl310.c
+++ b/drivers/arm/pl310/pl310.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2014-2016, STMicroelectronics International N.V.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <arch_helpers.h>
+#include <mmio.h>
+#include <pl310.h>
+
+void pl310_enable(uintptr_t pl310_base)
+{
+	mmio_setbits_32(pl310_base + PL310_CTRL, PL310_CTRL_ENABLE_BIT);
+
+	/* if PL310 AUX_CTRL[FLZW] is enable, enable ACTLR[FLZW] */
+	if (mmio_read_32(pl310_base + PL310_AUX_CTRL) & PL310_AUX_FLZ_BIT)
+		write_actlr(read_actlr() | (1 << 3));	// FIXME: macro for FLZW bit
+}
+
+void pl310_disable(uintptr_t pl310_base)
+{
+	/* if PL310 AUX_CTRL[FLZW] is disable, disable ACTLR[FLZW] */
+	if (mmio_read_32(pl310_base + PL310_AUX_CTRL) & PL310_AUX_FLZ_BIT)
+		write_actlr(read_actlr() & ~(1 << 3));	// FIXME: macro for FLZW bit
+
+	mmio_clrbits_32(pl310_base + PL310_CTRL, PL310_CTRL_ENABLE_BIT);
+}
+
+void pl310_lock_all_ways(uintptr_t pl310_base)
+{
+	uintptr_t pl310_lock = pl310_base + PL310_DCACHE_LOCKDOWN_BASE;
+	uint32_t mask = PL310_8WAYS_MASK;
+	size_t n = PL310_LOCKDOWN_NBREGS;
+
+	if (mmio_read_32(pl310_base + PL310_AUX_CTRL) & PL310_AUX_16WAY_BIT)
+		mask |= PL310_16WAYS_UPPERMASK;
+
+	while (n--) {
+		/* lock data cache */
+		mmio_write_32(pl310_lock, mask);
+		pl310_lock += PL310_LOCKDOWN_SZREG;
+		/* lock instruction cache */
+		mmio_write_32(pl310_lock, mask);
+		pl310_lock += PL310_LOCKDOWN_SZREG;
+	}
+}

--- a/drivers/arm/pl310/pl310_asm.S
+++ b/drivers/arm/pl310/pl310_asm.S
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2014-2016, STMicroelectronics International N.V.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <asm_macros.S>
+#include <pl310.h>
+
+	.globl	pl310_clean_by_way
+	.globl	pl310_invalidate_by_way
+	.globl	pl310_clean_invalidate_by_way
+
+/*
+ * Set sync operation mask according to ways associativity.
+ * Preserve r0 = pl310 iomem base address
+ */
+.macro syncbyway_set_mask reg
+	ldr	\reg, [r0, #PL310_AUX_CTRL]
+	tst	\reg, #PL310_AUX_16WAY_BIT
+	mov	\reg, #PL310_8WAYS_MASK
+	orrne	\reg, \reg, #PL310_16WAYS_UPPERMASK
+.endm
+
+/*
+ * r0: vaddr_t pl310_base
+ * r3: ptr to PL310_CLEAN_BY_WAY, PL310_INV_BY_WAY or PL310_FLUSH_BY_WAY.
+ */
+func __pl310_maintenace_by_way
+
+	syncbyway_set_mask r1
+	ldr	r3, [r3]
+	str	r1, [r0, r3]
+
+	/* loop on ways */
+1:	ldr	r2, [r0, r3]
+	and	r2, r2, r1
+	cmp	r2, #0
+	bne	1b
+
+	/* wait synchro */
+1:	ldr	r1, [r0, #PL310_SYNC]
+	cmp	r1, #0
+	bne	1b
+	mov	r1, #1
+	str	r1, [r0, #PL310_SYNC]
+1:	ldr	r1, [r0, #PL310_SYNC]
+	cmp	r1, #0
+	bne	1b
+
+	mov	pc, lr
+
+endfunc __pl310_maintenace_by_way
+
+/*
+ * void pl310_clean_by_way(vaddr_t base)
+ */
+func pl310_clean_by_way
+
+	ldr	r3, =1f
+	b	__pl310_maintenace_by_way
+1:	.word PL310_CLEAN_BY_WAY
+
+endfunc pl310_clean_by_way
+
+/*
+ * void pl310_invalidate_by_way(vaddr_t base)
+ */
+func pl310_invalidate_by_way
+
+	ldr	r3, =1f
+	b	__pl310_maintenace_by_way
+1:	.word PL310_INV_BY_WAY
+
+endfunc pl310_invalidate_by_way
+
+/*
+ * void pl310_clean_invalidate_by_way(vaddr_t base)
+ */
+func pl310_clean_invalidate_by_way
+
+	ldr	r3, =1f
+	b	__pl310_maintenace_by_way
+1:	.word PL310_FLUSH_BY_WAY
+
+endfunc pl310_clean_invalidate_by_way

--- a/include/common/aarch32/asm_macros.S
+++ b/include/common/aarch32/asm_macros.S
@@ -79,6 +79,26 @@
 	ldr r0, =(\_name + \_size)
 	.endm
 
+#if ARCH_IS_ARMV7_WITHOUT_VE
+	/*
+	 * ARMv7 cores without Virtualization extension do not support the
+	 * eret instruction.
+	 */
+	.macro eret
+	movs pc, lr
+	.endm
+#endif
+
+#if (ARM_ARCH_MAJOR == 7)
+	/* ARMv7 does not support stl instruction */
+	.macro stl _reg, _write_lock
+	dmb
+	str	\_reg, \_write_lock
+	dsb
+	sev
+	.endm
+#endif
+
 	/*
 	 * Macro to mark instances where we're jumping to a function and don't
 	 * expect a return. To provide the function being jumped to with

--- a/include/common/aarch32/el3_common_macros.S
+++ b/include/common/aarch32/el3_common_macros.S
@@ -107,6 +107,7 @@
 	vmsr	FPEXC, r0
 	isb
 
+#if (ARM_ARCH_MAJOR > 7)
 	/* ---------------------------------------------------------------------
 	 * Initialise SDCR, setting all the fields rather than relying on hw.
 	 *
@@ -116,6 +117,8 @@
 	 */
 	ldr	r0, =(SDCR_RESET_VAL | SDCR_SPD(SDCR_SPD_DISABLE))
 	stcopr	r0, SDCR
+#endif
+
 
 	.endm
 

--- a/include/drivers/arm/gic_common.h
+++ b/include/drivers/arm/gic_common.h
@@ -60,6 +60,8 @@
 #define ARCH_REV_GICV3		0x3
 /* GICv2 revision as reported by the PIDR2 register */
 #define ARCH_REV_GICV2		0x2
+/* GICv1 revision as reported by the PIDR2 register */
+#define ARCH_REV_GICV1		0x1
 
 #define IGROUPR_SHIFT		5
 #define ISENABLER_SHIFT		5

--- a/include/drivers/arm/pl310.h
+++ b/include/drivers/arm/pl310.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2014-2016, STMicroelectronics International N.V.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __PL310_H__
+#define __PL310_H__
+
+/* PL310 registers */
+
+#define PL310_CTRL			0x100
+#define PL310_AUX_CTRL			0x104
+#define PL310_TAG_RAM_CTRL		0x108
+#define PL310_DATA_RAM_CTRL		0x10C
+
+#define PL310_SYNC			0x730
+#define PL310_INV_BY_WAY		0x77C
+#define PL310_CLEAN_BY_WAY		0x7BC
+#define PL310_FLUSH_BY_WAY		0x7FC
+#define PL310_INV_BY_PA			0x770
+#define PL310_CLEAN_BY_PA		0x7B0
+#define PL310_FLUSH_BY_PA		0x7F0
+#define PL310_FLUSH_BY_INDEXWAY		0x7F8
+
+#define PL310_DCACHE_LOCKDOWN_BASE	0x900
+#define PL310_ICACHE_LOCKDOWN_BASE	0x904
+
+#define PL310_ADDR_FILT_START		0xC00
+#define PL310_ADDR_FILT_END		0xC04
+
+#define PL310_DEBUG_CTRL		0xF40
+#define PL310_PREFETCH_CTRL		0xF60
+#define PL310_POWER_CTRL		0xF80
+
+/* registers bit fields */
+
+#define PL310_CTRL_ENABLE_BIT		(1 << 0)
+
+#define PL310_AUX_FLZ_BIT		(1 << 0)
+#define PL310_AUX_16WAY_BIT		(1 << 16)
+
+#define PL310_SYNC_SYNCHRO_BIT		(1 << 0)
+
+/* misc */
+
+#define PL310_LINE_SIZE			32
+#define PL310_8_WAYS			8
+
+#define PL310_8WAYS_MASK		0x00FF
+#define PL310_16WAYS_UPPERMASK		0xFF00
+
+#define PL310_LOCKDOWN_NBREGS		8
+#define PL310_LOCKDOWN_SZREG		4
+
+#ifndef __ASSEMBLY__
+
+#include <cdefs.h>
+#include <stdint.h>
+
+void pl310_enable(uintptr_t pl310_base);
+void pl310_disable(uintptr_t pl310_base);
+void pl310_invalidate_by_way(uintptr_t pl310_base);
+void pl310_clean_by_way(uintptr_t pl310_base);
+void pl310_clean_invalidate_by_way(uintptr_t pl310_base);
+void pl310_lock_all_ways(uintptr_t pl310_base);
+
+#endif /* __ASSEMBLY__ */
+
+#endif /* __PL130_H__ */

--- a/include/lib/aarch32/arch.h
+++ b/include/lib/aarch32/arch.h
@@ -8,6 +8,24 @@
 #define __ARCH_H__
 
 /*******************************************************************************
+ * Macros to identify ARMv7 extensions
+ ******************************************************************************/
+#define ARMV7_ARCH_MINOR_LPAE	(1 << 0)
+#define ARMV7_ARCH_MINOR_VE	(1 << 1)
+
+#define ARCH_IS_ARMV7_WITH_LPAE		\
+	((ARM_ARCH_MAJOR == 7) && (ARM_ARCH_MINOR & ARMV7_ARCH_MINOR_LPAE))
+
+#define ARCH_IS_ARMV7_WITHOUT_LPAE	\
+	((ARM_ARCH_MAJOR == 7) && !(ARM_ARCH_MINOR & ARMV7_ARCH_MINOR_LPAE))
+
+#define ARCH_IS_ARMV7_WITH_VE		\
+	((ARM_ARCH_MAJOR == 7) && (ARM_ARCH_MINOR & ARMV7_ARCH_MINOR_VE))
+
+#define ARCH_IS_ARMV7_WITHOUT_VE	\
+	((ARM_ARCH_MAJOR == 7) && !(ARM_ARCH_MINOR & ARMV7_ARCH_MINOR_VE))
+
+/*******************************************************************************
  * MIDR bit definitions
  ******************************************************************************/
 #define MIDR_IMPL_MASK		0xff
@@ -375,6 +393,7 @@
 /* System register defines The format is: coproc, opt1, CRn, CRm, opt2 */
 #define SCR		p15, 0, c1, c1, 0
 #define SCTLR		p15, 0, c1, c0, 0
+#define ACTLR		p15, 0, c1, c0, 1
 #define SDCR		p15, 0, c1, c3, 1
 #define MPIDR		p15, 0, c0, c0, 5
 #define MIDR		p15, 0, c0, c0, 0
@@ -420,6 +439,11 @@
 #define HDCR		p15, 4, c1, c1, 1
 #define PMCR		p15, 0, c9, c12, 0
 #define CNTHP_CTL	p15, 4, c14, c2, 1
+
+/* ARMv7 coproc registers for 32bit MMU descriptor support */
+#define PRRR		p15, 0, c10, c2, 0
+#define NMRR		p15, 0, c10, c2, 1
+#define DACR		p15, 0, c3, c0, 0
 
 /* GICv3 CPU Interface system register defines. The format is: coproc, opt1, CRn, CRm, opt2 */
 #define ICC_IAR1	p15, 0, c12, c12, 0

--- a/include/lib/aarch32/arch.h
+++ b/include/lib/aarch32/arch.h
@@ -102,15 +102,16 @@
 #define ID_PFR1_GIC_MASK	0xf
 
 /* SCTLR definitions */
-#define SCTLR_RES1	((1 << 23) | (1 << 22) | (1 << 11) | (1 << 4) | \
-			(1 << 3))
+#define SCTLR_RES1	((1 << 23) | (1 << 22) | (1 << 4) | (1 << 3))
 #define SCTLR_M_BIT		(1 << 0)
 #define SCTLR_A_BIT		(1 << 1)
 #define SCTLR_C_BIT		(1 << 2)
 #define SCTLR_CP15BEN_BIT	(1 << 5)
 #define SCTLR_ITD_BIT		(1 << 7)
+#define SCTLR_Z_BIT		(1 << 11)
 #define SCTLR_I_BIT		(1 << 12)
 #define SCTLR_V_BIT		(1 << 13)
+#define SCTLR_RR_BIT		(1 << 14)
 #define SCTLR_NTWI_BIT		(1 << 16)
 #define SCTLR_NTWE_BIT		(1 << 18)
 #define SCTLR_WXN_BIT		(1 << 19)
@@ -444,6 +445,9 @@
 #define PRRR		p15, 0, c10, c2, 0
 #define NMRR		p15, 0, c10, c2, 1
 #define DACR		p15, 0, c3, c0, 0
+
+/* ARMv7 Cortex-A9 specific coproc register */
+#define PCR		p15, 0, c15, c0, 0
 
 /* GICv3 CPU Interface system register defines. The format is: coproc, opt1, CRn, CRm, opt2 */
 #define ICC_IAR1	p15, 0, c12, c12, 0

--- a/include/lib/aarch32/arch_helpers.h
+++ b/include/lib/aarch32/arch_helpers.h
@@ -234,6 +234,7 @@ DEFINE_COPROCR_READ_FUNC_64(cntpct, CNTPCT_64)
 DEFINE_COPROCR_RW_FUNCS(scr, SCR)
 DEFINE_COPROCR_RW_FUNCS(ctr, CTR)
 DEFINE_COPROCR_RW_FUNCS(sctlr, SCTLR)
+DEFINE_COPROCR_RW_FUNCS(actlr, ACTLR)
 DEFINE_COPROCR_RW_FUNCS(hsctlr, HSCTLR)
 DEFINE_COPROCR_RW_FUNCS(hcr, HCR)
 DEFINE_COPROCR_RW_FUNCS(hcptr, HCPTR)
@@ -270,6 +271,13 @@ DEFINE_COPROCR_RW_FUNCS(hdcr, HDCR)
 DEFINE_COPROCR_RW_FUNCS(cnthp_ctl, CNTHP_CTL)
 DEFINE_COPROCR_READ_FUNC(pmcr, PMCR)
 
+DEFINE_COPROCR_RW_FUNCS(nsacr, NSACR)
+
+/* ARMv7 coproc registers for 32bit MMU descriptor support */
+DEFINE_COPROCR_RW_FUNCS(prrr, PRRR)
+DEFINE_COPROCR_RW_FUNCS(nmrr, NMRR)
+DEFINE_COPROCR_RW_FUNCS(dacr, DACR)
+
 /*
  * TLBI operation prototypes
  */
@@ -293,6 +301,7 @@ DEFINE_DCOP_PARAM_FUNC(cvac, DCCMVAC)
 
 /* Previously defined accessor functions with incomplete register names  */
 #define dsb()			dsbsy()
+#define dmb()			dmbsy()
 
 #define IS_IN_SECURE() \
 	(GET_NS_BIT(read_scr()) == 0)

--- a/include/lib/aarch32/arch_helpers.h
+++ b/include/lib/aarch32/arch_helpers.h
@@ -278,6 +278,9 @@ DEFINE_COPROCR_RW_FUNCS(prrr, PRRR)
 DEFINE_COPROCR_RW_FUNCS(nmrr, NMRR)
 DEFINE_COPROCR_RW_FUNCS(dacr, DACR)
 
+/* ARMv7 Cortex-A9 specific coproc register */
+DEFINE_COPROCR_RW_FUNCS(pcr, PCR)
+
 /*
  * TLBI operation prototypes
  */

--- a/include/lib/aarch32/smcc_macros.S
+++ b/include/lib/aarch32/smcc_macros.S
@@ -20,6 +20,44 @@
 	mov	r0, sp
 	add	r0, r0, #SMC_CTX_SP_USR
 
+#if ARCH_IS_ARMV7_WITHOUT_VE
+	/* must be in secure state to restore Monitor mode */
+	ldcopr	r4, SCR
+	bic	r2, r4, #SCR_NS_BIT
+	stcopr	r2, SCR
+	isb
+
+	cps	#MODE32_sys
+	stm	r0!, {sp, lr}
+
+	cps	#MODE32_irq
+	mrs	r2, spsr
+	stm	r0!, {r2, sp, lr}
+
+	cps	#MODE32_fiq
+	mrs	r2, spsr
+	stm	r0!, {r2, sp, lr}
+
+	cps	#MODE32_svc
+	mrs	r2, spsr
+	stm	r0!, {r2, sp, lr}
+
+	cps	#MODE32_abt
+	mrs	r2, spsr
+	stm	r0!, {r2, sp, lr}
+
+	cps	#MODE32_und
+	mrs	r2, spsr
+	stm	r0!, {r2, sp, lr}
+
+	/* lr_mon is already saved by caller */
+	cps	#MODE32_mon
+	mrs	r2, spsr
+	stm	r0!, {r2}
+
+	stcopr	r4, SCR
+	isb
+#else
 	/* Save the banked registers including the current SPSR and LR */
 	mrs	r4, sp_usr
 	mrs	r5, lr_usr
@@ -42,9 +80,10 @@
 	mrs	r11, lr_und
 	mrs	r12, spsr
 	stm	r0!, {r4-r12}
-
 	/* lr_mon is already saved by caller */
+
 	ldcopr	r4, SCR
+#endif
 	str	r4, [sp, #SMC_CTX_SCR]
 	.endm
 
@@ -72,6 +111,44 @@
 
 	/* Restore the banked registers including the current SPSR */
 	add	r1, r0, #SMC_CTX_SP_USR
+
+#if ARCH_IS_ARMV7_WITHOUT_VE
+	/* must be in secure state to restore Monitor mode */
+	ldcopr	r4, SCR
+	bic	r2, r4, #SCR_NS_BIT
+	stcopr	r2, SCR
+	isb
+
+	cps	#MODE32_sys
+	ldm	r1!, {sp, lr}
+
+	cps	#MODE32_irq
+	ldm	r1!, {r2, sp, lr}
+	msr	spsr_fsxc, r2
+
+	cps	#MODE32_fiq
+	ldm	r1!, {r2, sp, lr}
+	msr	spsr_fsxc, r2
+
+	cps	#MODE32_svc
+	ldm	r1!, {r2, sp, lr}
+	msr	spsr_fsxc, r2
+
+	cps	#MODE32_abt
+	ldm	r1!, {r2, sp, lr}
+	msr	spsr_fsxc, r2
+
+	cps	#MODE32_und
+	ldm	r1!, {r2, sp, lr}
+	msr	spsr_fsxc, r2
+
+	cps	#MODE32_mon
+	ldm	r1!, {r2}
+	msr	spsr_fsxc, r2
+
+	stcopr	r4, SCR
+	isb
+#else
 	ldm	r1!, {r4-r12}
 	msr	sp_usr, r4
 	msr	lr_usr, r5
@@ -99,6 +176,7 @@
 	 * f->[31:24] and c->[7:0] bits of SPSR.
 	 */
 	msr	spsr_fsxc, r12
+#endif
 
 	/* Restore the LR */
 	ldr	lr, [r0, #SMC_CTX_LR_MON]

--- a/include/lib/cpus/aarch32/cortex_a9.h
+++ b/include/lib/cpus/aarch32/cortex_a9.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __CORTEX_A9_H__
+#define __CORTEX_A9_H__
+
+/*******************************************************************************
+ * Cortex-A9 midr for revision 0
+ ******************************************************************************/
+#define CORTEX_A9_MIDR			0x413FC090
+
+/*******************************************************************************
+ * CPU Auxiliary Control register specific definitions.
+ ******************************************************************************/
+#define CORTEX_A9_ACTLR_SMP		(1 << 6)
+
+#endif /* __CORTEX_A9_H__ */

--- a/include/lib/xlat_tables/xlat_tables_defs.h
+++ b/include/lib/xlat_tables/xlat_tables_defs.h
@@ -7,6 +7,7 @@
 #ifndef __XLAT_TABLES_DEFS_H__
 #define __XLAT_TABLES_DEFS_H__
 
+#include <arch.h>
 #include <utils_def.h>
 
 /* Miscellaneous MMU related constants */
@@ -57,7 +58,11 @@
 #define PAGE_SIZE_MASK		(PAGE_SIZE - 1)
 #define IS_PAGE_ALIGNED(addr)	(((addr) & PAGE_SIZE_MASK) == 0)
 
+#if ARCH_IS_ARMV7_WITHOUT_LPAE
+#define XLAT_ENTRY_SIZE_SHIFT	U(2) /* Each MMU table entry is 4 bytes (1 << 2) */
+#else
 #define XLAT_ENTRY_SIZE_SHIFT	U(3) /* Each MMU table entry is 8 bytes (1 << 3) */
+#endif
 #define XLAT_ENTRY_SIZE		(U(1) << XLAT_ENTRY_SIZE_SHIFT)
 
 #define XLAT_TABLE_SIZE_SHIFT	PAGE_SIZE_SHIFT /* Size of one complete table */

--- a/lib/aarch32/arm32_aeabi_divmod.c
+++ b/lib/aarch32/arm32_aeabi_divmod.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Form ABI specifications:
+ *      int __aeabi_idiv(int numerator, int denominator);
+ *     unsigned __aeabi_uidiv(unsigned numerator, unsigned denominator);
+ *
+ *     typedef struct { int quot; int rem; } idiv_return;
+ *     typedef struct { unsigned quot; unsigned rem; } uidiv_return;
+ *
+ *     __value_in_regs idiv_return __aeabi_idivmod(int numerator,
+ *     int *denominator);
+ *     __value_in_regs uidiv_return __aeabi_uidivmod(unsigned *numerator,
+ *     unsigned denominator);
+ */
+
+/* struct qr - stores qutient/remainder to handle divmod EABI interfaces. */
+struct qr {
+	unsigned q;		/* computed quotient */
+	unsigned r;		/* computed remainder */
+	unsigned q_n;		/* specficies if quotient shall be negative */
+	unsigned r_n;		/* specficies if remainder shall be negative */
+};
+
+static void uint_div_qr(unsigned numerator, unsigned denominator,
+			struct qr *qr);
+
+/* returns in R0 and R1 by tail calling an asm function */
+unsigned __aeabi_uidivmod(unsigned numerator, unsigned denominator);
+
+unsigned __aeabi_uidiv(unsigned numerator, unsigned denominator);
+unsigned __aeabi_uimod(unsigned numerator, unsigned denominator);
+
+/* returns in R0 and R1 by tail calling an asm function */
+signed __aeabi_idivmod(signed numerator, signed denominator);
+
+signed __aeabi_idiv(signed numerator, signed denominator);
+signed __aeabi_imod(signed numerator, signed denominator);
+
+/*
+ * __ste_idivmod_ret_t __aeabi_idivmod(signed numerator, signed denominator)
+ * Numerator and Denominator are received in R0 and R1.
+ * Where __ste_idivmod_ret_t is returned in R0 and R1.
+ *
+ * __ste_uidivmod_ret_t __aeabi_uidivmod(unsigned numerator,
+ *                                       unsigned denominator)
+ * Numerator and Denominator are received in R0 and R1.
+ * Where __ste_uidivmod_ret_t is returned in R0 and R1.
+ */
+#ifdef __GNUC__
+signed ret_idivmod_values(signed quotient, signed remainder);
+unsigned ret_uidivmod_values(unsigned quotient, unsigned remainder);
+#else
+#error "Compiler not supported"
+#endif
+
+static void division_qr(unsigned n, unsigned p, struct qr *qr)
+{
+	unsigned i = 1, q = 0;
+
+	if (p == 0) {
+		qr->r = 0xFFFFFFFF;	/* division by 0 */
+		return;
+	}
+
+	while ((p >> 31) == 0) {
+		i = i << 1;	/* count the max division steps */
+		p = p << 1;     /* increase p until it has maximum size*/
+	}
+
+	while (i > 0) {
+		q = q << 1;	/* write bit in q at index (size-1) */
+		if (n >= p)
+		{
+			n -= p;
+			q++;
+		}
+		p = p >> 1;	/* decrease p */
+		i = i >> 1;	/* decrease remaining size in q */
+	}
+	qr->r = n;
+	qr->q = q;
+}
+
+static void uint_div_qr(unsigned numerator, unsigned denominator, struct qr *qr)
+{
+	division_qr(numerator, denominator, qr);
+
+	/* negate quotient and/or remainder according to requester */
+	if (qr->q_n)
+		qr->q = -qr->q;
+	if (qr->r_n)
+		qr->r = -qr->r;
+}
+
+unsigned __aeabi_uidiv(unsigned numerator, unsigned denominator)
+{
+	struct qr qr = { .q_n = 0, .r_n = 0 };
+
+	uint_div_qr(numerator, denominator, &qr);
+
+	return qr.q;
+}
+
+unsigned __aeabi_uimod(unsigned numerator, unsigned denominator)
+{
+	struct qr qr = { .q_n = 0, .r_n = 0 };
+
+	uint_div_qr(numerator, denominator, &qr);
+
+	return qr.r;
+}
+
+unsigned __aeabi_uidivmod(unsigned numerator, unsigned denominator)
+{
+	struct qr qr = { .q_n = 0, .r_n = 0 };
+
+	uint_div_qr(numerator, denominator, &qr);
+
+	return ret_uidivmod_values(qr.q, qr.r);
+}
+
+signed __aeabi_idiv(signed numerator, signed denominator)
+{
+	struct qr qr = { .q_n = 0, .r_n = 0 };
+
+	if (((numerator < 0) && (denominator > 0)) ||
+	    ((numerator > 0) && (denominator < 0)))
+		qr.q_n = 1;	/* quotient shall be negate */
+
+	if (numerator < 0) {
+		numerator = -numerator;
+		qr.r_n = 1;	/* remainder shall be negate */
+	}
+
+	if (denominator < 0)
+		denominator = -denominator;
+
+	uint_div_qr(numerator, denominator, &qr);
+
+	return qr.q;
+}
+
+signed __aeabi_imod(signed numerator, signed denominator)
+{
+	signed s;
+	signed i;
+	signed j;
+	signed h;
+	struct qr qr = { .q_n = 0, .r_n = 0 };
+
+	/* in case modulo of a power of 2 */
+	for (i = 0, j = 0, h = 0, s = denominator; (s != 0) || (h > 1); i++) {
+		if (s & 1) {
+			j = i;
+			h++;
+		}
+		s = s >> 1;
+	}
+	if (h == 1)
+		return numerator >> j;
+
+	if (((numerator < 0) && (denominator > 0)) ||
+	    ((numerator > 0) && (denominator < 0)))
+		qr.q_n = 1;	/* quotient shall be negate */
+
+	if (numerator < 0) {
+		numerator = -numerator;
+		qr.r_n = 1;	/* remainder shall be negate */
+	}
+
+	if (denominator < 0)
+		denominator = -denominator;
+
+	uint_div_qr(numerator, denominator, &qr);
+
+	return qr.r;
+}
+
+signed __aeabi_idivmod(signed numerator, signed denominator)
+{
+	struct qr qr = { .q_n = 0, .r_n = 0 };
+
+	if (((numerator < 0) && (denominator > 0)) ||
+	    ((numerator > 0) && (denominator < 0)))
+		qr.q_n = 1;	/* quotient shall be negate */
+
+	if (numerator < 0) {
+		numerator = -numerator;
+		qr.r_n = 1;	/* remainder shall be negate */
+	}
+
+	if (denominator < 0)
+		denominator = -denominator;
+
+	uint_div_qr(numerator, denominator, &qr);
+
+	return ret_idivmod_values(qr.q, qr.r);
+}

--- a/lib/aarch32/arm32_aeabi_divmod_a32.S
+++ b/lib/aarch32/arm32_aeabi_divmod_a32.S
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <asm_macros.S>
+
+/*
+ * EABI wrappers from the udivmod and idivmod functions
+ */
+
+	.globl ret_uidivmod_values
+	.globl ret_idivmod_values
+
+/*
+ * signed ret_idivmod_values(signed quot, signed rem);
+ * return quotient and remaining the EABI way (regs r0,r1)
+ */
+func ret_idivmod_values
+        bx lr
+endfunc ret_idivmod_values
+
+/*
+ * unsigned ret_uidivmod_values(unsigned quot, unsigned rem);
+ * return quotient and remaining the EABI way (regs r0,r1)
+ */
+func ret_uidivmod_values
+        bx      lr
+endfunc ret_uidivmod_values

--- a/lib/cpus/aarch32/cortex_a9.S
+++ b/lib/cpus/aarch32/cortex_a9.S
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <arch.h>
+#include <asm_macros.S>
+#include <assert_macros.S>
+#include <cortex_a9.h>
+#include <cpu_macros.S>
+
+#if !ARCH_IS_ARMV7_WITHOUT_LPAE || !ARCH_IS_ARMV7_WITHOUT_VE
+#error Cortex-A9 is an ARMv7 architecture without LPAE and VE
+#endif
+
+	.macro assert_cache_enabled
+#if ENABLE_ASSERTIONS
+		ldcopr	r0, SCTLR
+		tst	r0, #SCTLR_C_BIT
+		ASM_ASSERT(eq)
+#endif
+	.endm
+
+func cortex_a9_disable_smp
+	ldcopr	r0, ACTLR
+	bic	r0, #CORTEX_A9_ACTLR_SMP
+	stcopr	r0, ACTLR
+	isb
+	dsb	sy
+	bx	lr
+endfunc cortex_a9_disable_smp
+
+func cortex_a9_enable_smp
+	ldcopr	r0, ACTLR
+	orr	r0, #CORTEX_A9_ACTLR_SMP
+	stcopr	r0, ACTLR
+	isb
+	bx	lr
+endfunc cortex_a9_enable_smp
+
+func cortex_a9_reset_func
+	b	cortex_a9_enable_smp
+endfunc cortex_a9_reset_func
+
+func cortex_a9_core_pwr_dwn
+	push	{r12, lr}
+
+	assert_cache_enabled
+
+	/* Flush L1 cache */
+	mov	r0, #DC_OP_CISW
+	bl	dcsw_op_level1
+
+	/* Exit cluster coherency */
+	pop	{r12, lr}
+	b	cortex_a9_disable_smp
+endfunc cortex_a9_core_pwr_dwn
+
+func cortex_a9_cluster_pwr_dwn
+	push	{r12, lr}
+
+	assert_cache_enabled
+
+	/* Flush L1 caches */
+	mov	r0, #DC_OP_CISW
+	bl	dcsw_op_level1
+
+	bl	plat_disable_acp
+
+#ifdef PLAT_OUTER_CACHE
+	/* Flush outer requires flushing inner */
+	mov	r0, #DC_OP_CSW
+	bl	dcsw_op_level1
+	bl	plat_flush_outer_cache
+	mov	r0, #DC_OP_CISW
+	bl	dcsw_op_level1
+#endif
+
+	/* Exit cluster coherency */
+	pop	{r12, lr}
+	b	cortex_a9_disable_smp
+endfunc cortex_a9_cluster_pwr_dwn
+
+declare_cpu_ops cortex_a9, CORTEX_A9_MIDR, \
+	cortex_a9_reset_func, \
+	cortex_a9_core_pwr_dwn, \
+	cortex_a9_cluster_pwr_dwn

--- a/lib/psci/psci_setup.c
+++ b/lib/psci/psci_setup.c
@@ -259,8 +259,10 @@ int psci_setup(const psci_lib_args_t *lib_args)
  ******************************************************************************/
 void psci_arch_setup(void)
 {
+#if !ARCH_IS_ARMV7_WITHOUT_VE
 	/* Program the counter frequency */
 	write_cntfrq_el0(plat_get_syscnt_freq2());
+#endif
 
 	/* Initialize the cpu_ops pointer. */
 	init_cpu_ops();

--- a/lib/xlat_tables/aarch32/nonlpae_tables.c
+++ b/lib/xlat_tables/aarch32/nonlpae_tables.c
@@ -1,0 +1,531 @@
+/*
+ * Copyright (c) 2016-2017, Linaro Limited. All rights reserved.
+ * Copyright (c) 2014-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014, STMicroelectronics International N.V.
+ * All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <arch.h>
+#include <arch_helpers.h>
+#include <assert.h>
+#include <cassert.h>
+#include <debug.h>
+#include <platform_def.h>
+#include <string.h>
+#include <utils.h>
+#include <xlat_tables.h>
+#include "../xlat_tables_private.h"
+
+CASSERT(ARCH_IS_ARMV7_WITHOUT_LPAE, non_lpae_support_misconfiguration);
+
+#ifndef DEBUG_XLAT_TABLE
+#define DEBUG_XLAT_TABLE	0
+#endif
+
+#if DEBUG_XLAT_TABLE
+#include <stdio.h>
+#define debug_print(...) tf_printf(__VA_ARGS__)
+#else
+#define debug_print(...) ((void)0)
+#endif
+
+CASSERT(PLAT_VIRT_ADDR_SPACE_SIZE == (1ULL << 32), invalid_vaddr_space_size);
+CASSERT(PLAT_PHY_ADDR_SPACE_SIZE == (1ULL << 32), invalid_paddr_space_size);
+
+#define MMU32B_UNSET_DESC	~0ul
+#define MMU32B_INVALID_DESC	0ul
+
+/*
+ * MMU related values
+ */
+
+/* Sharable */
+#define MMU32B_TTB_S           (1 << 1)
+
+/* Not Outer Sharable */
+#define MMU32B_TTB_NOS         (1 << 5)
+
+/* Normal memory, Inner Non-cacheable */
+#define MMU32B_TTB_IRGN_NC     0
+
+/* Normal memory, Inner Write-Back Write-Allocate Cacheable */
+#define MMU32B_TTB_IRGN_WBWA   (1 << 6)
+
+/* Normal memory, Inner Write-Through Cacheable */
+#define MMU32B_TTB_IRGN_WT     1
+
+/* Normal memory, Inner Write-Back no Write-Allocate Cacheable */
+#define MMU32B_TTB_IRGN_WB     (1 | (1 << 6))
+
+/* Normal memory, Outer Write-Back Write-Allocate Cacheable */
+#define MMU32B_TTB_RNG_WBWA    (1 << 3)
+
+#define MMU32B_DEFAULT_ATTRS \
+		(MMU32B_TTB_S | MMU32B_TTB_NOS | \
+		 MMU32B_TTB_IRGN_WBWA | MMU32B_TTB_RNG_WBWA)
+
+/* armv7 memory mapping attributes: section mapping */
+#define SECTION_SECURE			(0 << 19)
+#define SECTION_NOTSECURE		(1 << 19)
+#define SECTION_SHARED			(1 << 16)
+#define SECTION_NOTGLOBAL		(1 << 17)
+#define SECTION_ACCESS_FLAG		(1 << 10)
+#define SECTION_UNPRIV			(1 << 11)
+#define SECTION_RO			(1 << 15)
+#define SECTION_TEXCB(texcb)		((((texcb) >> 2) << 12) | \
+					 ((((texcb) >> 1) & 0x1) << 3) | \
+					 (((texcb) & 0x1) << 2))
+#define SECTION_DEVICE			SECTION_TEXCB(MMU32B_ATTR_DEVICE_INDEX)
+#define SECTION_NORMAL			SECTION_TEXCB(MMU32B_ATTR_DEVICE_INDEX)
+#define SECTION_NORMAL_CACHED		SECTION_TEXCB(MMU32B_ATTR_IWBWA_OWBWA_INDEX)
+
+#define SECTION_XN			(1 << 4)
+#define SECTION_PXN			(1 << 0)
+#define SECTION_SECTION			(2 << 0)
+
+#define SECTION_PT_NOTSECURE		(1 << 3)
+#define SECTION_PT_PT			(1 << 0)
+
+#define SMALL_PAGE_SMALL_PAGE		(1 << 1)
+#define SMALL_PAGE_SHARED		(1 << 10)
+#define SMALL_PAGE_NOTGLOBAL		(1 << 11)
+#define SMALL_PAGE_TEXCB(texcb)		((((texcb) >> 2) << 6) | \
+					 ((((texcb) >> 1) & 0x1) << 3) | \
+					 (((texcb) & 0x1) << 2))
+#define SMALL_PAGE_DEVICE		SMALL_PAGE_TEXCB(MMU32B_ATTR_DEVICE_INDEX)
+#define SMALL_PAGE_NORMAL		SMALL_PAGE_TEXCB(MMU32B_ATTR_DEVICE_INDEX)
+#define SMALL_PAGE_NORMAL_CACHED	SMALL_PAGE_TEXCB(MMU32B_ATTR_IWBWA_OWBWA_INDEX)
+#define SMALL_PAGE_ACCESS_FLAG		(1 << 4)
+#define SMALL_PAGE_UNPRIV		(1 << 5)
+#define SMALL_PAGE_RO			(1 << 9)
+#define SMALL_PAGE_XN			(1 << 0)
+
+/* The TEX, C and B bits concatenated */
+#define MMU32B_ATTR_DEVICE_INDEX		0x0
+#define MMU32B_ATTR_IWBWA_OWBWA_INDEX		0x1
+
+#define MMU32B_PRRR_IDX(idx, tr, nos)		(((tr) << (2 * (idx))) | \
+					 ((uint32_t)(nos) << ((idx) + 24)))
+#define MMU32B_NMRR_IDX(idx, ir, or)		(((ir) << (2 * (idx))) | \
+					 ((uint32_t)(or) << (2 * (idx) + 16)))
+#define MMU32B_PRRR_DS0			(1 << 16)
+#define MMU32B_PRRR_DS1			(1 << 17)
+#define MMU32B_PRRR_NS0			(1 << 18)
+#define MMU32B_PRRR_NS1			(1 << 19)
+
+#define MMU32B_ATTR_DEVICE_PRRR		MMU32B_PRRR_IDX(MMU32B_ATTR_DEVICE_INDEX, 1, 0)
+#define MMU32B_ATTR_DEVICE_NMRR		MMU32B_NMRR_IDX(MMU32B_ATTR_DEVICE_INDEX, 0, 0)
+
+#define MMU32B_ATTR_IWBWA_OWBWA_PRRR	MMU32B_PRRR_IDX(MMU32B_ATTR_IWBWA_OWBWA_INDEX, 2, 1)
+#define MMU32B_ATTR_IWBWA_OWBWA_NMRR	MMU32B_NMRR_IDX(MMU32B_ATTR_IWBWA_OWBWA_INDEX, 1, 1)
+
+#define DACR_DOMAIN(num, perm)		((perm) << ((num) * 2))
+#define DACR_DOMAIN_PERM_NO_ACCESS	0x0
+#define DACR_DOMAIN_PERM_CLIENT		0x1
+#define DACR_DOMAIN_PERM_MANAGER	0x3
+
+#define NUM_1MB_IN_4GB		(1 << 12)
+#define NUM_4K_IN_1MB		(1 << 8)
+
+#define ONE_MB_SHIFT		20
+
+/* mmu 32b integration */
+#define MMU32B_L1_TABLE_SIZE		(NUM_1MB_IN_4GB * 4)
+#define MMU32B_L2_TABLE_SIZE		(NUM_4K_IN_1MB * 4)
+#define MMU32B_L1_TABLE_ALIGN		(1 << 14)
+#define MMU32B_L2_TABLE_ALIGN		(1 << 10)
+
+static unsigned next_xlat;
+static unsigned long long xlat_max_pa;
+static uintptr_t xlat_max_va;
+
+static uint32_t mmu_l1_base[NUM_1MB_IN_4GB]
+	__aligned(MMU32B_L1_TABLE_ALIGN) __attribute__((section("xlat_table")));
+
+static uint32_t mmu_l2_base[MAX_XLAT_TABLES][NUM_4K_IN_1MB]
+	__aligned(MMU32B_L2_TABLE_ALIGN) __attribute__((section("xlat_table")));
+
+/*
+ * Array of all memory regions stored in order of ascending base address.
+ * The list is terminated by the first entry with size == 0.
+ */
+static mmap_region_t mmap[MAX_MMAP_REGIONS + 1];
+
+void print_mmap(void)
+{
+#if LOG_LEVEL >= LOG_LEVEL_VERBOSE
+	mmap_region_t *mm = mmap;
+
+	debug_print("init xlat - l1:%p  l2:%p (%d)\n",
+		    (void *)mmu_l1_base, (void *)mmu_l2_base, MAX_XLAT_TABLES);
+	debug_print("mmap:\n");
+	while (mm->size) {
+		debug_print(" VA:%p  PA:0x%llx  size:0x%zx  attr:0x%x\n",
+				(void *)mm->base_va, mm->base_pa,
+				mm->size, mm->attr);
+		++mm;
+	};
+	debug_print("\n");
+#endif
+}
+
+void mmap_add(const mmap_region_t *mm)
+{
+	for (; mm->size; mm++)
+		mmap_add_region(mm->base_pa, mm->base_va, mm->size, mm->attr);
+}
+
+void mmap_add_region(unsigned long long base_pa, uintptr_t base_va,
+			size_t size, unsigned int attr)
+{
+	mmap_region_t *mm = mmap;
+	mmap_region_t *mm_last = mm + ARRAY_SIZE(mmap) - 1;
+	unsigned long long end_pa = base_pa + size - 1;
+	uintptr_t end_va = base_va + size - 1;
+
+	debug_print("add region: pa %llx, va %p, size %lx, attr %lx\n",
+				base_pa, (void *)base_va,
+				(unsigned long)size, (unsigned long)attr);
+
+	assert(IS_PAGE_ALIGNED(base_pa));
+	assert(IS_PAGE_ALIGNED(base_va));
+	assert(IS_PAGE_ALIGNED(size));
+
+	if (!size)
+		return;
+
+	assert(base_pa < end_pa); /* Check for overflows */
+	assert(base_va < end_va);
+
+	assert((base_va + (uintptr_t)size - (uintptr_t)1) <=
+					(PLAT_VIRT_ADDR_SPACE_SIZE - 1));
+	assert((base_pa + (unsigned long long)size - 1ULL) <=
+					(PLAT_PHY_ADDR_SPACE_SIZE - 1));
+
+#if ENABLE_ASSERTIONS
+	/* Check for PAs and VAs overlaps with all other regions */
+	for (mm = mmap; mm->size; ++mm) {
+
+		uintptr_t mm_end_va = mm->base_va + mm->size - 1;
+
+		/*
+		 * Check if one of the regions is completely inside the other
+		 * one.
+		 */
+		int fully_overlapped_va =
+			((base_va >= mm->base_va) && (end_va <= mm_end_va)) ||
+			((mm->base_va >= base_va) && (mm_end_va <= end_va));
+
+		/*
+		 * Full VA overlaps are only allowed if both regions are
+		 * identity mapped (zero offset) or have the same VA to PA
+		 * offset. Also, make sure that it's not the exact same area.
+		 */
+		if (fully_overlapped_va) {
+			assert((mm->base_va - mm->base_pa) ==
+			       (base_va - base_pa));
+			assert((base_va != mm->base_va) || (size != mm->size));
+		} else {
+			/*
+			 * If the regions do not have fully overlapping VAs,
+			 * then they must have fully separated VAs and PAs.
+			 * Partial overlaps are not allowed
+			 */
+
+			unsigned long long mm_end_pa =
+						     mm->base_pa + mm->size - 1;
+
+			int separated_pa =
+				(end_pa < mm->base_pa) || (base_pa > mm_end_pa);
+			int separated_va =
+				(end_va < mm->base_va) || (base_va > mm_end_va);
+
+			assert(separated_va && separated_pa);
+		}
+	}
+
+	mm = mmap; /* Restore pointer to the start of the array */
+
+#endif /* ENABLE_ASSERTIONS */
+
+	/* Find correct place in mmap to insert new region */
+	while (mm->base_va < base_va && mm->size) {
+		++mm;
+		assert(mm <= mmap + ARRAY_SIZE(mmap));
+	}
+
+	/*
+	 * If a section is contained inside another one with the same base
+	 * address, it must be placed after the one it is contained in:
+	 *
+	 * 1st |-----------------------|
+	 * 2nd |------------|
+	 * 3rd |------|
+	 *
+	 * This is required for mmap_region_attr() to get the attributes of the
+	 * small region correctly.
+	 */
+	while ((mm->base_va == base_va) && (mm->size > size)) {
+		++mm;
+		assert(mm <= mmap + ARRAY_SIZE(mmap));
+	}
+
+	/* Make room for new region by moving other regions up by one place */
+	memmove(mm + 1, mm, (uintptr_t)mm_last - (uintptr_t)mm);
+
+	/* Check we haven't lost the empty sentinal from the end of the array */
+	assert(mm_last->size == 0);
+
+	mm->base_pa = base_pa;
+	mm->base_va = base_va;
+	mm->size = size;
+	mm->attr = attr;
+
+	if (end_pa > xlat_max_pa)
+		xlat_max_pa = end_pa;
+	if (end_va > xlat_max_va)
+		xlat_max_va = end_va;
+}
+
+/* map all memory as shared/global/domain0/no-usr access */
+static unsigned long mmap_desc(unsigned attr, unsigned long addr_pa,
+					unsigned level)
+{
+	unsigned long desc;
+
+	switch (level) {
+	case 1:
+		assert(!(addr_pa & (MMU32B_L1_TABLE_ALIGN - 1)));
+
+		desc = SECTION_SECTION | SECTION_SHARED;
+
+		desc |= attr & MT_NS ? SECTION_NOTSECURE : 0;
+
+		desc |= SECTION_ACCESS_FLAG;
+		desc |= attr & MT_RW ? 0 : SECTION_RO;
+
+		desc |= attr & MT_MEMORY ? SECTION_NORMAL_CACHED : SECTION_DEVICE;
+
+		if ((attr & MT_RW) || !(attr & MT_MEMORY))
+			desc |= SECTION_XN;
+		break;
+	case 2:
+		assert(!(addr_pa & (MMU32B_L2_TABLE_ALIGN - 1)));
+
+		desc = SMALL_PAGE_SMALL_PAGE | SMALL_PAGE_SHARED;
+
+		desc |= SMALL_PAGE_ACCESS_FLAG;
+		desc |= attr & MT_RW ? 0 : SMALL_PAGE_RO;
+
+		desc |= attr & MT_MEMORY ? SMALL_PAGE_NORMAL_CACHED : SMALL_PAGE_DEVICE;
+
+		if ((attr & MT_RW) || !(attr & MT_MEMORY))
+			desc |= SMALL_PAGE_XN;
+		break;
+	default:
+		panic();
+	}
+
+	/* dump only the non-lpae level 2 tables */
+	if (level == 2) {
+		debug_print(attr & MT_MEMORY ? "MEM" : "dev");
+		debug_print(attr & MT_RW ? "-rw" : "-RO");
+		debug_print(attr & MT_NS ? "-NS" : "-S");
+	}
+
+	return desc | addr_pa;
+}
+
+static int mmap_region_attr(mmap_region_t *mm, unsigned long base_va,
+					unsigned long size)
+{
+	int attr = mm->attr;
+
+	for (;;) {
+		++mm;
+
+		if (!mm->size)
+			return attr; /* Reached end of list */
+		if (mm->base_va >= base_va + size)
+			return attr; /* Next region is after area so end */
+
+		if (mm->base_va + mm->size <= base_va)
+			continue; /* Next region has already been overtaken */
+
+		if ((mm->attr & attr) == attr)
+			continue; /* Region doesn't override attribs so skip */
+
+		attr &= mm->attr;
+
+		if (mm->base_va > base_va ||
+			mm->base_va + mm->size < base_va + size)
+			return -1; /* Region doesn't fully cover our area */
+	}
+}
+
+static mmap_region_t *init_xlation_table_inner(mmap_region_t *mm,
+					unsigned long base_va,
+					unsigned long *table, unsigned level)
+{
+	unsigned level_size_shift = (level == 1) ? ONE_MB_SHIFT : FOUR_KB_SHIFT;
+	unsigned level_size = 1 << level_size_shift;
+	unsigned long level_index_mask = (level == 1) ?
+					(NUM_1MB_IN_4GB - 1) << ONE_MB_SHIFT :
+					(NUM_4K_IN_1MB - 1) << FOUR_KB_SHIFT;
+
+	assert(level == 1 || level == 2);
+
+	debug_print("init xlat table at %p (level%1d)\n", (void *)table, level);
+
+	do  {
+		unsigned long desc = MMU32B_UNSET_DESC;
+
+		if (mm->base_va + mm->size <= base_va) {
+			/* Area now after the region so skip it */
+			++mm;
+			continue;
+		}
+
+		/* dump only non-lpae level 2 tables content */
+		if (level == 2)
+			debug_print("      0x%lx %x " + 6 - 2 * level,
+						base_va, level_size);
+
+		if (mm->base_va >= base_va + level_size) {
+			/* Next region is after area so nothing to map yet */
+			desc = MMU32B_INVALID_DESC;
+		} else if (mm->base_va <= base_va && mm->base_va + mm->size >=
+				base_va + level_size) {
+			/* Next region covers all of area */
+			int attr = mmap_region_attr(mm, base_va, level_size);
+
+			if (attr >= 0) {
+				desc = mmap_desc(attr,
+					base_va - mm->base_va + mm->base_pa,
+					level);
+			}
+		}
+		/* else Next region only partially covers area, so need */
+
+		if (desc == MMU32B_UNSET_DESC) {
+			unsigned long xlat_table;
+
+			/*
+			 * Area not covered by a region so need finer table
+			 * Reuse next level table if any (assert attrib matching).
+			 * Otherwise allocate a xlat table.
+			 */
+			if (*table) {
+				assert((*table & 3) == SECTION_PT_PT);
+				assert(!(*table & SECTION_PT_NOTSECURE) ==
+							!(mm->attr & MT_NS));
+
+				xlat_table = (*table) &
+						~(MMU32B_L1_TABLE_ALIGN - 1);
+				desc = *table;
+			} else {
+				xlat_table = (unsigned long)mmu_l2_base +
+						next_xlat * MMU32B_L2_TABLE_SIZE;
+				assert(++next_xlat <= MAX_XLAT_TABLES);
+				memset((char *)xlat_table, 0,
+						MMU32B_L2_TABLE_SIZE);
+
+				desc = xlat_table | SECTION_PT_PT;
+				desc |= mm->attr & MT_NS
+					? SECTION_PT_NOTSECURE : 0;
+			}
+			/* Recurse to fill in new table */
+			mm = init_xlation_table_inner(mm, base_va,
+							(unsigned long *)xlat_table,
+							level + 1);
+		}
+
+		/* dump only non-lpae level 2 tables content */
+		if (level == 2)
+			debug_print("\n");
+
+		*table++ = desc;
+		base_va += level_size;
+	} while (mm->size && (base_va & level_index_mask));
+
+	return mm;
+}
+
+void init_xlat_tables(void)
+{
+	print_mmap();
+
+	assert(!((unsigned)mmu_l1_base & (MMU32B_L1_TABLE_ALIGN - 1)));
+	assert(!((unsigned)mmu_l2_base & (MMU32B_L2_TABLE_ALIGN - 1)));
+
+	memset(mmu_l1_base, 0, MMU32B_L1_TABLE_SIZE);
+
+	init_xlation_table_inner(mmap, 0, (unsigned long *)mmu_l1_base, 1);
+
+	debug_print("init xlat - max_va=%p, max_pa=%llx\n",
+			(void *)xlat_max_va, xlat_max_pa);
+	assert(xlat_max_va <= PLAT_VIRT_ADDR_SPACE_SIZE - 1);
+	assert(xlat_max_pa <= PLAT_VIRT_ADDR_SPACE_SIZE - 1);
+}
+
+/*******************************************************************************
+ * Function for enabling the MMU in Secure PL1, assuming that the
+ * page-tables have already been created.
+ ******************************************************************************/
+void enable_mmu_secure(unsigned int flags)
+{
+	unsigned int prrr;
+	unsigned int nmrr;
+	unsigned int sctlr;
+
+	assert(IS_IN_SECURE());
+	assert((read_sctlr() & SCTLR_M_BIT) == 0);
+
+	/* Enable Access flag (simplified access permissions) and TEX remap */
+	write_sctlr(read_sctlr() | SCTLR_AFE_BIT | SCTLR_TRE_BIT);
+
+	prrr = MMU32B_ATTR_DEVICE_PRRR | MMU32B_ATTR_IWBWA_OWBWA_PRRR;
+	nmrr = MMU32B_ATTR_DEVICE_NMRR | MMU32B_ATTR_IWBWA_OWBWA_NMRR;
+
+	prrr |= MMU32B_PRRR_NS1 | MMU32B_PRRR_DS1;
+
+	write_prrr(prrr);
+	write_nmrr(nmrr);
+
+	/* Program Domain access control register: domain 0 only */
+	write_dacr(DACR_DOMAIN(0, DACR_DOMAIN_PERM_CLIENT));
+
+	/* Invalidate TLBs at the current exception level */
+	tlbiall();
+
+	/* set MMU base xlat table entry (use only TTBR0) */
+	write_ttbr0((uint32_t)mmu_l1_base | MMU32B_DEFAULT_ATTRS);
+	write_ttbr1(0);
+
+	/*
+	 * Ensure all translation table writes have drained
+	 * into memory, the TLB invalidation is complete,
+	 * and translation register writes are committed
+	 * before enabling the MMU
+	 */
+	dsb();
+	isb();
+
+	sctlr = read_sctlr();
+	sctlr |= SCTLR_M_BIT;
+#if ARCH_IS_ARMV7_WITHOUT_VE
+	sctlr |= SCTLR_WXN_BIT;
+#endif
+
+	if (flags & DISABLE_DCACHE)
+		sctlr &= ~SCTLR_C_BIT;
+	else
+		sctlr |= SCTLR_C_BIT;
+
+	write_sctlr(sctlr);
+
+	/* Ensure the MMU enable takes effect immediately */
+	isb();
+}

--- a/lib/xlat_tables/aarch32/xlat_tables.c
+++ b/lib/xlat_tables/aarch32/xlat_tables.c
@@ -19,8 +19,17 @@
 #define NUM_BASE_LEVEL_ENTRIES	\
        GET_NUM_BASE_LEVEL_ENTRIES(PLAT_VIRT_ADDR_SPACE_SIZE)
 
+#ifdef PLAT_BASE_XLAT_BASE
+CASSERT(!(PLAT_BASE_XLAT_BASE &
+	(NUM_BASE_LEVEL_ENTRIES * sizeof(uint64_t) - 1)),
+	invalid_plat_base_xlat_base);
+CASSERT(PLAT_BASE_XLAT_SIZE == sizeof(uint64_t) * NUM_BASE_LEVEL_ENTRIES,
+	invalid_plat_base_xlat_size);
+static uint64_t *base_xlation_table = (uint64_t *)PLAT_BASE_XLAT_BASE;
+#else
 static uint64_t base_xlation_table[NUM_BASE_LEVEL_ENTRIES]
 		__aligned(NUM_BASE_LEVEL_ENTRIES * sizeof(uint64_t));
+#endif
 
 #if ENABLE_ASSERTIONS
 static unsigned long long get_max_supported_pa(void)

--- a/lib/xlat_tables/aarch64/xlat_tables.c
+++ b/lib/xlat_tables/aarch64/xlat_tables.c
@@ -22,6 +22,10 @@
 #define NUM_BASE_LEVEL_ENTRIES	\
        GET_NUM_BASE_LEVEL_ENTRIES(PLAT_VIRT_ADDR_SPACE_SIZE)
 
+#ifdef PLAT_BASE_XLAT_BASE
+#error "PLAT_BASE_XLAT_BASE is not allowed on AArch64 capable architectures"
+#endif
+
 static uint64_t base_xlation_table[NUM_BASE_LEVEL_ENTRIES]
 		__aligned(NUM_BASE_LEVEL_ENTRIES * sizeof(uint64_t));
 

--- a/lib/xlat_tables_v2/xlat_tables_internal.c
+++ b/lib/xlat_tables_v2/xlat_tables_internal.c
@@ -1152,7 +1152,12 @@ void init_xlat_tables_ctx(xlat_ctx_t *ctx)
 			xlat_arch_get_xn_desc(xlat_arch_current_el());
 
 	/* All tables must be zeroed before mapping any region. */
-
+#ifdef PLAT_BASE_XLAT_BASE
+	inv_dcache_range(PLAT_BASE_XLAT_BASE, PLAT_BASE_XLAT_SIZE);
+#endif
+#ifdef PLAT_XLAT_BASE
+	inv_dcache_range(PLAT_XLAT_BASE, PLAT_XLAT_SIZE);
+#endif
 	for (unsigned int i = 0; i < ctx->base_table_entries; i++)
 		ctx->base_table[i] = INVALID_DESC;
 

--- a/plat/common/aarch32/platform_helpers.S
+++ b/plat/common/aarch32/platform_helpers.S
@@ -12,7 +12,9 @@
 	.weak	plat_crash_console_flush
 	.weak	plat_reset_handler
 	.weak	plat_disable_acp
+	.weak	bl1_plat_prepare_exit
 	.weak	platform_mem_init
+	.weak	plat_error_handler
 	.weak	plat_panic_handler
 
 	/* -----------------------------------------------------
@@ -70,6 +72,25 @@ endfunc plat_disable_acp
 func platform_mem_init
 	bx	lr
 endfunc platform_mem_init
+
+	/* -----------------------------------------------------
+	 * void bl1_plat_prepare_exit(entry_point_info_t *ep_info);
+	 * Called before exiting BL1. Default: do nothing
+	 * -----------------------------------------------------
+	 */
+func bl1_plat_prepare_exit
+	bx	lr
+endfunc bl1_plat_prepare_exit
+
+	/* -----------------------------------------------------
+	 * void plat_error_handler(int err) __dead2;
+	 * Endless loop by default.
+	 * -----------------------------------------------------
+	 */
+func plat_error_handler
+	wfi
+	b	plat_error_handler
+endfunc plat_error_handler
 
 	/* -----------------------------------------------------
 	 * void plat_panic_handler(void) __dead2;


### PR DESCRIPTION
This P-R proposes to add support for ARMv7-A architectures in the ARM trusted firmware.

Obviously, only ARMv7 with the Trustzone extensions can be supported by ARM trusted firmware. The proposed changes aims at covering most such ARMv7 cores. However these changes where initially designed to cover a Cortex-A9 based system.

These changes are split in incrementing changes:
- a single change for basic ARMv7 support
- a proposal to support GICv1
- several changes for Cortex-A9 based systems (non LPAE, division, PL310)
- a late maybe a bit out of scope optimization regarding memory consumption of the xlat table on AArch32 only architectures)

A port for the Cortex-A9 based "b2260" board (96board form factor style) based on this RFC will be later proposed (available from branch armv7-b2260 from https://github.com/etienne-lms/arm-trusted-firmware)