### PR TITLE
Reduce time lock in psci_do_cpu_off

### DIFF
--- a/lib/psci/psci_off.c
+++ b/lib/psci/psci_off.c
@@ -49,6 +49,9 @@ int psci_do_cpu_off(unsigned int end_pwrlvl)
 	 */
 	assert(psci_plat_pm_ops->pwr_domain_off);
 
+	/* Construct the psci_power_state for CPU_OFF */
+	psci_set_power_off_state(&state_info);
+
 	/*
 	 * This function acquires the lock corresponding to each power
 	 * level so that by the time all locks are taken, the system topology
@@ -67,9 +70,6 @@ int psci_do_cpu_off(unsigned int end_pwrlvl)
 		if (rc)
 			goto exit;
 	}
-
-	/* Construct the psci_power_state for CPU_OFF */
-	psci_set_power_off_state(&state_info);
 
 	/*
 	 * This function is passed the requested state info and


### PR DESCRIPTION
psci_set_power_off_state only initializes a local variable, so there
isn't any reason why it should be done while the lock is hold.

Change-Id: I1c62f4cd5d860d102532e5a5350152180d41d127
Signed-off-by: Roberto Vargas <roberto.vargas@arm.com>