### PR TITLE
Change the default option of ARM_TSP_RAM_LOCATION and Enlarge the BL2 size on ARM platforms

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -664,9 +664,10 @@ ARM development platform specific build options
 
 -  ``ARM_TSP_RAM_LOCATION``: location of the TSP binary. Options:
 
-   -  ``tsram`` : Trusted SRAM (default option)
+   -  ``tsram`` : Trusted SRAM (default option when TBB is not enabled)
    -  ``tdram`` : Trusted DRAM (if available)
-   -  ``dram`` : Secure region in DRAM (configured by the TrustZone controller)
+   -  ``dram``  : Secure region in DRAM (default option when TBB is enabled,
+                  configured by the TrustZone controller)
 
 -  ``ARM_XLAT_TABLES_LIB_V1``: boolean option to compile the Trusted Firmware
    with version 1 of the translation tables library instead of version 2. It is

--- a/include/drivers/auth/mbedtls/mbedtls_config.h
+++ b/include/drivers/auth/mbedtls/mbedtls_config.h
@@ -76,12 +76,13 @@
 #define MBEDTLS_MPI_WINDOW_SIZE              2
 #define MBEDTLS_MPI_MAX_SIZE               256
 
-/* System headers required to build mbed TLS with the current configuration */
-#include <stdlib.h>
-
 /* Memory buffer allocator options */
 #define MBEDTLS_MEMORY_ALIGN_MULTIPLE        8
 
+#ifndef __ASSEMBLY__
+/* System headers required to build mbed TLS with the current configuration */
+#include <stdlib.h>
 #include "mbedtls/check_config.h"
+#endif
 
 #endif /* __MBEDTLS_CONFIG_H__ */

--- a/include/plat/arm/board/common/board_arm_def.h
+++ b/include/plat/arm/board/common/board_arm_def.h
@@ -71,7 +71,7 @@
  * little space for growth.
  */
 #if TRUSTED_BOARD_BOOT
-# define PLAT_ARM_MAX_BL2_SIZE		0x1D000
+# define PLAT_ARM_MAX_BL2_SIZE		0x1E000
 #else
 # define PLAT_ARM_MAX_BL2_SIZE		0xF000
 #endif

--- a/plat/arm/board/juno/include/platform_def.h
+++ b/plat/arm/board/juno/include/platform_def.h
@@ -12,6 +12,9 @@
 #include <board_css_def.h>
 #include <common_def.h>
 #include <css_def.h>
+#if TRUSTED_BOARD_BOOT
+#include <mbedtls_config.h>
+#endif
 #include <soc_css_def.h>
 #include <tzc400.h>
 #include <v2m_def.h>
@@ -106,7 +109,11 @@
  * little space for growth.
  */
 #if TRUSTED_BOARD_BOOT
-# define PLAT_ARM_MAX_BL2_SIZE		0x19000
+#if TF_MBEDTLS_KEY_ALG_ID == TF_MBEDTLS_RSA_AND_ECDSA
+# define PLAT_ARM_MAX_BL2_SIZE		0x1E000
+#else
+# define PLAT_ARM_MAX_BL2_SIZE		0x1A000
+#endif
 #else
 # define PLAT_ARM_MAX_BL2_SIZE		0xC000
 #endif

--- a/plat/arm/common/arm_common.mk
+++ b/plat/arm/common/arm_common.mk
@@ -9,7 +9,12 @@ ifeq (${ARCH}, aarch64)
   # DRAM (if available) or the TZC secured area of DRAM.
   # Trusted SRAM is the default.
 
-  ARM_TSP_RAM_LOCATION	:=	tsram
+  ifneq (${TRUSTED_BOARD_BOOT},0)
+    ARM_TSP_RAM_LOCATION	?=	dram
+  else
+    ARM_TSP_RAM_LOCATION	?=	tsram
+  endif
+
   ifeq (${ARM_TSP_RAM_LOCATION}, tsram)
     ARM_TSP_RAM_LOCATION_ID = ARM_TRUSTED_SRAM_ID
   else ifeq (${ARM_TSP_RAM_LOCATION}, tdram)


### PR DESCRIPTION
1. Change the default option of ARM_TSP_RAM_LOCATION
    On Arm standard platforms, it runs out of SRAM space when TBB is enabled, so the TSP default location is changed to dram when TBB is enabled.

2. Enlarge the BL2 size on Arm platforms when TBB is enabled
    For Trusted Board Boot, BL2 needs more space to support the ECDSA and ECDSA+RSA algorithms.