### PR TITLE
Fix BL2 memory map when OP-TEE is the Secure Payload

### DIFF
--- a/include/plat/arm/common/arm_def.h
+++ b/include/plat/arm/common/arm_def.h
@@ -113,6 +113,15 @@
 					ARM_OPTEE_PAGEABLE_LOAD_BASE,	\
 					ARM_OPTEE_PAGEABLE_LOAD_SIZE,	\
 					MT_MEMORY | MT_RW | MT_SECURE)
+
+/*
+ * Map the memory for the OP-TEE core (also known as OP-TEE pager when paging
+ * support is enabled).
+ */
+#define ARM_MAP_OPTEE_CORE_MEM		MAP_REGION_FLAT(		\
+						BL32_BASE,		\
+						BL32_LIMIT - BL32_BASE,	\
+						MT_MEMORY | MT_RW | MT_SECURE)
 #endif /* SPD_opteed */
 
 #define ARM_NS_DRAM1_BASE		ARM_DRAM1_BASE

--- a/plat/arm/board/common/board_css_common.c
+++ b/plat/arm/board/common/board_css_common.c
@@ -37,6 +37,7 @@ const mmap_region_t plat_arm_mmap[] = {
 	ARM_MAP_TSP_SEC_MEM,
 #endif
 #ifdef SPD_opteed
+	ARM_MAP_OPTEE_CORE_MEM,
 	ARM_OPTEE_PAGEABLE_LOAD_MEM,
 #endif
 	{0}

--- a/plat/arm/board/fvp/fvp_common.c
+++ b/plat/arm/board/fvp/fvp_common.c
@@ -90,6 +90,7 @@ const mmap_region_t plat_arm_mmap[] = {
 	ARM_MAP_BL31_SEC_DRAM,
 #endif
 #ifdef SPD_opteed
+	ARM_MAP_OPTEE_CORE_MEM,
 	ARM_OPTEE_PAGEABLE_LOAD_MEM,
 #endif
 	{0}


### PR DESCRIPTION
The commit 3eb2d67 optimizes the memory map for BL2 when TSP
is not present. But this also broke OP-TEE as it was reusing
the TSP mapping. This patch fixes this problem by adding a
separate mapping for OP-TEE in the BL2 memory map table.

Change-Id: I130a2ea552b7b62d8478081feb1f4ddf5292a118
Signed-off-by: Soby Mathew <soby.mathew@arm.com>