### PR TITLE
Change sizeof to use type of struct not function

### DIFF
--- a/include/lib/el3_runtime/cpu_data.h
+++ b/include/lib/el3_runtime/cpu_data.h
@@ -141,17 +141,17 @@ void init_cpu_ops(void);
 #define set_cpu_data(_m, _v)		   _cpu_data()->_m = _v
 #define get_cpu_data_by_index(_ix, _m)	   _cpu_data_by_index(_ix)->_m
 #define set_cpu_data_by_index(_ix, _m, _v) _cpu_data_by_index(_ix)->_m = _v
-
+/* ((cpu_data_t *)0)->_m is a dummy to get the sizeof the struct member _m */
 #define flush_cpu_data(_m)	   flush_dcache_range((uintptr_t)	  \
-						      &(_cpu_data()->_m), \
-						      sizeof(_cpu_data()->_m))
+						&(_cpu_data()->_m), \
+						sizeof(((cpu_data_t *)0)->_m))
 #define inv_cpu_data(_m)	   inv_dcache_range((uintptr_t)	  	  \
-						      &(_cpu_data()->_m), \
-						      sizeof(_cpu_data()->_m))
+						&(_cpu_data()->_m), \
+						sizeof(((cpu_data_t *)0)->_m))
 #define flush_cpu_data_by_index(_ix, _m)	\
 				   flush_dcache_range((uintptr_t)	  \
 					 &(_cpu_data_by_index(_ix)->_m),  \
-					 sizeof(_cpu_data_by_index(_ix)->_m))
+						sizeof(((cpu_data_t *)0)->_m))
 
 
 #endif /* __ASSEMBLY__ */


### PR DESCRIPTION
Change sizeof call so it references a static type instead of return of
a function in order to be MISRA compliant.

Change-Id: I6f1adb206073d6cd200156e281b8d76249e3af0e
Signed-off-by: Joel Hutton <joel.hutton@arm.com>