### PR TITLE
FVP: Include utils_def.h instead of utils.h

### DIFF
--- a/plat/arm/board/fvp/include/platform_def.h
+++ b/plat/arm/board/fvp/include/platform_def.h
@@ -11,7 +11,7 @@
 #include <board_arm_def.h>
 #include <common_def.h>
 #include <tzc400.h>
-#include <utils.h>
+#include <utils_def.h>
 #include <v2m_def.h>
 #include "../fvp_def.h"
 


### PR DESCRIPTION
platform_def.h doesn't need all the definitions in utils.h,
the ones in utils_def.h are enough. This patch is related
to the changes introduced by commit 53d9c9c85b.
