### PR TITLE
SPM fixes

### DIFF
--- a/services/std_svc/spm/secure_partition_setup.c
+++ b/services/std_svc/spm/secure_partition_setup.c
@@ -92,20 +92,20 @@ void secure_partition_setup(void)
 
 	/* Get max granularity supported by the platform. */
 
-	u_register_t id_aa64prf0_el1 = read_id_aa64pfr0_el1();
+	u_register_t id_aa64mmfr0_el1 = read_id_aa64mmfr0_el1();
 
 	int tgran64_supported =
-		((id_aa64prf0_el1 >> ID_AA64MMFR0_EL1_TGRAN64_SHIFT) &
+		((id_aa64mmfr0_el1 >> ID_AA64MMFR0_EL1_TGRAN64_SHIFT) &
 		 ID_AA64MMFR0_EL1_TGRAN64_MASK) ==
 		 ID_AA64MMFR0_EL1_TGRAN64_SUPPORTED;
 
 	int tgran16_supported =
-		((id_aa64prf0_el1 >> ID_AA64MMFR0_EL1_TGRAN16_SHIFT) &
+		((id_aa64mmfr0_el1 >> ID_AA64MMFR0_EL1_TGRAN16_SHIFT) &
 		 ID_AA64MMFR0_EL1_TGRAN16_MASK) ==
 		 ID_AA64MMFR0_EL1_TGRAN16_SUPPORTED;
 
 	int tgran4_supported =
-		((id_aa64prf0_el1 >> ID_AA64MMFR0_EL1_TGRAN4_SHIFT) &
+		((id_aa64mmfr0_el1 >> ID_AA64MMFR0_EL1_TGRAN4_SHIFT) &
 		 ID_AA64MMFR0_EL1_TGRAN4_MASK) ==
 		 ID_AA64MMFR0_EL1_TGRAN4_SUPPORTED;
 
@@ -121,7 +121,7 @@ void secure_partition_setup(void)
 	}
 
 	VERBOSE("Max translation granule supported: %lu KiB\n",
-		max_granule_size);
+		max_granule_size / 1024);
 
 	uintptr_t max_granule_size_mask = max_granule_size - 1;
 

--- a/services/std_svc/spm/spm_main.c
+++ b/services/std_svc/spm/spm_main.c
@@ -431,12 +431,14 @@ uint64_t spm_smc_handler(uint32_t smc_fid,
 			cm_el1_sysregs_context_restore(SECURE);
 			cm_set_next_eret_context(SECURE);
 
-			if (x2 != 0) {
-				VERBOSE("SP_COMMUNICATE_AARCH32/64: X2 is not 0 as recommended.");
+			/* Cookie. Reserved for future use. It must be zero. */
+			assert(x1 == 0);
+
+			if (x3 != 0) {
+				VERBOSE("SP_COMMUNICATE_AARCH32/64: X3 is not 0 as recommended.\n");
 			}
 
-			SMC_RET4(&sp_ctx.cpu_ctx,
-				 smc_fid, x2, x3, plat_my_core_pos());
+			SMC_RET4(&sp_ctx.cpu_ctx, smc_fid, x1, x2, x3);
 
 		case SP_MEM_ATTRIBUTES_GET_AARCH64:
 		case SP_MEM_ATTRIBUTES_SET_AARCH64:


### PR DESCRIPTION
- The parameters passed to the Secure world from the Secure Partition Manager when invoking SP_COMMUNICATE_AARCH32/64 were incorrect, as well as the checks done on them.

- The code was incorrectly reading from ID_AA64PRF0_EL1 instead of
ID_AA64MMFR0_EL1 causing the supported granularity sizes returned by the
code to be wrong.