### PR TITLE
TSP: Support multi-threading CPUs on FVP

### DIFF
--- a/plat/arm/board/fvp/tsp/tsp-fvp.mk
+++ b/plat/arm/board/fvp/tsp/tsp-fvp.mk
@@ -1,12 +1,13 @@
 #
-# Copyright (c) 2013-2015, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
 # TSP source files specific to FVP platform
-BL32_SOURCES		+=	plat/arm/board/fvp/fvp_topology.c		\
+BL32_SOURCES		+=	plat/arm/board/fvp/aarch64/fvp_helpers.S	\
 				plat/arm/board/fvp/drivers/pwrc/fvp_pwrc.c	\
+				plat/arm/board/fvp/fvp_topology.c		\
 				plat/arm/board/fvp/tsp/fvp_tsp_setup.c		\
 				${FVP_GIC_SOURCES}
 


### PR DESCRIPTION
Commit 11ad8f208db42f7729b0ce2bd16c631c293e665c added supporting
multi-threaded CPUs on FVP platform, including modifications for
calculating CPU IDs. This patch imports the strong definition of the
same CPU ID calculation on FVP platform for TSP.

Without this patch, TSP on FVP was using the default CPU ID calculation,
which would end up being wrong on CPUs with multi-threading.

Change-Id: If67fd492dfce1f57224c9e693988c4b0f89a9a9a
Signed-off-by: Jeenu Viswambharan <jeenu.viswambharan@arm.com>