### PR TITLE
cert_tool: Fix ECDSA certificates create failure

### DIFF
--- a/tools/cert_create/src/key.c
+++ b/tools/cert_create/src/key.c
@@ -91,9 +91,10 @@ err:
 
 typedef int (*key_create_fn_t)(key_t *key);
 static const key_create_fn_t key_create_fn[KEY_ALG_MAX_NUM] = {
-	key_create_rsa,
+	key_create_rsa, 	/* KEY_ALG_RSA */
+	key_create_rsa, 	/* KEY_ALG_RSA_1_5 */
 #ifndef OPENSSL_NO_EC
-	key_create_ecdsa,
+	key_create_ecdsa, 	/* KEY_ALG_ECDSA */
 #endif /* OPENSSL_NO_EC */
 };
 


### PR DESCRIPTION
Commit a8eb286adaa73e86305317b9cae15d41c57de8e7 introduced the
following error when creating ECDSA certificates.
    ERROR:   Error creating key 'Trusted World key'
    Makefile:634: recipe for target 'certificates' failed
    make: *** [certificates] Error 1

this patch adds the function to create PKCS#1 v1.5.

Change-Id: Ief96d55969d5e9877aeb528c6bb503b560563537
Signed-off-by: Qixiang Xu <qixiang.xu@arm.com>