### PR TITLE
qemu/optee: load OP-TEE pageable part 2MB above OP-TEE image

### DIFF
--- a/plat/qemu/include/platform_def.h
+++ b/plat/qemu/include/platform_def.h
@@ -73,9 +73,8 @@
 #define SEC_DRAM_BASE			0x0e100000
 #define SEC_DRAM_SIZE			0x00f00000
 
-/* Load pageable part of OP-TEE at end of secure DRAM */
-#define QEMU_OPTEE_PAGEABLE_LOAD_BASE	(SEC_DRAM_BASE + SEC_DRAM_SIZE - \
-					 QEMU_OPTEE_PAGEABLE_LOAD_SIZE)
+/* Load pageable part of OP-TEE 2MB above secure DRAM base */
+#define QEMU_OPTEE_PAGEABLE_LOAD_BASE	(SEC_DRAM_BASE + 0x00200000)
 #define QEMU_OPTEE_PAGEABLE_LOAD_SIZE	0x00400000
 
 /*


### PR DESCRIPTION
OP-TEE dedicates the end of the Qemu secure DRAM as specific out-of-TEE
secure RAM. To support this configuration the trusted firmware should
not load OP-TEE resources in this area.

To overcome the issue, OP-TEE pageable image is now loaded 2MByte above
the secure RAM base address.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>