### PR TITLE
SPM: Move S-EL1/S-EL0 xlat tables to TZC DRAM

### DIFF
--- a/include/lib/xlat_tables/xlat_tables_v2.h
+++ b/include/lib/xlat_tables/xlat_tables_v2.h
@@ -168,21 +168,28 @@ typedef struct xlat_ctx xlat_ctx_t;
 					 _xlat_tables_count,		\
 					 _virt_addr_space_size,		\
 					 _phy_addr_space_size,		\
-					 IMAGE_XLAT_DEFAULT_REGIME)
+					 IMAGE_XLAT_DEFAULT_REGIME,	\
+					"xlat_table")
 
 /*
- * Same as REGISTER_XLAT_CONTEXT plus the additional parameter _xlat_regime to
- * specify the translation regime managed by this xlat_ctx_t instance. The
- * values are the one from xlat_regime_t enumeration.
+ * Same as REGISTER_XLAT_CONTEXT plus the additional parameters:
+ *
+ * _xlat_regime:
+ *   Specify the translation regime managed by this xlat_ctx_t instance. The
+ *   values are the one from xlat_regime_t enumeration.
+ *
+ * _section_name:
+ *   Specify the name of the section where the translation tables have to be
+ *   placed by the linker.
  */
 #define REGISTER_XLAT_CONTEXT2(_ctx_name, _mmap_count, _xlat_tables_count,	\
 			_virt_addr_space_size, _phy_addr_space_size,		\
-			_xlat_regime)					\
+			_xlat_regime, _section_name)				\
 	_REGISTER_XLAT_CONTEXT_FULL_SPEC(_ctx_name, _mmap_count,	\
 					 _xlat_tables_count,		\
 					 _virt_addr_space_size,		\
 					 _phy_addr_space_size,		\
-					 _xlat_regime)
+					 _xlat_regime, _section_name)
 
 /******************************************************************************
  * Generic translation table APIs.

--- a/include/lib/xlat_tables/xlat_tables_v2_helpers.h
+++ b/include/lib/xlat_tables/xlat_tables_v2_helpers.h
@@ -123,7 +123,7 @@ struct xlat_ctx {
 
 #define _REGISTER_XLAT_CONTEXT_FULL_SPEC(_ctx_name, _mmap_count, _xlat_tables_count,	\
 			_virt_addr_space_size, _phy_addr_space_size,		\
-			_xlat_regime)					\
+			_xlat_regime, _section_name)				\
 	CASSERT(CHECK_VIRT_ADDR_SPACE_SIZE(_virt_addr_space_size),		\
 		assert_invalid_virtual_addr_space_size_for_##_ctx_name);	\
 										\
@@ -134,7 +134,7 @@ struct xlat_ctx {
 										\
 	static uint64_t _ctx_name##_xlat_tables[_xlat_tables_count]		\
 		[XLAT_TABLE_ENTRIES]						\
-		__aligned(XLAT_TABLE_SIZE) __section("xlat_table");		\
+		__aligned(XLAT_TABLE_SIZE) __section(_section_name);		\
 										\
 	static uint64_t _ctx_name##_base_xlat_table				\
 		[GET_NUM_BASE_LEVEL_ENTRIES(_virt_addr_space_size)]		\

--- a/include/plat/arm/board/common/board_arm_def.h
+++ b/include/plat/arm/board/common/board_arm_def.h
@@ -90,11 +90,7 @@
  * PLAT_ARM_MAX_BL31_SIZE is calculated using the current BL31 debug size plus a
  * little space for growth.
  */
-#if ENABLE_SPM
-#define PLAT_ARM_MAX_BL31_SIZE		0x28000
-#else
 #define PLAT_ARM_MAX_BL31_SIZE		0x1D000
-#endif
 
 #ifdef AARCH32
 /*

--- a/include/plat/arm/common/arm_spm_def.h
+++ b/include/plat/arm/common/arm_spm_def.h
@@ -98,6 +98,12 @@
 /* Total number of memory regions with distinct properties */
 #define ARM_SP_IMAGE_NUM_MEM_REGIONS	6
 
+/*
+ * Name of the section to put the translation tables used by the S-EL1/S-EL0
+ * context of a Secure Partition.
+ */
+#define PLAT_SP_IMAGE_XLAT_SECTION_NAME	"arm_el3_tzc_dram"
+
 /* Cookies passed to the Secure Partition at boot. Not used by ARM platforms. */
 #define PLAT_SPM_COOKIE_0		ULL(0)
 #define PLAT_SPM_COOKIE_1		ULL(0)

--- a/services/std_svc/spm/secure_partition_setup.c
+++ b/services/std_svc/spm/secure_partition_setup.c
@@ -22,12 +22,17 @@
 #include "spm_private.h"
 #include "spm_shim_private.h"
 
+/* Place translation tables by default along with the ones used by BL31. */
+#ifndef PLAT_SP_IMAGE_XLAT_SECTION_NAME
+#define PLAT_SP_IMAGE_XLAT_SECTION_NAME	"xlat_table"
+#endif
+
 /* Allocate and initialise the translation context for the secure partition. */
 REGISTER_XLAT_CONTEXT2(secure_partition,
 			PLAT_SP_IMAGE_MMAP_REGIONS,
 			PLAT_SP_IMAGE_MAX_XLAT_TABLES,
 			PLAT_VIRT_ADDR_SPACE_SIZE, PLAT_PHY_ADDR_SPACE_SIZE,
-			EL1_EL0_REGIME);
+			EL1_EL0_REGIME, PLAT_SP_IMAGE_XLAT_SECTION_NAME);
 
 /* Export a handle on the secure partition translation context */
 xlat_ctx_t *secure_partition_xlat_ctx_handle = &secure_partition_xlat_ctx;


### PR DESCRIPTION
A new platform define, `PLAT_SP_IMAGE_XLAT_SECTION_NAME`, has been introduced to select the section where the translation tables used by the S-EL1/S-EL0 are placed.

This define has been used to move the translation tables to DRAM secured by TrustZone.

Most of the extra needed space in BL31 when SPM is enabled is due to the large size of the translation tables. By moving them to this memory region we can save 44 KiB.

A new argument has been added to REGISTER_XLAT_CONTEXT2() to specify the region where the translation tables have to be placed by the linker.