### PR TITLE
Fix type of `unsigned long` constants

### DIFF
--- a/drivers/arm/ccn/ccn.c
+++ b/drivers/arm/ccn/ccn.c
@@ -236,7 +236,7 @@ static unsigned long long ccn_master_to_rn_id_map(unsigned long long master_map)
 		node_id = ccn_plat_desc->master_to_rn_id_map[iface_id];
 
 		/* Set the bit corresponding to this node ID */
-		rn_id_map |= (1UL << node_id);
+		rn_id_map |= (1ULL << node_id);
 	}
 
 	return rn_id_map;

--- a/drivers/arm/ccn/ccn_private.h
+++ b/drivers/arm/ccn/ccn_private.h
@@ -134,13 +134,13 @@ typedef enum rn_types {
 #define HNF_SAM_CTRL_SN1_ID_SHIFT	8
 #define HNF_SAM_CTRL_SN2_ID_SHIFT	16
 
-#define HNF_SAM_CTRL_TAB0_MASK		0x3fUL
+#define HNF_SAM_CTRL_TAB0_MASK		ULL(0x3f)
 #define HNF_SAM_CTRL_TAB0_SHIFT		48
-#define HNF_SAM_CTRL_TAB1_MASK		0x3fUL
+#define HNF_SAM_CTRL_TAB1_MASK		ULL(0x3f)
 #define HNF_SAM_CTRL_TAB1_SHIFT		56
 
 #define HNF_SAM_CTRL_3SN_ENB_SHIFT	32
-#define HNF_SAM_CTRL_3SN_ENB_MASK	0x01UL
+#define HNF_SAM_CTRL_3SN_ENB_MASK	ULL(0x01)
 
 /*
  * Macro to create a value suitable for programming into a HNF SAM Control
@@ -169,7 +169,7 @@ typedef enum rn_types {
 #define FOR_EACH_BIT(bit_pos, bit_map)			\
 	for (bit_pos = __builtin_ctzll(bit_map);	\
 	     bit_map;					\
-	     bit_map &= ~(1UL << bit_pos),		\
+	     bit_map &= ~(1ULL << (bit_pos)),		\
 	     bit_pos = __builtin_ctzll(bit_map))
 
 /*

--- a/include/drivers/arm/gic_v3.h
+++ b/include/drivers/arm/gic_v3.h
@@ -26,17 +26,17 @@
 #define GICR_WAKER		0x14
 
 /* GICR_WAKER bit definitions */
-#define WAKER_CA		(1UL << 2)
-#define WAKER_PS		(1UL << 1)
+#define WAKER_CA		(U(1) << 2)
+#define WAKER_PS		(U(1) << 1)
 
 /* GICR_TYPER bit definitions */
 #define GICR_TYPER_AFF_SHIFT	32
 #define GICR_TYPER_AFF_MASK	0xffffffff
-#define GICR_TYPER_LAST		(1UL << 4)
+#define GICR_TYPER_LAST		(U(1) << 4)
 
 /* GICv3 ICC_SRE register bit definitions*/
-#define ICC_SRE_EN		(1UL << 3)
-#define ICC_SRE_SRE		(1UL << 0)
+#define ICC_SRE_EN		(U(1) << 3)
+#define ICC_SRE_SRE		(U(1) << 0)
 
 /*******************************************************************************
  * GICv3 defintions

--- a/include/lib/aarch64/arch.h
+++ b/include/lib/aarch64/arch.h
@@ -312,7 +312,7 @@
 /*
  * TCR defintions
  */
-#define TCR_EL3_RES1		((1UL << 31) | (1UL << 23))
+#define TCR_EL3_RES1		((U(1) << 31) | (U(1) << 23))
 #define TCR_EL1_IPS_SHIFT	U(32)
 #define TCR_EL3_PS_SHIFT	U(16)
 

--- a/include/lib/utils_def.h
+++ b/include/lib/utils_def.h
@@ -16,7 +16,7 @@
 
 #define SIZE_FROM_LOG2_WORDS(n)		(4 << (n))
 
-#define BIT(nr)				(1UL << (nr))
+#define BIT(nr)				(1ULL << (nr))
 
 #define MIN(x, y) __extension__ ({	\
 	__typeof__(x) _x = (x);		\

--- a/plat/nvidia/tegra/common/tegra_gic.c
+++ b/plat/nvidia/tegra/common/tegra_gic.c
@@ -237,10 +237,10 @@ static uint32_t tegra_gic_get_pending_interrupt_id(void)
 
 	id = gicc_read_hppir(TEGRA_GICC_BASE) & INT_ID_MASK;
 
-	if (id < 1022UL) {
+	if (id < 1022U) {
 		ret = id;
-	} else if (id == 1023UL) {
-		ret = 0xFFFFFFFFUL; /* INTR_ID_UNAVAILABLE */
+	} else if (id == 1023U) {
+		ret = 0xFFFFFFFFU; /* INTR_ID_UNAVAILABLE */
 	} else {
 		/*
 		 * Find out which non-secure interrupt it is under the assumption that

--- a/plat/nvidia/tegra/soc/t186/drivers/mce/ari.c
+++ b/plat/nvidia/tegra/soc/t186/drivers/mce/ari.c
@@ -435,7 +435,7 @@ uint64_t ari_read_write_mca(uint32_t ari_base, uint64_t cmd, uint64_t *data)
 
 	ret = ari_request_wait(ari_base, 0U, TEGRA_ARI_MCA,
 			       (uint32_t)mca_arg_data,
-			       (uint32_t)(mca_arg_data >> 32UL));
+			       (uint32_t)(mca_arg_data >> 32U));
 	if (ret == 0) {
 		resp_lo = ari_get_response_low(ari_base);
 		resp_hi = ari_get_response_high(ari_base);
@@ -450,7 +450,7 @@ uint64_t ari_read_write_mca(uint32_t ari_base, uint64_t cmd, uint64_t *data)
 			if (data != NULL) {
 				resp_lo = ari_get_request_low(ari_base);
 				resp_hi = ari_get_request_high(ari_base);
-				*data = ((uint64_t)resp_hi << 32UL) |
+				*data = ((uint64_t)resp_hi << 32U) |
 					 (uint64_t)resp_lo;
 			}
 		}
@@ -513,7 +513,7 @@ int32_t ari_read_write_uncore_perfmon(uint32_t ari_base, uint64_t req,
 		 * to the uncore perfmon registers
 		 */
 		val = (req_cmd == UNCORE_PERFMON_CMD_WRITE) ?
-			(uint32_t)*data : 0UL;
+			(uint32_t)*data : 0U;
 
 		ret = ari_request_wait(ari_base, 0U, TEGRA_ARI_PERFMON, val,
 				       (uint32_t)req);


### PR DESCRIPTION
The type `unsigned long` is 32 bit wide in AArch32, but 64 bit wide in AArch64. This is inconsistent and that's why we avoid using it as per the Coding Guidelines. This patch changes all `UL` occurrences to `U` or `ULL` depending on the context so that the size of the constant is clear.

This problem affected the macro `BIT(nr)`. As long as this macro is used to fill fields of registers, that's not a problem, since all registers are 32 bit wide in AArch32 and 64 bit wide in AArch64. However, if the macro is used to fill the fields of a 64-bit integer, it won't be able to set the upper 32 bits in AArch32.

By changing the type of this macro to `unsigned long long` the behaviour is always the same regardless of the architecture, as this type is 64-bit wide in both cases.

Some Tegra platform files have been modified by this patch.