### PR TITLE
ARM platforms: Map TSP only when TSPD is included

### DIFF
--- a/include/plat/arm/common/arm_def.h
+++ b/include/plat/arm/common/arm_def.h
@@ -168,10 +168,12 @@
 						ARM_NS_DRAM1_SIZE,	\
 						MT_MEMORY | MT_RW | MT_NS)
 
+#ifdef SPD_tspd
 #define ARM_MAP_TSP_SEC_MEM		MAP_REGION_FLAT(		\
 						TSP_SEC_MEM_BASE,	\
 						TSP_SEC_MEM_SIZE,	\
 						MT_MEMORY | MT_RW | MT_SECURE)
+#endif
 
 #if ARM_BL31_IN_DRAM
 #define ARM_MAP_BL31_SEC_DRAM		MAP_REGION_FLAT(		\

--- a/plat/arm/board/common/board_css_common.c
+++ b/plat/arm/board/common/board_css_common.c
@@ -33,7 +33,9 @@ const mmap_region_t plat_arm_mmap[] = {
 	CSS_MAP_DEVICE,
 	SOC_CSS_MAP_DEVICE,
 	ARM_MAP_NS_DRAM1,
+#ifdef SPD_tspd
 	ARM_MAP_TSP_SEC_MEM,
+#endif
 #ifdef SPD_opteed
 	ARM_OPTEE_PAGEABLE_LOAD_MEM,
 #endif

--- a/plat/arm/board/fvp/fvp_common.c
+++ b/plat/arm/board/fvp/fvp_common.c
@@ -79,7 +79,9 @@ const mmap_region_t plat_arm_mmap[] = {
 	MAP_DEVICE0,
 	MAP_DEVICE1,
 	ARM_MAP_NS_DRAM1,
+#ifdef SPD_tspd
 	ARM_MAP_TSP_SEC_MEM,
+#endif
 #if TRUSTED_BOARD_BOOT
 	/* To access the Root of Trust Public Key registers. */
 	MAP_DEVICE2,


### PR DESCRIPTION
This patch ensures that the ARM_MAP_TSP_SEC_MEM memory region is mapped
in BL2 only if the TSPD has been included in the build. This saves one
entry in the plat_arm_mmap[] array and avoids to map extra memory when
it's not needed.
