### PR TITLE
rockchip: Include stdint header in plat_sip_calls.c

### DIFF
--- a/plat/rockchip/rk3399/plat_sip_calls.c
+++ b/plat/rockchip/rk3399/plat_sip_calls.c
@@ -11,6 +11,7 @@
 #include <plat_sip_calls.h>
 #include <rockchip_sip_svc.h>
 #include <runtime_svc.h>
+#include <stdint.h>
 
 #define RK_SIP_DDR_CFG		0x82000008
 #define DRAM_INIT		0x00


### PR DESCRIPTION
This includes the stdint header to declare the various types used within
the file, preventing build errors with recent GCC versions.

Change-Id: I9e7e92bb31deb58d4ff2732067dd88b53124bcc9
Signed-off-by: Paul Kocialkowski <contact@paulk.fr>