### PR TITLE
plat: xilinx: Add ZynqMP IPI mailbox service [v4]

### DIFF
--- a/plat/xilinx/zynqmp/ipi_mailbox_service/ipi_mailbox_svc.c
+++ b/plat/xilinx/zynqmp/ipi_mailbox_service/ipi_mailbox_svc.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Top-level SMC handler for ZynqMP IPI Mailbox doorbell functions.
+ */
+
+#include <bakery_lock.h>
+#include <debug.h>
+#include <errno.h>
+#include <mmio.h>
+#include <runtime_svc.h>
+#include <string.h>
+#include "ipi_mailbox_svc.h"
+#include "../zynqmp_ipi.h"
+#include "../zynqmp_private.h"
+#include "../../../services/spd/trusty/smcall.h"
+
+/*********************************************************************
+ * Macros definitions
+ ********************************************************************/
+
+/* IPI SMC calls macros: */
+#define IPI_SMC_OPEN_IRQ_MASK		0x00000001U /* IRQ enable bit in IPI
+						     * open SMC call
+						     */
+#define IPI_SMC_NOTIFY_BLOCK_MASK	0x00000001U /* Flag to indicate if
+						     * IPI notification needs
+						     * to be blocking.
+						     */
+#define IPI_SMC_ENQUIRY_DIRQ_MASK	0x00000001U /* Flag to indicate if
+						     * notification interrupt
+						     * to be disabled.
+						     */
+#define IPI_SMC_ACK_EIRQ_MASK		0x00000001U /* Flag to indicate if
+						     * notification interrupt
+						     * to be enable.
+						     */
+
+#define UNSIGNED32_MASK			0xFFFFFFFFU /* 32bit mask */
+
+/**
+ * ipi_smc_handler() - SMC handler for IPI SMC calls
+ *
+ * @smc_fid - Function identifier
+ * @x1 - x4 - Arguments
+ * @cookie  - Unused
+ * @handler - Pointer to caller's context structure
+ *
+ * @return  - Unused
+ *
+ * Determines that smc_fid is valid and supported PM SMC Function ID from the
+ * list of pm_api_ids, otherwise completes the request with
+ * the unknown SMC Function ID
+ *
+ * The SMC calls for PM service are forwarded from SIP Service SMC handler
+ * function with rt_svc_handle signature
+ */
+uint64_t ipi_smc_handler(uint32_t smc_fid, uint64_t x1, uint64_t x2,
+			 uint64_t x3, uint64_t x4, void *cookie,
+			 void *handle, uint64_t flags)
+{
+	int ret;
+	uint32_t ipi_local_id;
+	uint32_t ipi_remote_id;
+	unsigned int is_secure;
+
+	ipi_local_id = x1 & UNSIGNED32_MASK;
+	ipi_remote_id = x2 & UNSIGNED32_MASK;
+
+	if (SMC_ENTITY(smc_fid) >= SMC_ENTITY_TRUSTED_APP)
+		is_secure = 1;
+	else
+		is_secure = 0;
+
+	/* Validate IPI mailbox access */
+	ret = ipi_mb_validate(ipi_local_id, ipi_remote_id, is_secure);
+	if (ret)
+		SMC_RET1(handle, ret);
+
+	switch (SMC_FUNCTION(smc_fid)) {
+	case IPI_MAILBOX_OPEN:
+		ipi_mb_open(ipi_local_id, ipi_remote_id);
+		SMC_RET1(handle, 0);
+	case IPI_MAILBOX_RELEASE:
+		ipi_mb_release(ipi_local_id, ipi_remote_id);
+		SMC_RET1(handle, 0);
+	case IPI_MAILBOX_STATUS_ENQUIRY:
+	{
+		int disable_irq;
+
+		disable_irq = (x3 & IPI_SMC_ENQUIRY_DIRQ_MASK) ? 1 : 0;
+		ret = ipi_mb_enquire_status(ipi_local_id, ipi_remote_id);
+		if ((ret & IPI_MB_STATUS_RECV_PENDING) && disable_irq)
+			ipi_mb_disable_irq(ipi_local_id, ipi_remote_id);
+		SMC_RET1(handle, ret);
+	}
+	case IPI_MAILBOX_NOTIFY:
+	{
+		uint32_t is_blocking;
+
+		is_blocking = (x3 & IPI_SMC_NOTIFY_BLOCK_MASK) ? 1 : 0;
+		ipi_mb_notify(ipi_local_id, ipi_remote_id, is_blocking);
+		SMC_RET1(handle, 0);
+	}
+	case IPI_MAILBOX_ACK:
+	{
+		int enable_irq;
+
+		enable_irq = (x3 & IPI_SMC_ACK_EIRQ_MASK) ? 1 : 0;
+		ipi_mb_ack(ipi_local_id, ipi_remote_id);
+		if (enable_irq)
+			ipi_mb_enable_irq(ipi_local_id, ipi_remote_id);
+		SMC_RET1(handle, 0);
+	}
+	case IPI_MAILBOX_ENABLE_IRQ:
+		ipi_mb_enable_irq(ipi_local_id, ipi_remote_id);
+		SMC_RET1(handle, 0);
+	case IPI_MAILBOX_DISABLE_IRQ:
+		ipi_mb_disable_irq(ipi_local_id, ipi_remote_id);
+		SMC_RET1(handle, 0);
+	default:
+		WARN("Unimplemented IPI service call: 0x%x\n", smc_fid);
+		SMC_RET1(handle, SMC_UNK);
+	}
+}

--- a/plat/xilinx/zynqmp/ipi_mailbox_service/ipi_mailbox_svc.h
+++ b/plat/xilinx/zynqmp/ipi_mailbox_service/ipi_mailbox_svc.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* ZynqMP IPI mailbox doorbell service enums and defines */
+
+#ifndef _IPI_MAILBOX_SVC_H_
+#define _IPI_MAILBOX_SVC_H_
+
+#include <stdint.h>
+
+/*********************************************************************
+ * Enum definitions
+ ********************************************************************/
+
+/* IPI SMC function numbers enum definition */
+enum ipi_api_id {
+	/* IPI mailbox operations functions: */
+	IPI_MAILBOX_OPEN = 0x1000,
+	IPI_MAILBOX_RELEASE,
+	IPI_MAILBOX_STATUS_ENQUIRY,
+	IPI_MAILBOX_NOTIFY,
+	IPI_MAILBOX_ACK,
+	IPI_MAILBOX_ENABLE_IRQ,
+	IPI_MAILBOX_DISABLE_IRQ
+};
+
+/*********************************************************************
+ * IPI mailbox service APIs declarations
+ ********************************************************************/
+
+/* IPI SMC handler */
+uint64_t ipi_smc_handler(uint32_t smc_fid, uint64_t x1, uint64_t x2,
+			 uint64_t x3, uint64_t x4, void *cookie, void *handle,
+			 uint64_t flags);
+
+#endif /* _IPI_MAILBOX_SVC_H_ */

--- a/plat/xilinx/zynqmp/platform.mk
+++ b/plat/xilinx/zynqmp/platform.mk
@@ -71,6 +71,7 @@ BL31_SOURCES		+=	drivers/arm/cci/cci.c				\
 				plat/xilinx/zynqmp/plat_startup.c		\
 				plat/xilinx/zynqmp/plat_topology.c		\
 				plat/xilinx/zynqmp/sip_svc_setup.c		\
+				plat/xilinx/zynqmp/zynqmp_ipi.c		\
 				plat/xilinx/zynqmp/pm_service/pm_svc_main.c	\
 				plat/xilinx/zynqmp/pm_service/pm_api_sys.c	\
 				plat/xilinx/zynqmp/pm_service/pm_ipi.c		\

--- a/plat/xilinx/zynqmp/platform.mk
+++ b/plat/xilinx/zynqmp/platform.mk
@@ -42,7 +42,8 @@ $(eval $(call add_define_val,ZYNQMP_CONSOLE,ZYNQMP_CONSOLE_ID_${ZYNQMP_CONSOLE})
 PLAT_INCLUDES		:=	-Iinclude/plat/arm/common/			\
 				-Iinclude/plat/arm/common/aarch64/		\
 				-Iplat/xilinx/zynqmp/include/			\
-				-Iplat/xilinx/zynqmp/pm_service/
+				-Iplat/xilinx/zynqmp/pm_service/		\
+				-Iplat/xilinx/zynqmp/ipi_mailbox_service/
 
 PLAT_BL_COMMON_SOURCES	:=	lib/xlat_tables/xlat_tables_common.c		\
 				lib/xlat_tables/aarch64/xlat_tables.c		\
@@ -75,4 +76,5 @@ BL31_SOURCES		+=	drivers/arm/cci/cci.c				\
 				plat/xilinx/zynqmp/pm_service/pm_svc_main.c	\
 				plat/xilinx/zynqmp/pm_service/pm_api_sys.c	\
 				plat/xilinx/zynqmp/pm_service/pm_ipi.c		\
-				plat/xilinx/zynqmp/pm_service/pm_client.c
+				plat/xilinx/zynqmp/pm_service/pm_client.c	\
+				plat/xilinx/zynqmp/ipi_mailbox_service/ipi_mailbox_svc.c

--- a/plat/xilinx/zynqmp/pm_service/pm_api_sys.c
+++ b/plat/xilinx/zynqmp/pm_service/pm_api_sys.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -542,7 +542,6 @@ enum pm_ret_status pm_get_chipid(uint32_t *value)
  */
 void pm_get_callbackdata(uint32_t *data, size_t count)
 {
-
 	pm_ipi_buff_read_callb(data, count);
-	pm_ipi_irq_clear();
+	pm_ipi_irq_clear(primary_proc);
 }

--- a/plat/xilinx/zynqmp/pm_service/pm_common.h
+++ b/plat/xilinx/zynqmp/pm_service/pm_common.h
@@ -21,13 +21,13 @@
 
 /**
  * pm_ipi - struct for capturing IPI-channel specific info
- * @mask	mask for enabling/disabling and triggering the IPI
- * @base	base address for IPI
+ * @apu_ipi_id	APU IPI agent ID
+ * @pmu_ipi_id	PMU Agent ID
  * @buffer_base	base address for payload buffer
  */
 struct pm_ipi {
-	const unsigned int mask;
-	const uintptr_t base;
+	const uint32_t apu_ipi_id;
+	const uint32_t pmu_ipi_id;
 	const uintptr_t buffer_base;
 };
 

--- a/plat/xilinx/zynqmp/pm_service/pm_ipi.h
+++ b/plat/xilinx/zynqmp/pm_service/pm_ipi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -9,7 +9,7 @@
 
 #include "pm_common.h"
 
-int pm_ipi_init(void);
+int pm_ipi_init(const struct pm_proc *proc);
 
 enum pm_ret_status pm_ipi_send(const struct pm_proc *proc,
 			       uint32_t payload[PAYLOAD_ARG_CNT]);
@@ -17,8 +17,7 @@ enum pm_ret_status pm_ipi_send_sync(const struct pm_proc *proc,
 				    uint32_t payload[PAYLOAD_ARG_CNT],
 				    unsigned int *value, size_t count);
 void pm_ipi_buff_read_callb(unsigned int *value, size_t count);
-void pm_ipi_irq_enable(void);
-void pm_ipi_irq_disable(void);
-void pm_ipi_irq_clear(void);
+void pm_ipi_irq_enable(const struct pm_proc *proc);
+void pm_ipi_irq_clear(const struct pm_proc *proc);
 
 #endif /* _PM_IPI_H_ */

--- a/plat/xilinx/zynqmp/sip_svc_setup.c
+++ b/plat/xilinx/zynqmp/sip_svc_setup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -8,7 +8,9 @@
 
 #include <runtime_svc.h>
 #include <uuid.h>
+#include "ipi_mailbox_svc.h"
 #include "pm_svc_main.h"
+#include "zynqmp_ipi.h"
 
 /* SMC function IDs for SiP Service queries */
 #define ZYNQMP_SIP_SVC_CALL_COUNT	0x8200ff00
@@ -19,10 +21,12 @@
 #define SIP_SVC_VERSION_MAJOR	0
 #define SIP_SVC_VERSION_MINOR	1
 
-/* These macros are used to identify PM calls from the SMC function ID */
+/* These macros are used to identify PM, IPI calls from the SMC function ID */
 #define PM_FID_MASK	0xf000u
 #define PM_FID_VALUE	0u
+#define IPI_FID_VALUE	0x1000u
 #define is_pm_fid(_fid) (((_fid) & PM_FID_MASK) == PM_FID_VALUE)
+#define is_ipi_fid(_fid) (((_fid) & PM_FID_MASK) == IPI_FID_VALUE)
 
 /* SiP Service UUID */
 DEFINE_SVC_UUID(zynqmp_sip_uuid,
@@ -60,6 +64,12 @@ uint64_t sip_svc_smc_handler(uint32_t smc_fid,
 	/* Let PM SMC handler deal with PM-related requests */
 	if (is_pm_fid(smc_fid)) {
 		return pm_smc_handler(smc_fid, x1, x2, x3, x4, cookie, handle,
+				      flags);
+	}
+
+	/* Let IPI SMC handler deal with IPI-related requests */
+	if (is_ipi_fid(smc_fid)) {
+		return ipi_smc_handler(smc_fid, x1, x2, x3, x4, cookie, handle,
 				      flags);
 	}
 

--- a/plat/xilinx/zynqmp/zynqmp_ipi.c
+++ b/plat/xilinx/zynqmp/zynqmp_ipi.c
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * Zynq UltraScale+ MPSoC IPI agent registers access management
+ */
+
+#include <bakery_lock.h>
+#include <debug.h>
+#include <errno.h>
+#include <mmio.h>
+#include <runtime_svc.h>
+#include <string.h>
+#include "zynqmp_ipi.h"
+#include "../zynqmp_private.h"
+
+/*********************************************************************
+ * Macros definitions
+ ********************************************************************/
+
+/* IPI registers base address */
+#define IPI_REGS_BASE   0xFF300000U
+
+/* IPI registers offsets macros */
+#define IPI_TRIG_OFFSET 0x00U
+#define IPI_OBR_OFFSET  0x04U
+#define IPI_ISR_OFFSET  0x10U
+#define IPI_IMR_OFFSET  0x14U
+#define IPI_IER_OFFSET  0x18U
+#define IPI_IDR_OFFSET  0x1CU
+
+/* IPI register start offset */
+#define IPI_REG_BASE(I) (zynqmp_ipi_table[(I)].ipi_reg_base)
+
+/* IPI register bit mask */
+#define IPI_BIT_MASK(I) (zynqmp_ipi_table[(I)].ipi_bit_mask)
+
+/* IPI secure check */
+#define IPI_SECURE_MASK  0x1U
+#define IPI_IS_SECURE(I) ((zynqmp_ipi_table[(I)].secure_only & \
+			   IPI_SECURE_MASK) ? 1 : 0)
+
+/*********************************************************************
+ * Struct definitions
+ ********************************************************************/
+
+/* structure to maintain IPI configuration information */
+struct zynqmp_ipi_config {
+	unsigned int ipi_bit_mask;
+	unsigned int ipi_reg_base;
+	unsigned char secure_only;
+};
+
+/* Zynqmp ipi configuration table */
+const static struct zynqmp_ipi_config zynqmp_ipi_table[] = {
+	/* APU IPI */
+	{
+		.ipi_bit_mask = 0x1,
+		.ipi_reg_base = 0xFF300000,
+		.secure_only = 0,
+	},
+	/* RPU0 IPI */
+	{
+		.ipi_bit_mask = 0x100,
+		.ipi_reg_base = 0xFF310000,
+		.secure_only = 0,
+	},
+	/* RPU1 IPI */
+	{
+		.ipi_bit_mask = 0x200,
+		.ipi_reg_base = 0xFF320000,
+		.secure_only = 0,
+	},
+	/* PMU0 IPI */
+	{
+		.ipi_bit_mask = 0x10000,
+		.ipi_reg_base = 0xFF330000,
+		.secure_only = IPI_SECURE_MASK,
+	},
+	/* PMU1 IPI */
+	{
+		.ipi_bit_mask = 0x20000,
+		.ipi_reg_base = 0xFF331000,
+		.secure_only = IPI_SECURE_MASK,
+	},
+	/* PMU2 IPI */
+	{
+		.ipi_bit_mask = 0x40000,
+		.ipi_reg_base = 0xFF332000,
+		.secure_only = IPI_SECURE_MASK,
+	},
+	/* PMU3 IPI */
+	{
+		.ipi_bit_mask = 0x80000,
+		.ipi_reg_base = 0xFF333000,
+		.secure_only = IPI_SECURE_MASK,
+	},
+	/* PL0 IPI */
+	{
+		.ipi_bit_mask = 0x1000000,
+		.ipi_reg_base = 0xFF340000,
+		.secure_only = 0,
+	},
+	/* PL1 IPI */
+	{
+		.ipi_bit_mask = 0x2000000,
+		.ipi_reg_base = 0xFF350000,
+		.secure_only = 0,
+	},
+	/* PL2 IPI */
+	{
+		.ipi_bit_mask = 0x4000000,
+		.ipi_reg_base = 0xFF360000,
+		.secure_only = 0,
+	},
+	/* PL3 IPI */
+	{
+		.ipi_bit_mask = 0x8000000,
+		.ipi_reg_base = 0xFF370000,
+		.secure_only = 0,
+	},
+};
+
+/* is_ipi_mb_within_range() - verify if IPI mailbox is within range
+ *
+ * @local  - local IPI ID
+ * @remote - remote IPI ID
+ *
+ * return - 1 if within range, 0 if not
+ */
+static inline int is_ipi_mb_within_range(uint32_t local, uint32_t remote)
+{
+	int ret = 1;
+	uint32_t ipi_total = ARRAY_SIZE(zynqmp_ipi_table);
+
+	if (remote >= ipi_total || local >= ipi_total)
+		ret = 0;
+
+	return ret;
+}
+
+/**
+ * ipi_mb_validate() - validate IPI mailbox access
+ *
+ * @local  - local IPI ID
+ * @remote - remote IPI ID
+ * @is_secure - indicate if the requester is from secure software
+ *
+ * return - 0 success, negative value for errors
+ */
+int ipi_mb_validate(uint32_t local, uint32_t remote, unsigned int is_secure)
+{
+	int ret = 0;
+
+	if (!is_ipi_mb_within_range(local, remote))
+		ret = -EINVAL;
+	else if (IPI_IS_SECURE(local) && !is_secure)
+		ret = -EPERM;
+	else if (IPI_IS_SECURE(remote) && !is_secure)
+		ret = -EPERM;
+
+	return ret;
+}
+
+/**
+ * ipi_mb_open() - Open IPI mailbox.
+ *
+ * @local  - local IPI ID
+ * @remote - remote IPI ID
+ *
+ */
+void ipi_mb_open(uint32_t local, uint32_t remote)
+{
+	mmio_write_32(IPI_REG_BASE(local) + IPI_IDR_OFFSET,
+		      IPI_BIT_MASK(remote));
+	mmio_write_32(IPI_REG_BASE(local) + IPI_ISR_OFFSET,
+		      IPI_BIT_MASK(remote));
+}
+
+/**
+ * ipi_mb_release() - Open IPI mailbox.
+ *
+ * @local  - local IPI ID
+ * @remote - remote IPI ID
+ *
+ */
+void ipi_mb_release(uint32_t local, uint32_t remote)
+{
+	mmio_write_32(IPI_REG_BASE(local) + IPI_IDR_OFFSET,
+		      IPI_BIT_MASK(remote));
+}
+
+/**
+ * ipi_mb_enquire_status() - Enquire IPI mailbox status
+ *
+ * @local  - local IPI ID
+ * @remote - remote IPI ID
+ *
+ * return - 0 idle, positive value for pending sending or receiving,
+ *          negative value for errors
+ */
+int ipi_mb_enquire_status(uint32_t local, uint32_t remote)
+{
+	int ret = 0;
+	uint32_t status;
+
+	status = mmio_read_32(IPI_REG_BASE(local) + IPI_OBR_OFFSET);
+	if (status & IPI_BIT_MASK(remote))
+		ret |= IPI_MB_STATUS_SEND_PENDING;
+	status = mmio_read_32(IPI_REG_BASE(local) + IPI_ISR_OFFSET);
+	if (status & IPI_BIT_MASK(remote))
+		ret |= IPI_MB_STATUS_RECV_PENDING;
+
+	return ret;
+}
+
+/* ipi_mb_notify() - Trigger IPI mailbox notification
+ *
+ * @local - local IPI ID
+ * @remote - remote IPI ID
+ * @is_blocking - if to trigger the notification in blocking mode or not.
+ *
+ * It sets the remote bit in the IPI agent trigger register.
+ *
+ */
+void ipi_mb_notify(uint32_t local, uint32_t remote, uint32_t is_blocking)
+{
+	uint32_t status;
+
+	mmio_write_32(IPI_REG_BASE(local) + IPI_TRIG_OFFSET,
+		      IPI_BIT_MASK(remote));
+	if (is_blocking) {
+		do {
+			status = mmio_read_32(IPI_REG_BASE(local) +
+					      IPI_OBR_OFFSET);
+		} while (status & IPI_BIT_MASK(remote));
+	}
+}
+
+/* ipi_mb_ack() - Ack IPI mailbox notification from the other end
+ *
+ * @local - local IPI ID
+ * @remote - remote IPI ID
+ *
+ * It will clear the remote bit in the isr register.
+ *
+ */
+void ipi_mb_ack(uint32_t local, uint32_t remote)
+{
+	mmio_write_32(IPI_REG_BASE(local) + IPI_ISR_OFFSET,
+		      IPI_BIT_MASK(remote));
+}
+
+/* ipi_mb_disable_irq() - Disable IPI mailbox notification interrupt
+ *
+ * @local - local IPI ID
+ * @remote - remote IPI ID
+ *
+ * It will mask the remote bit in the idr register.
+ *
+ */
+void ipi_mb_disable_irq(uint32_t local, uint32_t remote)
+{
+	mmio_write_32(IPI_REG_BASE(local) + IPI_IDR_OFFSET,
+		      IPI_BIT_MASK(remote));
+}
+
+/* ipi_mb_enable_irq() - Enable IPI mailbox notification interrupt
+ *
+ * @local - local IPI ID
+ * @remote - remote IPI ID
+ *
+ * It will mask the remote bit in the idr register.
+ *
+ */
+void ipi_mb_enable_irq(uint32_t local, uint32_t remote)
+{
+	mmio_write_32(IPI_REG_BASE(local) + IPI_IER_OFFSET,
+		      IPI_BIT_MASK(remote));
+}

--- a/plat/xilinx/zynqmp/zynqmp_ipi.h
+++ b/plat/xilinx/zynqmp/zynqmp_ipi.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/* ZynqMP IPI management enums and defines */
+
+#ifndef _ZYNQMP_IPI_H_
+#define _ZYNQMP_IPI_H_
+
+#include <stdint.h>
+
+/*********************************************************************
+ * IPI agent IDs macros
+ ********************************************************************/
+#define IPI_ID_APU	0U
+#define IPI_ID_RPU0	1U
+#define IPI_ID_RPU1	2U
+#define IPI_ID_PMU0	3U
+#define IPI_ID_PMU1	4U
+#define IPI_ID_PMU2	5U
+#define IPI_ID_PMU3	6U
+#define IPI_ID_PL0	7U
+#define IPI_ID_PL1	8U
+#define IPI_ID_PL2	9U
+#define IPI_ID_PL3	10U
+
+/*********************************************************************
+ * IPI mailbox status macros
+ ********************************************************************/
+#define IPI_MB_STATUS_IDLE		0
+#define IPI_MB_STATUS_SEND_PENDING	1
+#define IPI_MB_STATUS_RECV_PENDING	2
+
+/*********************************************************************
+ * IPI mailbox call is secure or not macros
+ ********************************************************************/
+#define IPI_MB_CALL_NOTSECURE	0
+#define IPI_MB_CALL_SECURE	1
+
+/*********************************************************************
+ * IPI APIs declarations
+ ********************************************************************/
+
+/* Validate IPI mailbox access */
+int ipi_mb_validate(uint32_t local, uint32_t remote, unsigned int is_secure);
+
+/* Open the IPI mailbox */
+void ipi_mb_open(uint32_t local, uint32_t remote);
+
+/* Release the IPI mailbox */
+void ipi_mb_release(uint32_t local, uint32_t remote);
+
+/* Enquire IPI mailbox status */
+int ipi_mb_enquire_status(uint32_t local, uint32_t remote);
+
+/* Trigger notification on the IPI mailbox */
+void ipi_mb_notify(uint32_t local, uint32_t remote, uint32_t is_blocking);
+
+/* Ack IPI mailbox notification */
+void ipi_mb_ack(uint32_t local, uint32_t remote);
+
+/* Disable IPI mailbox notification interrupt */
+void ipi_mb_disable_irq(uint32_t local, uint32_t remote);
+
+/* Enable IPI mailbox notification interrupt */
+void ipi_mb_enable_irq(uint32_t local, uint32_t remote);
+
+#endif /* _ZYNQMP_IPI_H_ */


### PR DESCRIPTION
This patch series will:
* centralize the ZynqMP IPI(Inter Processor Interrupt) IP core access management
* provide ZynqMP IPI mailbox service

v4:
- fix include headers sequence in zynqmp_ipi.c
- update the comments to check if IPI is within valid range to match the function implementation
 
v3:
- use ((x & y) && z)
- use macro to check if the IPI is secure

v2:
- updated the license text
- use U instead of UL for 32bit macros
- use ARRAY_SIZE to get the size of IPI table
- adjust the include headers sequence
- move ipi mailbox validation to IPI SMC handler
  