### PR TITLE
ARM Platforms: Change the TZC access permissions for EL3 payload

### DIFF
--- a/plat/arm/common/arm_tzc400.c
+++ b/plat/arm/common/arm_tzc400.c
@@ -74,8 +74,8 @@ void arm_tzc400_setup(void)
 
 #else /* if defined(EL3_PAYLOAD_BASE) */
 
-	/* Allow secure access only to DRAM for EL3 payloads. */
-	tzc400_configure_region0(TZC_REGION_S_RDWR, 0);
+	/* Allow Secure and Non-secure access to DRAM for EL3 payloads */
+	tzc400_configure_region0(TZC_REGION_S_RDWR, PLAT_ARM_TZC_NS_DEV_ACCESS);
 
 #endif /* EL3_PAYLOAD_BASE */
 


### PR DESCRIPTION
This patch allows non-secure bus masters to access TZC region0 as well
as the EL3 Payload itself.

Change-Id: I7e44f2673a2992920d41503fb4c57bd7fb30747a
Signed-off-by: Soby Mathew <soby.mathew@arm.com>