### PR TITLE
SPM: Fix pointer to MP info in boot info struct

### DIFF
--- a/services/std_svc/spm/secure_partition_setup.c
+++ b/services/std_svc/spm/secure_partition_setup.c
@@ -270,8 +270,8 @@ void secure_partition_setup(void)
 	 * be populated, just after the boot info.
 	 */
 	((secure_partition_boot_info_t *) shared_buf_ptr)->mp_info =
-		((secure_partition_mp_info_t *) shared_buf_ptr) +
-		sizeof(secure_partition_boot_info_t);
+		(secure_partition_mp_info_t *) ((uintptr_t)shared_buf_ptr
+				+ sizeof(secure_partition_boot_info_t));
 
 	/*
 	 * Update the shared buffer pointer to where the MP information for the


### PR DESCRIPTION
The MP info struct is placed right after the boot info struct. However, when calculating the address of the MP info, the size of the boot info struct was being multiplied by the size of the MP boot info. This left a big gap of empty space between the structs.

This didn't break any code because the boot info struct has a pointer to the MP info struct. It was just wasting space.