### PR TITLE
juno: Fix bug in plat_get_my_entrypoint

### DIFF
--- a/plat/arm/board/juno/aarch64/juno_helpers.S
+++ b/plat/arm/board/juno/aarch64/juno_helpers.S
@@ -199,6 +199,7 @@ func juno_do_reset_to_aarch32_state
 	msr	rmr_el3, x0
 	isb
 	wfi
+	b	plat_panic_handler
 endfunc juno_do_reset_to_aarch32_state
 
 	/* -----------------------------------------------------
@@ -233,8 +234,6 @@ func plat_get_my_entrypoint
 	ldr	x0, [x0]
 	cbz	x0, return
 	b	juno_do_reset_to_aarch32_state
-1:
-	b	1b
 return:
 	ret
 endfunc plat_get_my_entrypoint
@@ -287,9 +286,7 @@ func juno_reset_to_aarch32_state
 	str	w1, [x3], #4
 	str	w2, [x3]
 
-	bl	juno_do_reset_to_aarch32_state
-1:
-	b	1b
+	b	juno_do_reset_to_aarch32_state
 endfunc juno_reset_to_aarch32_state
 
 #endif /* JUNO_AARCH32_EL3_RUNTIME */


### PR DESCRIPTION
plat_get_my_entrypoint was branching to juno_do_reset_to_aarch_32_state,
which is not supposed to return, and in case of returning it implemented
an infinite loop. The problem was that plat_get_my_entrypoint was using
"b" instead of "bl", so juno_do_reset_to_aarch_32_state was returning to
the caller of plat_get_my_entrypoint instead of stop the system with a
panic.

To avoid this problem juno_do_reset_to_aarch_32_state was modified to
call directly to plat_panic_handler if it tries to return.

Change-Id: I591cf2dd78d27d8568fb15b91366e4b3dce027b5
Signed-off-by: Roberto Vargas <roberto.vargas@arm.com>