### PR TITLE
Hikey: enable watchdog reset

### DIFF
--- a/plat/hisilicon/hikey/hisi_pwrc.c
+++ b/plat/hisilicon/hikey/hisi_pwrc.c
@@ -75,8 +75,13 @@ int hisi_pwrc_setup(void)
 	       pm_asm_code_end - pm_asm_code);
 
 	reg = mmio_read_32(AO_SC_SYS_CTRL1);
+	/* Remap SRAM address for ACPU */
 	reg |= AO_SC_SYS_CTRL1_REMAP_SRAM_AARM |
 	       AO_SC_SYS_CTRL1_REMAP_SRAM_AARM_MSK;
+
+	/* Enable reset signal for watchdog */
+	reg |= AO_SC_SYS_CTRL1_AARM_WD_RST_CFG |
+	       AO_SC_SYS_CTRL1_AARM_WD_RST_CFG_MSK;
 	mmio_write_32(AO_SC_SYS_CTRL1, reg);
 
 	return 0;


### PR DESCRIPTION
At the system boot time we need enable watchdog reset, otherwise after
the watchdog is timeout it cannot reset the SoC. We need set the bit 0
and bit 16 together, the bit 16 is mask bit so after set bit 16 we have
permission to operate bit 0 and bit 0 is watchdog reset enabling bit.

Signed-off-by: Leo Yan <leo.yan@linaro.org>