### PR TITLE
Add usage note for FVP model versions 11.0 and 8.5

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -1397,6 +1397,11 @@ NOTE: FVPs can be launched with ``--cadi-server`` option such that a
 CADI-compliant debugger (for example, ARM DS-5) can connect to and control its
 execution.
 
+NOTE: With FVP model Version 11.0 Build 11.0.34 and Version 8.5 Build 0.8.5202
+the internal synchronisation timings changed compared to older versions of the
+models. The models can be launched with ``-Q 100`` option if they are required
+to match the run time characteristics of the older versions.
+
 The Foundation FVP is a cut down version of the AArch64 Base FVP. It can be
 downloaded for free from `ARM's website`_.
 


### PR DESCRIPTION
The internal synchronisation timings of the FVP model version
11.0 build 11.0.34 and version 8.5 build 0.8.5202 has been
changed compared to older version of the models.

This change may have an impact on how the model behaves depending
on the workload being run on the model. For example test failures
have been seen where the primary core has powered on a secondary
core but was then starved of host CPU time and so was not able to
update power status, resulting a test failure due to an incorrect
status. This, or similar behaviour, is not to be expected from
real hardware platforms.

This patch adds a usage note on how to launch these models so
that internal synchronisation timing matches that of the older
version of the models, specifically adding the -Q 100 option.

Change-Id: If922afddba1581b7246ec889b3f1598533ea1b7e
Signed-off-by: David Cunado <david.cunado@arm.com>