### PR TITLE
xlat: fix mm copy when adding a region

### DIFF
--- a/lib/xlat_tables_v2/xlat_tables_internal.c
+++ b/lib/xlat_tables_v2/xlat_tables_internal.c
@@ -754,10 +754,7 @@ void mmap_add_region_ctx(xlat_ctx_t *ctx, const mmap_region_t *mm)
 	 */
 	assert(mm_last->size == 0);
 
-	mm_cursor->base_pa = mm->base_pa;
-	mm_cursor->base_va = mm->base_va;
-	mm_cursor->size = mm->size;
-	mm_cursor->attr = mm->attr;
+	*mm_cursor = *mm;
 
 	if (end_pa > ctx->max_pa)
 		ctx->max_pa = end_pa;
@@ -832,10 +829,8 @@ int mmap_add_dynamic_region_ctx(xlat_ctx_t *ctx, mmap_region_t *mm)
 	 */
 	assert(mm_last->size == 0);
 
-	mm_cursor->base_pa = mm->base_pa;
-	mm_cursor->base_va = mm->base_va;
-	mm_cursor->size = mm->size;
-	mm_cursor->attr = mm->attr | MT_DYNAMIC;
+	*mm_cursor = *mm;
+	mm_cursor->attr |= MT_DYNAMIC;
 
 	/*
 	 * Update the translation tables if the xlat tables are initialized. If


### PR DESCRIPTION
mmap_add_region_ctx and mmap_add_dynamic_region_ctx are clearing members
that they are not aware of by copying each member one by one. Replace
this by structure assignment.

Change-Id: I7c70cb408c8a8eb551402a5d8d956c1fb7f32b55
Signed-off-by: Douglas Raillard <douglas.raillard@arm.com>