### PR TITLE
Avoid use of undefined macros

### DIFF
--- a/common/aarch64/debug.S
+++ b/common/aarch64/debug.S
@@ -6,6 +6,7 @@
 
 #include <arch.h>
 #include <asm_macros.S>
+#include <debug.h>
 
 	.globl	asm_print_str
 	.globl	asm_print_hex

--- a/include/lib/xlat_tables/xlat_tables_v2_helpers.h
+++ b/include/lib/xlat_tables/xlat_tables_v2_helpers.h
@@ -168,7 +168,7 @@ struct xlat_ctx {
  * This IMAGE_EL macro must not to be used outside the library, and it is only
  * used in AArch64.
  */
-#if IMAGE_BL1 || IMAGE_BL31
+#if defined(IMAGE_BL1) || defined(IMAGE_BL31)
 # define IMAGE_EL	3
 # define IMAGE_XLAT_DEFAULT_REGIME EL3_REGIME
 #else

--- a/plat/arm/common/arm_common.mk
+++ b/plat/arm/common/arm_common.mk
@@ -21,13 +21,16 @@ ifeq (${ARCH}, aarch64)
   endif
 
   # Process flags
-  $(eval $(call add_define,ARM_TSP_RAM_LOCATION_ID))
-
   # Process ARM_BL31_IN_DRAM flag
   ARM_BL31_IN_DRAM		:=	0
   $(eval $(call assert_boolean,ARM_BL31_IN_DRAM))
   $(eval $(call add_define,ARM_BL31_IN_DRAM))
+else
+  ARM_TSP_RAM_LOCATION_ID = ARM_TRUSTED_SRAM_ID
 endif
+
+$(eval $(call add_define,ARM_TSP_RAM_LOCATION_ID))
+
 
 # For the original power-state parameter format, the State-ID can be encoded
 # according to the recommended encoding or zero. This flag determines which

--- a/plat/hisilicon/hikey/aarch64/hikey_common.c
+++ b/plat/hisilicon/hikey/aarch64/hikey_common.c
@@ -59,7 +59,7 @@
  * This doesn't include Trusted RAM as the 'mem_layout' argument passed to
  * hikey_init_mmu_elx() will give the available subset of that,
  */
-#if IMAGE_BL1
+#ifdef IMAGE_BL1
 static const mmap_region_t hikey_mmap[] = {
 	MAP_DEVICE,
 	MAP_ROM_PARAM,
@@ -68,7 +68,7 @@ static const mmap_region_t hikey_mmap[] = {
 };
 #endif
 
-#if IMAGE_BL2
+#ifdef IMAGE_BL2
 static const mmap_region_t hikey_mmap[] = {
 	MAP_DDR,
 	MAP_DEVICE,
@@ -82,7 +82,7 @@ static const mmap_region_t hikey_mmap[] = {
 };
 #endif
 
-#if IMAGE_BL31
+#ifdef IMAGE_BL31
 static const mmap_region_t hikey_mmap[] = {
 	MAP_DEVICE,
 	MAP_SRAM,
@@ -91,7 +91,7 @@ static const mmap_region_t hikey_mmap[] = {
 };
 #endif
 
-#if IMAGE_BL32
+#ifdef IMAGE_BL32
 static const mmap_region_t hikey_mmap[] = {
 	MAP_DEVICE,
 	MAP_DDR,

--- a/plat/hisilicon/hikey/hikey_io_storage.c
+++ b/plat/hisilicon/hikey/hikey_io_storage.c
@@ -47,7 +47,7 @@ static const io_block_spec_t emmc_fip_spec = {
 
 static const io_block_dev_spec_t emmc_dev_spec = {
 	/* It's used as temp buffer in block driver. */
-#if IMAGE_BL1
+#ifdef IMAGE_BL1
 	.buffer		= {
 		.offset	= HIKEY_BL1_MMC_DATA_BASE,
 		.length	= HIKEY_BL1_MMC_DATA_SIZE,

--- a/plat/hisilicon/hikey/include/platform_def.h
+++ b/plat/hisilicon/hikey/include/platform_def.h
@@ -151,15 +151,15 @@
  */
 #define ADDR_SPACE_SIZE			(1ull << 32)
 
-#if IMAGE_BL1 || IMAGE_BL32
+#if defined(IMAGE_BL1) || defined(IMAGE_BL32)
 #define MAX_XLAT_TABLES			3
 #endif
 
-#if IMAGE_BL31
+#ifdef IMAGE_BL31
 #define MAX_XLAT_TABLES			4
 #endif
 
-#if IMAGE_BL2
+#ifdef IMAGE_BL2
 #if LOAD_IMAGE_V2
 #ifdef SPD_opteed
 #define MAX_XLAT_TABLES			4

--- a/plat/hisilicon/hikey960/aarch64/hikey960_common.c
+++ b/plat/hisilicon/hikey960/aarch64/hikey960_common.c
@@ -55,7 +55,7 @@
  * This doesn't include Trusted RAM as the 'mem_layout' argument passed to
  * hikey960_init_mmu_elx() will give the available subset of that,
  */
-#if IMAGE_BL1
+#ifdef IMAGE_BL1
 static const mmap_region_t hikey960_mmap[] = {
 	MAP_UFS_DATA,
 	MAP_BL1_RW,
@@ -65,7 +65,7 @@ static const mmap_region_t hikey960_mmap[] = {
 };
 #endif
 
-#if IMAGE_BL2
+#ifdef IMAGE_BL2
 static const mmap_region_t hikey960_mmap[] = {
 	MAP_DDR,
 	MAP_DEVICE,
@@ -79,7 +79,7 @@ static const mmap_region_t hikey960_mmap[] = {
 };
 #endif
 
-#if IMAGE_BL31
+#ifdef IMAGE_BL31
 static const mmap_region_t hikey960_mmap[] = {
 	MAP_DEVICE,
 	MAP_TSP_MEM,
@@ -87,7 +87,7 @@ static const mmap_region_t hikey960_mmap[] = {
 };
 #endif
 
-#if IMAGE_BL32
+#ifdef IMAGE_BL32
 static const mmap_region_t hikey960_mmap[] = {
 	MAP_DEVICE,
 	MAP_DDR,

--- a/plat/hisilicon/hikey960/include/platform_def.h
+++ b/plat/hisilicon/hikey960/include/platform_def.h
@@ -116,11 +116,11 @@
  */
 #define ADDR_SPACE_SIZE			(1ull << 32)
 
-#if IMAGE_BL1 || IMAGE_BL31 || IMAGE_BL32
+#if defined(IMAGE_BL1) || defined(IMAGE_BL31) || defined(IMAGE_BL32)
 #define MAX_XLAT_TABLES			3
 #endif
 
-#if IMAGE_BL2
+#ifdef IMAGE_BL2
 #if LOAD_IMAGE_V2
 #ifdef SPD_opteed
 #define MAX_XLAT_TABLES			4

--- a/plat/rockchip/rk3328/include/platform_def.h
+++ b/plat/rockchip/rk3328/include/platform_def.h
@@ -26,13 +26,13 @@
 /* Size of cacheable stacks */
 #if DEBUG_XLAT_TABLE
 #define PLATFORM_STACK_SIZE 0x800
-#elif IMAGE_BL1
+#elif defined(IMAGE_BL1)
 #define PLATFORM_STACK_SIZE 0x440
-#elif IMAGE_BL2
+#elif defined(IMAGE_BL2)
 #define PLATFORM_STACK_SIZE 0x400
-#elif IMAGE_BL31
+#elif defined(IMAGE_BL31)
 #define PLATFORM_STACK_SIZE 0x800
-#elif IMAGE_BL32
+#elif defined(IMAGE_BL32)
 #define PLATFORM_STACK_SIZE 0x440
 #endif
 


### PR DESCRIPTION
There are several cases where some macros are used in prepocessor conditionals without a previous definition and in some cases it was generating some problems.