### PR TITLE
Fix Makefile for ARMv8-A AArch32 builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ target32-directive	= 	-target arm-none-eabi
 # Will set march32-directive from platform configuration
 else
 target32-directive	= 	-target armv8a-none-eabi
-march32-directive	= 	-march armv8-a
+march32-directive	= 	-march=armv8-a
 endif
 
 ifeq ($(notdir $(CC)),armclang)


### PR DESCRIPTION
Commit 26e63c4450 broke the Makefile for ARMv8-A AArch32 platforms.
This patch fixes it.
