### PR TITLE
plat/arm: Fix ARM_INSTANTIATE_LOCK syntax anomaly

### DIFF
--- a/include/plat/arm/common/plat_arm.h
+++ b/include/plat/arm/common/plat_arm.h
@@ -45,7 +45,7 @@ void arm_setup_page_tables(uintptr_t total_base,
  * Use this macro to instantiate lock before it is used in below
  * arm_lock_xxx() macros
  */
-#define ARM_INSTANTIATE_LOCK	DEFINE_BAKERY_LOCK(arm_lock);
+#define ARM_INSTANTIATE_LOCK	DEFINE_BAKERY_LOCK(arm_lock)
 #define ARM_LOCK_GET_INSTANCE	(&arm_lock)
 /*
  * These are wrapper macros to the Coherent Memory Bakery Lock API.
@@ -59,7 +59,7 @@ void arm_setup_page_tables(uintptr_t total_base,
 /*
  * Empty macros for all other BL stages other than BL31 and BL32
  */
-#define ARM_INSTANTIATE_LOCK
+#define ARM_INSTANTIATE_LOCK	static int arm_lock __unused
 #define ARM_LOCK_GET_INSTANCE	0
 #define arm_lock_init()
 #define arm_lock_get()

--- a/plat/arm/board/fvp/drivers/pwrc/fvp_pwrc.c
+++ b/plat/arm/board/fvp/drivers/pwrc/fvp_pwrc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -15,7 +15,7 @@
  * TODO: Someday there will be a generic power controller api. At the moment
  * each platform has its own pwrc so just exporting functions is fine.
  */
-ARM_INSTANTIATE_LOCK
+ARM_INSTANTIATE_LOCK;
 
 unsigned int fvp_pwrc_get_cpu_wkr(u_register_t mpidr)
 {

--- a/plat/arm/css/drivers/scp/css_pm_scmi.c
+++ b/plat/arm/css/drivers/scp/css_pm_scmi.c
@@ -76,7 +76,7 @@ void *scmi_handle;
 /* The SCMI channel global object */
 static scmi_channel_t scmi_channel;
 
-ARM_INSTANTIATE_LOCK
+ARM_INSTANTIATE_LOCK;
 
 /*
  * Helper function to suspend a CPU power domain and its parent power domains

--- a/plat/arm/css/drivers/scpi/css_mhu.c
+++ b/plat/arm/css/drivers/scpi/css_mhu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2017, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -23,7 +23,7 @@
 #define CPU_INTR_S_SET		0x308
 #define CPU_INTR_S_CLEAR	0x310
 
-ARM_INSTANTIATE_LOCK
+ARM_INSTANTIATE_LOCK;
 
 /* Weak definition may be overridden in specific CSS based platform */
 #pragma weak plat_arm_pwrc_setup


### PR DESCRIPTION
The current definition of ARM_INSTANTIATE_LOCK macro includes a
semicolon, which means it's omitted where it's used. This is anomalous
for a C statement in global scope.

Fix this by removing semicolon from the definition; and where it's a
NOP, declare a file-scoped variable explicitly tagged as unused to avoid
compiler warning.

No functional changes.

Change-Id: I2c1d92ece4777e272a025011e03b8003f3543335
Signed-off-by: Jeenu Viswambharan <jeenu.viswambharan@arm.com>