### PR TITLE
SDEI: Fix return value of reset calls

### DIFF
--- a/services/std_svc/sdei/sdei_main.c
+++ b/services/std_svc/sdei/sdei_main.c
@@ -795,7 +795,7 @@ static int sdei_private_reset(void)
 		 */
 		ret = sdei_event_unregister(map->ev_num);
 		if ((ret == SDEI_EPEND) && (final_ret == 0))
-			final_ret = ret;
+			final_ret = SDEI_EDENY;
 	}
 
 	return final_ret;
@@ -817,7 +817,7 @@ static int sdei_shared_reset(void)
 		 */
 		ret = sdei_event_unregister(map->ev_num);
 		if ((ret == SDEI_EPEND) && (final_ret == 0))
-			final_ret = ret;
+			final_ret = SDEI_EDENY;
 	}
 
 	if (final_ret != 0)


### PR DESCRIPTION
At present, both SDEI_PRIVATE_RESET and SDEI_SHARED_RESET returns
SDEI_PENDING if they fail to unregister an event. The SDEI specification
however requires that the APIs return SDEI_EDENY in these cases. This
patch fixes the return codes for the reset APIs.

Change-Id: Ic14484c91fa8396910387196c256d1ff13d03afd
Signed-off-by: Jeenu Viswambharan <jeenu.viswambharan@arm.com>