### PR TITLE
Set default value of USE_TBBR_DEFS

### DIFF
--- a/tools/cert_create/Makefile
+++ b/tools/cert_create/Makefile
@@ -10,6 +10,7 @@ V		?= 0
 DEBUG		:= 0
 BINARY		:= ${PROJECT}${BIN_EXT}
 OPENSSL_DIR	:= /usr
+USE_TBBR_DEFS   := 1
 
 OBJECTS := src/cert.o \
            src/cmd_opt.o \


### PR DESCRIPTION
Using the OIDs defined in tbbr_oids.h is the recommended way to build
the cert_create tool. This patch hence sets default value of the build
flag USE_TBBR_DEFS to 1 in the Makefile in `tools/cert_create` folder
when cert_create is built from this folder.

Fixes ARM-software/tf-issues#482

Change-Id: Id1d224826b3417770bccbefa1b68d9bdb3b567f0
Signed-off-by: Soby Mathew <soby.mathew@arm.com>