### PR TITLE
Juno: Define PLAT_LOG_LEVEL_ASSERT to LOG_LEVEL_INFO

### DIFF
--- a/plat/arm/board/juno/include/platform_def.h
+++ b/plat/arm/board/juno/include/platform_def.h
@@ -122,6 +122,12 @@
  */
 #define PLAT_ARM_MAX_BL31_SIZE		0x1D000
 
+/*
+ * Since free SRAM space is scant, enable the ASSERTION message size
+ * optimization by fixing the PLAT_LOG_LEVEL_ASSERT to LOG_LEVEL_INFO (40).
+ */
+#define PLAT_LOG_LEVEL_ASSERT		40
+
 #endif /* ARM_BOARD_OPTIMISE_MEM */
 
 /* CCI related constants */


### PR DESCRIPTION
This patch fixes the PLAT_LOG_LEVEL_ASSERT to 40 which corresponds
to LOG_LEVEL_INFO. Having this level of log for assertions means that the
`assert()` will not generate the strings implied in the expression taken
as parameter. This allows to save some memory when Juno is built for
LOG_LEVEL = LOG_LEVEL_VERBOSE and DEBUG = 1.

Fixes ARM-software/tf-issues#511

Change-Id: Id84a40f803ab07a5a8f6e587167af96694a07d04
Signed-off-by: Soby Mathew <soby.mathew@arm.com>