### PR TITLE
Add CFI debug info to vector entries

### DIFF
--- a/include/common/aarch64/asm_macros.S
+++ b/include/common/aarch64/asm_macros.S
@@ -65,8 +65,12 @@
 	 * security, robustness and potentially facilitates debugging.
 	 */
 	.macro vector_entry  label
+	.cfi_sections .debug_frame
 	.section .vectors, "ax"
 	.align 7, 0
+	.type \label, %function
+	.func \label
+	.cfi_startproc
 	\label:
 	.endm
 
@@ -77,6 +81,8 @@
 	 * vector entry as the parameter
 	 */
 	.macro check_vector_size since
+	  .endfunc
+	  .cfi_endproc
 	  .if (. - \since) > (32 * 4)
 	    .error "Vector exceeds 32 instructions"
 	  .endif


### PR DESCRIPTION
Add Call Frame Information assembler directives to vector entries so
that debuggers display the backtrace of functions that triggered a
synchronous exception. For example, a function triggering a data abort
will be easier to debug if the backtrace can be displayed from a
breakpoint at the beginning of the synchronous exception vector.

DS-5 needs CFI otherwise it will not attempt to display the backtrace.
Other debuggers might have other needs. These debug information are
stored in the ELF file but not in the final binary.

Change-Id: I32dc4e4b7af02546c93c1a45c71a1f6d710d36b1
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>