### PR TITLE
fvp: Disable SYSTEM_SUSPEND when ARM_BL31_IN_DRAM 

### DIFF
--- a/plat/arm/board/fvp/fvp_pm.c
+++ b/plat/arm/board/fvp/fvp_pm.c
@@ -402,12 +402,20 @@ plat_psci_ops_t plat_arm_psci_pm_ops = {
 	.validate_ns_entrypoint = arm_validate_psci_entrypoint,
 	.translate_power_state_by_mpidr = fvp_translate_power_state_by_mpidr,
 	.get_node_hw_state = fvp_node_hw_state,
+#if !ARM_BL31_IN_DRAM
+	/*
+	 * The TrustZone Controller is set up during the warmboot sequence after
+	 * resuming the CPU from a SYSTEM_SUSPEND. If BL31 is located in SRAM
+	 * this is  not a problem but, if it is in TZC-secured DRAM, it tries to
+	 * reconfigure the same memory it is running on, causing an exception.
+	 */
 	.get_sys_suspend_power_state = fvp_get_sys_suspend_power_state,
-/*
- * mem_protect is not supported in RESET_TO_BL31 and RESET_TO_SP_MIN,
- * as that would require mapping in all of NS DRAM into BL31 or BL32.
- */
+#endif
 #if !RESET_TO_BL31 && !RESET_TO_SP_MIN
+	/*
+	 * mem_protect is not supported in RESET_TO_BL31 and RESET_TO_SP_MIN,
+	 * as that would require mapping in all of NS DRAM into BL31 or BL32.
+	 */
 	.mem_protect_chk	= arm_psci_mem_protect_chk,
 	.read_mem_protect	= arm_psci_read_mem_protect,
 	.write_mem_protect	= arm_nor_psci_write_mem_protect,

--- a/plat/arm/board/fvp/include/platform_def.h
+++ b/plat/arm/board/fvp/include/platform_def.h
@@ -8,6 +8,7 @@
 #define __PLATFORM_DEF_H__
 
 #include <arm_def.h>
+#include <arm_spm_def.h>
 #include <board_arm_def.h>
 #include <common_def.h>
 #include <tzc400.h>

--- a/services/std_svc/spm/secure_partition_setup.c
+++ b/services/std_svc/spm/secure_partition_setup.c
@@ -6,7 +6,6 @@
 
 #include <arch.h>
 #include <arch_helpers.h>
-#include <arm_spm_def.h>
 #include <assert.h>
 #include <common_def.h>
 #include <context.h>


### PR DESCRIPTION
After returning from SYSTEM_SUSPEND state, BL31 reconfigures the TrustZone Controller during the boot sequence. If BL31 is placed in TZC-secured DRAM, it will try to change the permissions of the memory it is being executed from, causing an exception.

The solution is to disable SYSTEM_SUSPEND when the Trusted Firmware has been compiled with ``ARM_BL31_IN_DRAM=1``.

Also, a small issue regarding an Arm platform header has been fixed.