### PR TITLE
psci_common: Resolve GCC static analysis false positive

### DIFF
--- a/lib/psci/psci_common.c
+++ b/lib/psci/psci_common.c
@@ -194,8 +194,15 @@ static void psci_set_req_local_pwr_state(unsigned int pwrlvl,
 					 unsigned int cpu_idx,
 					 plat_local_state_t req_pwr_state)
 {
+	/*
+	 * This should never happen, we have this here to avoid
+	 * "array subscript is above array bounds" errors in GCC.
+	 */
 	assert(pwrlvl > PSCI_CPU_PWR_LVL);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
 	psci_req_local_pwr_states[pwrlvl - 1][cpu_idx] = req_pwr_state;
+#pragma GCC diagnostic pop
 }
 
 /******************************************************************************


### PR DESCRIPTION
Previously commit 555ebb34db8f3424c1b394df2f10ec attmpted to fix this
GCC issue:

services/std_svc/psci/psci_common.c: In function 'psci_do_state_coordination':
services/std_svc/psci/psci_common.c:220:27: error: array subscript is above
array bounds [-Werror=array-bounds]
  psci_req_local_pwr_states[pwrlvl - 1][cpu_idx] = req_pwr_state;

This fix doesn't work as asserts aren't built in non-debug build flows.
Let's ensure this error is fixed for all build cases.

Signed-off-by: Alistair Francis <alistair.francis@xilinx.com>
Signed-off-by: Nathan Rossi <nathan@nathanrossi.com>