### PR TITLE
cert_tool: update for compatibility with OpenSSL v1.1

### DIFF
--- a/tools/cert_create/src/ext.c
+++ b/tools/cert_create/src/ext.c
@@ -166,7 +166,7 @@ X509_EXTENSION *ext_new_hash(int nid, int crit, const EVP_MD *md,
 	int sz;
 
 	/* OBJECT_IDENTIFIER with hash algorithm */
-	algorithm = OBJ_nid2obj(md->type);
+	algorithm = OBJ_nid2obj(EVP_MD_type(md));
 	if (algorithm == NULL) {
 		return NULL;
 	}

--- a/tools/cert_create/src/key.c
+++ b/tools/cert_create/src/key.c
@@ -43,13 +43,31 @@ int key_new(key_t *key)
 
 static int key_create_rsa(key_t *key)
 {
-	RSA *rsa;
+	BIGNUM *e;
+	RSA *rsa = NULL;
 
-	rsa = RSA_generate_key(RSA_KEY_BITS, RSA_F4, NULL, NULL);
+	e = BN_new();
+	if (e == NULL) {
+		printf("Cannot create RSA exponent\n");
+		goto err;
+	}
+
+	if (!BN_set_word(e, RSA_F4)) {
+		printf("Cannot assign RSA exponent\n");
+		goto err;
+	}
+
+	rsa = RSA_new();
 	if (rsa == NULL) {
 		printf("Cannot create RSA key\n");
 		goto err;
 	}
+
+	if (!RSA_generate_key_ex(rsa, RSA_KEY_BITS, e, NULL)) {
+		printf("Cannot generate RSA key\n");
+		goto err;
+	}
+
 	if (!EVP_PKEY_assign_RSA(key->key, rsa)) {
 		printf("Cannot assign RSA key\n");
 		goto err;
@@ -58,6 +76,7 @@ static int key_create_rsa(key_t *key)
 	return 1;
 err:
 	RSA_free(rsa);
+	BN_free(e);
 	return 0;
 }
 

--- a/tools/cert_create/src/main.c
+++ b/tools/cert_create/src/main.c
@@ -244,7 +244,7 @@ PKCS#1 v2.1, 'rsa_1_5' - RSA PKCS#1 v1.5, 'ecdsa'"
 int main(int argc, char *argv[])
 {
 	STACK_OF(X509_EXTENSION) * sk;
-	X509_EXTENSION *cert_ext;
+	X509_EXTENSION *cert_ext = NULL;
 	ext_t *ext;
 	key_t *key;
 	cert_t *cert;


### PR DESCRIPTION
This patch fixes incompatibility issues that prevent building the cert_tool
with OpenSSL >= v1.1.0. The changes introduced are still backwards
compatible with OpenSSL v1.0.2.

Fixes arm-software/trusted-fw#521

Signed-off-by: Michalis Pappas <mpappas@fastmail.fm>