### PR TITLE
xlat: Use MAP_REGION macro as compatibility layer

### DIFF
--- a/include/lib/xlat_tables/xlat_tables_v2.h
+++ b/include/lib/xlat_tables/xlat_tables_v2.h
@@ -23,7 +23,12 @@
 /* Helper macro to define entries for mmap_region_t. It allows to
  * re-map address mappings from 'pa' to 'va' for each region.
  */
-#define MAP_REGION(pa, va, sz, attr) {(pa), (va), (sz), (attr)}
+#define MAP_REGION(_pa, _va, _sz, _attr) ((mmap_region_t){	\
+	.base_pa = (_pa),					\
+	.base_va = (_va),					\
+	.size    = (_sz),					\
+	.attr    = (_attr),					\
+	})
 
 /*
  * Shifts and masks to access fields of an mmap_attr_t

--- a/lib/xlat_tables_v2/xlat_tables_internal.c
+++ b/lib/xlat_tables_v2/xlat_tables_internal.c
@@ -770,12 +770,7 @@ void mmap_add_region(unsigned long long base_pa,
 				size_t size,
 				mmap_attr_t attr)
 {
-	mmap_region_t mm = {
-		.base_va = base_va,
-		.base_pa = base_pa,
-		.size = size,
-		.attr = attr,
-	};
+	mmap_region_t mm = MAP_REGION(base_pa, base_va, size, attr);
 	mmap_add_region_ctx(&tf_xlat_ctx, &mm);
 }
 
@@ -892,12 +887,7 @@ int mmap_add_dynamic_region_ctx(xlat_ctx_t *ctx, mmap_region_t *mm)
 int mmap_add_dynamic_region(unsigned long long base_pa,
 			    uintptr_t base_va, size_t size, mmap_attr_t attr)
 {
-	mmap_region_t mm = {
-		.base_va = base_va,
-		.base_pa = base_pa,
-		.size = size,
-		.attr = attr,
-	};
+	mmap_region_t mm = MAP_REGION(base_pa, base_va, size, attr);
 	return mmap_add_dynamic_region_ctx(&tf_xlat_ctx, &mm);
 }
 


### PR DESCRIPTION
Use the MAP_REGION to build the mmap_region_t argument in wrappers like
mmap_add_region(). Evolution of the mmap_region_t might require adding
new members with a non-zero default value. Users of MAP_REGION are
protected against such evolution. This commit also protects users of
mmap_add_region() and mmap_add_dynamic_region() functions against these
evolutions.

Also make the MAP_REGION macro implementation more explicit and make it
a mmap_region_t compound literal to make it useable as a function
parameter on its own and to prevent using it in initialization of
variables of different type.

Change-Id: I7bfc4689f6dd4dd23c895b65f628d8ee991fc161
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>