### PR TITLE
Set NS version SCTLR during warmboot path

### DIFF
--- a/bl32/sp_min/sp_min_main.c
+++ b/bl32/sp_min/sp_min_main.c
@@ -196,6 +196,8 @@ void sp_min_main(void)
 void sp_min_warm_boot(void)
 {
 	smc_ctx_t *next_smc_ctx;
+	cpu_context_t *ctx = cm_get_context(NON_SECURE);
+	u_register_t ns_sctlr;
 
 	psci_warmboot_entrypoint();
 
@@ -206,6 +208,16 @@ void sp_min_warm_boot(void)
 
 	copy_cpu_ctx_to_smc_stx(get_regs_ctx(cm_get_context(NON_SECURE)),
 			next_smc_ctx);
+
+	/* Temporarily set the NS bit to access NS SCTLR */
+	write_scr(read_scr() | SCR_NS_BIT);
+	isb();
+	ns_sctlr = read_ctx_reg(get_regs_ctx(ctx), CTX_NS_SCTLR);
+	write_sctlr(ns_sctlr);
+	isb();
+
+	write_scr(read_scr() & ~SCR_NS_BIT);
+	isb();
 }
 
 #if SP_MIN_WITH_SECURE_FIQ


### PR DESCRIPTION
When ARM TF executes in AArch32 state, the NS version of SCTLR
is not being set during warmboot flow. This results in secondary
CPUs entering the Non-secure world with the default reset value
in SCTLR.

This patch explicitly sets the value of the NS version of SCTLR
during the warmboot flow rather than relying on the h/w.

Change-Id: I86bf52b6294baae0a5bd8af0cd0358cc4f55c416
Signed-off-by: David Cunado <david.cunado@arm.com>