### PR TITLE
zynqmp: Sync function declaration and definition

### DIFF
--- a/plat/xilinx/zynqmp/pm_service/pm_api_sys.h
+++ b/plat/xilinx/zynqmp/pm_service/pm_api_sys.h
@@ -85,8 +85,8 @@ enum pm_ret_status pm_mmio_write(uintptr_t address,
 				 unsigned int mask,
 				 unsigned int value);
 enum pm_ret_status pm_mmio_read(uintptr_t address, unsigned int *value);
-enum pm_ret_status pm_fpga_load(uint32_t address_high,
-				uint32_t address_low,
+enum pm_ret_status pm_fpga_load(uint32_t address_low,
+				uint32_t address_high,
 				uint32_t size,
 				uint32_t flags);
 enum pm_ret_status pm_fpga_get_status(unsigned int *value);


### PR DESCRIPTION
Synchronize argument order between function definition and declaration
of pm_fpga_load.

Fixes ARM-software/tf-issues#514
Signed-off-by: Soren Brinkmann <soren.brinkmann@xilinx.com>