### PR TITLE
aarch64: Add PubSub events to capture security state transitions

### DIFF
--- a/docs/firmware-design.rst
+++ b/docs/firmware-design.rst
@@ -2309,6 +2309,12 @@ PE only; it won't cause handlers to execute on a different PE.
 Note that publishing an event on a PE blocks until all the subscribed handlers
 finish executing on the PE.
 
+ARM Trusted Firmware generic code publishes and subscribes to some events
+within. Platform ports are discouraged from subscribing to them. These events
+may be withdrawn, renamed, or have their semantics altered in the future.
+Platforms may however register, publish, and subscribe to platform-specific
+events.
+
 Publish and Subscribe Example
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -2338,22 +2344,6 @@ implement:
    }
 
    SUBSCRIBE_TO_EVENT(foo, foo_handler);
-
-Available Events
-~~~~~~~~~~~~~~~~
-
-ARM Trusted Firmware core makes some events available by default. They're listed
-below, along with information as to when they're published, and the arguments
-passed to subscribed handlers.
-
-Other EL3 components that are conditionally compiled in may make their own
-events available, but aren't documented here.
-
--  ``psci_cpu_on_finish``
-
-   - When: Published on a PE after it's finished its power-up sequence.
-
-   - Argument: ``NULL``.
 
 Performance Measurement Framework
 ---------------------------------

--- a/include/lib/el3_runtime/pubsub_events.h
+++ b/include/lib/el3_runtime/pubsub_events.h
@@ -16,3 +16,21 @@
  * initialization.
  */
 REGISTER_PUBSUB_EVENT(psci_cpu_on_finish);
+
+#ifdef AARCH64
+/*
+ * These events are published by the AArch64 context management framework
+ * after the secure context is restored/saved via
+ * cm_el1_sysregs_context_{restore,save}() API.
+ */
+REGISTER_PUBSUB_EVENT(cm_entering_secure_world);
+REGISTER_PUBSUB_EVENT(cm_exited_secure_world);
+
+/*
+ * These events are published by the AArch64 context management framework
+ * after the normal context is restored/saved via
+ * cm_el1_sysregs_context_{restore,save}() API.
+ */
+REGISTER_PUBSUB_EVENT(cm_entering_normal_world);
+REGISTER_PUBSUB_EVENT(cm_exited_normal_world);
+#endif /* AARCH64 */


### PR DESCRIPTION
Add events that trigger before entry to normal/secure world.  The
events trigger after the normal/secure context has been restored.

Similarly add events that trigger after leaving normal/secure world.
The events trigger after the normal/secure context has been saved.

Change-Id: I1b48a7ea005d56b1f25e2b5313d77e67d2f02bc5
Signed-off-by: Dimitris Papastamos <dimitris.papastamos@arm.com>