### PR TITLE
Increase PLAT_ARM_MMAP_ENTRIES and MAX_XLAT_TABLES

### DIFF
--- a/include/plat/arm/board/common/board_arm_def.h
+++ b/include/plat/arm/board/common/board_arm_def.h
@@ -54,9 +54,9 @@
  */
 #if defined(IMAGE_BL31) || defined(IMAGE_BL32)
 # define PLAT_ARM_MMAP_ENTRIES		6
-# define MAX_XLAT_TABLES		4
+# define MAX_XLAT_TABLES		5
 #else
-# define PLAT_ARM_MMAP_ENTRIES		10
+# define PLAT_ARM_MMAP_ENTRIES		11
 # define MAX_XLAT_TABLES		5
 #endif
 


### PR DESCRIPTION
The MEM_PROTECT support adds a MMAP region for DRAM2, which when
building with TBBR support and OP-TEE tsp requires an additional
entry in the MMAP region array in BL2 - PLAT_ARM_MMAP_ENTRIES is
increased.

The MEM_PROTECT support also adds a new region in BL31, and when
BL31 is placed in DRAM, the memory mappings require an additional
translation table - MAX_XLAT_TABLES is increased.

Change-Id: I0b76260da817dcfd0b8f73a7193c36efda977625
Signed-off-by: David Cunado <david.cunado@arm.com>