### PR TITLE
Unify cache flush code path after image load

### DIFF
--- a/include/common/bl_common.h
+++ b/include/common/bl_common.h
@@ -205,7 +205,6 @@ int is_mem_free(uintptr_t free_base, size_t free_size,
 
 #if LOAD_IMAGE_V2
 
-int load_image(unsigned int image_id, image_info_t *image_data);
 int load_auth_image(unsigned int image_id, image_info_t *image_data);
 
 #else


### PR DESCRIPTION
Previously the cache flush happened in 2 different places in code
depending on whether TRUSTED_BOARD_BOOT is enabled or not. This
patch unifies this code path for both the cases. The `load_image()`
function is now made an internal static function.

Change-Id: I96a1da29d29236bbc34b1c95053e6a9a7fc98a54
Signed-off-by: Soby Mathew <soby.mathew@arm.com>