### PR TITLE
Makefile: Add ability to build dtb (v2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ OC			:=	${CROSS_COMPILE}objcopy
 OD			:=	${CROSS_COMPILE}objdump
 NM			:=	${CROSS_COMPILE}nm
 PP			:=	${CROSS_COMPILE}gcc -E
+DTC			?=	dtc
 
 ifeq ($(notdir $(CC)),armclang)
 TF_CFLAGS_aarch32	=	-target arm-arm-none-eabi -march=armv8-a
@@ -154,6 +155,8 @@ TF_CFLAGS		+=	$(CPPFLAGS) $(TF_CFLAGS_$(ARCH))		\
 TF_LDFLAGS		+=	--fatal-warnings -O1
 TF_LDFLAGS		+=	--gc-sections
 TF_LDFLAGS		+=	$(TF_LDFLAGS_$(ARCH))
+
+DTC_FLAGS		+=	-I dts -O dtb
 
 ################################################################################
 # Common sources and include directories
@@ -431,6 +434,10 @@ endif
 endif
 endif
 
+ifdef FDT_SOURCES
+NEED_FDT := yes
+endif
+
 ################################################################################
 # Build options checks
 ################################################################################
@@ -524,7 +531,7 @@ endif
 # Build targets
 ################################################################################
 
-.PHONY:	all msg_start clean realclean distclean cscope locate-checkpatch checkcodebase checkpatch fiptool fip fwu_fip certtool
+.PHONY:	all msg_start clean realclean distclean cscope locate-checkpatch checkcodebase checkpatch fiptool fip fwu_fip certtool dtbs
 .SUFFIXES:
 
 all: msg_start
@@ -575,6 +582,13 @@ ifeq (${NEED_BL2U},yes)
 BL2U_PATH	:= $(if ${BL2U},${BL2U},$(call IMG_BIN,2u))
 $(if ${BL2U}, ,$(eval $(call MAKE_BL,2u)))
 $(eval $(call FWU_FIP_ADD_PAYLOAD,${BL2U_PATH},--ap-fwu-cfg))
+endif
+
+# Expand build macros for the different images
+ifeq (${NEED_FDT},yes)
+$(eval $(call MAKE_DTBS,$(BUILD_PLAT)/fdts,$(FDT_SOURCES)))
+$(eval $(call MAKE_FDT))
+dtbs: $(DTBS)
 endif
 
 locate-checkpatch:
@@ -704,6 +718,7 @@ help:
 	@echo "  distclean      Remove all build artifacts for all platforms"
 	@echo "  certtool       Build the Certificate generation tool"
 	@echo "  fiptool        Build the Firmware Image Package (FIP) creation tool"
+	@echo "  dtbs           Build the Flattened device tree (if required for the platform)"
 	@echo ""
 	@echo "Note: most build targets require PLAT to be set to a specific platform."
 	@echo ""


### PR DESCRIPTION
This is a revamp of the original approach in:
https://github.com/ARM-software/arm-trusted-firmware/pull/747

Current build system has no means to automatically generate dtbs from
dts, instead, stores the dtbs in the fdts/ folder. While this makes
perfect sense for many reference platforms, this becomes a minor
breakage in development flow for newer platforms.

However, this can be solved by providing a rule for the dtbs while
building the ATF binaries by purely describing which dts sources we
need.

For example, with this change, we will now be able to describe the
dtbs we need for the platform in the corresponding platform.mk file:
FDT_SOURCES += fdts/abc.dts

This should be able to generate the abc.dtb appropriately.

Since device trees are specification of hardware, we don't tie the rule
to any specific BL, instead a generic rule is introduced.

Further, this approach allows us to generate appropriate dtbs which may be
need to be regenerated when a common dtsi gets updated, by just
restricting changes to the dtsi alone, instead of synchronizing all the
dtbs as well.

If dtc is not available in default paths, but is available in an
alternate location, it can be chosen by overriding the DTC variable
such as 'make DTC=~/dtc/dtc ....`

NOTE: dtbs are built only with the explicit make dtbs command. The rule
is only available if the platform defines a FDT_SOURCES variable.

Signed-off-by: Benjamin Fair <b-fair@ti.com>
Signed-off-by: Nishanth Menon <nm@ti.com>