### PR TITLE
Don't use zero_normalmem in bl2_platform_setup

### DIFF
--- a/plat/arm/css/common/css_bl2_setup.c
+++ b/plat/arm/css/common/css_bl2_setup.c
@@ -74,11 +74,12 @@ void bl2_platform_setup(void)
 	 * at the beginning of the Trusted SRAM. It is is overwritten before
 	 * reaching this function. We need to restore this data, as if the
 	 * target had just come out of reset. This implies:
-	 *  - zeroing the first 128 bytes of Trusted SRAM;
+	 *  - zeroing the first 128 bytes of Trusted SRAM using zeromem instead
+	 *    of zero_normalmem since this is device memory.
 	 *  - restoring the SCP boot configuration.
 	 */
 	VERBOSE("BL2: Restoring SCP reset data in Trusted SRAM\n");
-	zero_normalmem((void *)ARM_TRUSTED_SRAM_BASE, 128);
+	zeromem((void *) ARM_SHARED_RAM_BASE, 128);
 	mmio_write_32(SCP_BOOT_CFG_ADDR, scp_boot_config);
 }
 #endif /* EL3_PAYLOAD_BASE */


### PR DESCRIPTION
zero_normalmem only can zero memory when caches are enabled
and the target memory is a normal memory, otherwise an abort is
generated. In the case of EL3_PAYLOAD_BASE bl2_platform_setup was
calling zero_normalmem with device memory and it generated an abort.

Change-Id: If013603f209a12af488a9c54481f97a8f395b26a
Signed-off-by: Roberto Vargas <roberto.vargas@arm.com>