### PR TITLE
Introduce BOOL macro

### DIFF
--- a/include/lib/utils_def.h
+++ b/include/lib/utils_def.h
@@ -81,4 +81,11 @@
 	((ARM_ARCH_MAJOR > _maj) || \
 	 ((ARM_ARCH_MAJOR == _maj) && (ARM_ARCH_MINOR >= _min)))
 
+/*
+ * Convert an integer value to an essentially boolean value explicitely. This
+ * allows using boolean operators on the result. For example a "!=" can be used
+ * as a boolean XOR on the result.
+ */
+#define BOOL(x) ((x) != 0)
+
 #endif /* __UTILS_DEF_H__ */


### PR DESCRIPTION
Introduce the BOOL macro to convert any integer type to an essentially
boolean value. This allows to write boolean expressions using integers
where the conversion between integer and boolean is explicit. For
example,

instead of writing: !!(x)   ^  !!(y)
you would write   : BOOL(x) != BOOL(y)
