### PR TITLE
qemu: update deprecated interrupt registering

### DIFF
--- a/plat/qemu/qemu_bl31_setup.c
+++ b/plat/qemu/qemu_bl31_setup.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <bl_common.h>
 #include <console.h>
+#include <gic_common.h>
 #include <gicv2.h>
 #include <platform_def.h>
 #include "qemu_private.h"
@@ -112,22 +113,40 @@ void bl31_plat_arch_setup(void)
 			      BL_COHERENT_RAM_BASE, BL_COHERENT_RAM_END);
 }
 
-static const unsigned int irq_sec_array[] = {
-	QEMU_IRQ_SEC_SGI_0,
-	QEMU_IRQ_SEC_SGI_1,
-	QEMU_IRQ_SEC_SGI_2,
-	QEMU_IRQ_SEC_SGI_3,
-	QEMU_IRQ_SEC_SGI_4,
-	QEMU_IRQ_SEC_SGI_5,
-	QEMU_IRQ_SEC_SGI_6,
-	QEMU_IRQ_SEC_SGI_7,
+/******************************************************************************
+ * On a GICv2 system, the Group 1 secure interrupts are treated as Group 0
+ * interrupts.
+ *****************************************************************************/
+#define PLATFORM_G1S_PROPS(grp)						\
+	INTR_PROP_DESC(QEMU_IRQ_SEC_SGI_0, GIC_HIGHEST_SEC_PRIORITY,	\
+					   grp, GIC_INTR_CFG_EDGE),	\
+	INTR_PROP_DESC(QEMU_IRQ_SEC_SGI_1, GIC_HIGHEST_SEC_PRIORITY,	\
+					   grp, GIC_INTR_CFG_EDGE),	\
+	INTR_PROP_DESC(QEMU_IRQ_SEC_SGI_2, GIC_HIGHEST_SEC_PRIORITY,	\
+					   grp, GIC_INTR_CFG_EDGE),	\
+	INTR_PROP_DESC(QEMU_IRQ_SEC_SGI_3, GIC_HIGHEST_SEC_PRIORITY,	\
+					   grp, GIC_INTR_CFG_EDGE),	\
+	INTR_PROP_DESC(QEMU_IRQ_SEC_SGI_4, GIC_HIGHEST_SEC_PRIORITY,	\
+					   grp, GIC_INTR_CFG_EDGE),	\
+	INTR_PROP_DESC(QEMU_IRQ_SEC_SGI_5, GIC_HIGHEST_SEC_PRIORITY,	\
+					   grp, GIC_INTR_CFG_EDGE),	\
+	INTR_PROP_DESC(QEMU_IRQ_SEC_SGI_6, GIC_HIGHEST_SEC_PRIORITY,	\
+					   grp, GIC_INTR_CFG_EDGE),	\
+	INTR_PROP_DESC(QEMU_IRQ_SEC_SGI_7, GIC_HIGHEST_SEC_PRIORITY,	\
+					   grp, GIC_INTR_CFG_EDGE)
+
+#define PLATFORM_G0_PROPS(grp)
+
+static const interrupt_prop_t qemu_interrupt_props[] = {
+	PLATFORM_G1S_PROPS(GICV2_INTR_GROUP0),
+	PLATFORM_G0_PROPS(GICV2_INTR_GROUP0)
 };
 
 static const struct gicv2_driver_data plat_gicv2_driver_data = {
 	.gicd_base = GICD_BASE,
 	.gicc_base = GICC_BASE,
-	.g0_interrupt_num = ARRAY_SIZE(irq_sec_array),
-	.g0_interrupt_array = irq_sec_array,
+	.interrupt_props = qemu_interrupt_props,
+	.interrupt_props_num = ARRAY_SIZE(qemu_interrupt_props),
 };
 
 void bl31_platform_setup(void)


### PR DESCRIPTION
Registered interrupts are configured in edge detection as the default
previous configuration assumed in previous code.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>