### PR TITLE
Filter out invalid configure for EL3_PAYLOAD_BASE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,12 @@ ifdef EL3_PAYLOAD_BASE
                 $(warning "PRELOADED_BL33_BASE and EL3_PAYLOAD_BASE are \
                 incompatible build options. EL3_PAYLOAD_BASE has priority.")
         endif
+        ifneq (${GENERATE_COT},0)
+                $(error "GENERATE_COT and EL3_PAYLOAD_BASE are incompatible build options.")
+        endif
+        ifneq (${TRUSTED_BOARD_BOOT},0)
+                $(error "TRUSTED_BOARD_BOOT and EL3_PAYLOAD_BASE are incompatible build options.")
+        endif
 endif
 
 ifeq (${NEED_BL33},yes)


### PR DESCRIPTION
TRUSTED_BOARD_BOOT and GENERATE_COT is not
compatible with EL3_PAYLOAD_BASE

Change-Id: I538c77e1f6c7da400d30ae4d633b8fcc55742202
Signed-off-by: Qixiang Xu <qixiang.xu@arm.com>