### PR TITLE
fix a typo abort sctlr_el2

### DIFF
--- a/lib/el3_runtime/aarch64/context_mgmt.c
+++ b/lib/el3_runtime/aarch64/context_mgmt.c
@@ -229,7 +229,7 @@ void cm_prepare_el3_exit(uint32_t security_state)
 			/* Use SCTLR_EL1.EE value to initialise sctlr_el2 */
 			sctlr_elx = read_ctx_reg(get_sysregs_ctx(ctx),
 						 CTX_SCTLR_EL1);
-			sctlr_elx &= ~SCTLR_EE_BIT;
+			sctlr_elx &= SCTLR_EE_BIT;
 			sctlr_elx |= SCTLR_EL2_RES1;
 			write_sctlr_el2(sctlr_elx);
 		} else if (EL_IMPLEMENTED(2)) {


### PR DESCRIPTION
which will cause write_sctlr_el2 use all sctlr_el1 value except the EE bit

the code doesn't "Use SCTLR_EL1.EE value to initialise sctlr_el2"
but, read out SCTLR_EL1 and clear EE bit, then set to sctlr_el2

Signed-off-by: Ken Kuang <ken.kuang@spreadtrum.com>