### PR TITLE
Hikey: enable CPU debug module

### DIFF
--- a/plat/hisilicon/hikey/hikey_pm.c
+++ b/plat/hisilicon/hikey/hikey_pm.c
@@ -40,7 +40,9 @@ static int hikey_pwr_domain_on(u_register_t mpidr)
 		hisi_ipc_cluster_on(cpu, cluster);
 
 	hisi_pwrc_set_core_bx_addr(cpu, cluster, hikey_sec_entrypoint);
+	hisi_pwrc_enable_debug(cpu, cluster);
 	hisi_ipc_cpu_on(cpu, cluster);
+
 	return 0;
 }
 

--- a/plat/hisilicon/hikey/hisi_pwrc.c
+++ b/plat/hisilicon/hikey/hisi_pwrc.c
@@ -51,6 +51,21 @@ void hisi_pwrc_set_cluster_wfi(unsigned int cluster)
 	}
 }
 
+void hisi_pwrc_enable_debug(unsigned int core, unsigned int cluster)
+{
+	unsigned int val, enable;
+
+	enable = 1U << (core + PDBGUP_CLUSTER1_SHIFT * cluster);
+
+	/* Enable debug module */
+	val = mmio_read_32(ACPU_SC_PDBGUP_MBIST);
+	mmio_write_32(ACPU_SC_PDBGUP_MBIST, val | enable);
+	do {
+		/* RAW barrier */
+		val = mmio_read_32(ACPU_SC_PDBGUP_MBIST);
+	} while (!(val & enable));
+}
+
 int hisi_pwrc_setup(void)
 {
 	unsigned int reg, sec_entrypoint;

--- a/plat/hisilicon/hikey/include/hisi_pwrc.h
+++ b/plat/hisilicon/hikey/include/hisi_pwrc.h
@@ -13,6 +13,8 @@ void hisi_pwrc_set_cluster_wfi(unsigned int id);
 void hisi_pwrc_set_core_bx_addr(unsigned int core,
 				unsigned int cluster,
 				uintptr_t entry_point);
+void hisi_pwrc_enable_debug(unsigned int core,
+			    unsigned int cluster);
 int hisi_pwrc_setup(void);
 
 #endif /*__ASSEMBLY__*/


### PR DESCRIPTION
Every CPU has its own debug module and this module is used by JTAG
debugging and coresight tracing. If without enabling it, it's easily to
introduce lockup issue when we enable debugging features.

This patch is to enable CPU debug module when power on CPU; this allows
connecting to all cores through JTAG and used by kernel coresight
driver.

Signed-off-by: Matthias Welwarsky <maw@sysgo.com>
Signed-off-by: Leo Yan <leo.yan@linaro.org>