### PR TITLE
arm-tf: Update scmi driver to support multiple MHU generations

### DIFF
--- a/plat/arm/css/drivers/scmi/scmi.h
+++ b/plat/arm/css/drivers/scmi/scmi.h
@@ -83,6 +83,12 @@
 #define SCMI_E_OUT_OF_RANGE		-5
 #define SCMI_E_BUSY			-6
 
+/* MHU Control Registers */
+#define MHU_V1                  0x1
+#define MHU_V2                  0x2
+#define MHU_V2_ACCESS_REQUEST          0xF88
+#define MHU_V2_ACCESS_READY            0xF8C
+
 /*
  * SCMI driver platform information. The details of the doorbell mechanism
  * can be found in the SCMI specification.
@@ -96,6 +102,8 @@ typedef struct scmi_channel_plat_info {
 	uint32_t db_preserve_mask;
 	/* The bit mask that need to be set to ring doorbell */
 	uint32_t db_modify_mask;
+	/* The version of MHU controller available in the system */
+	uint8_t db_mhu_ver;
 } scmi_channel_plat_info_t;
 
 /*

--- a/plat/arm/css/drivers/scmi/scmi_common.c
+++ b/plat/arm/css/drivers/scmi/scmi_common.c
@@ -39,6 +39,15 @@ void scmi_send_sync_command(scmi_channel_t *ch)
 	 */
 	dmbst();
 
+	if (ch->info->db_mhu_ver == MHU_V2) {
+		/* wake receiver */
+		mmio_write_32(PLAT_CSS_MHU_BASE + MHU_V2_ACCESS_REQUEST, 1);
+		/* wait for receiver to acknowldege */
+		while (!(mmio_read_32(PLAT_CSS_MHU_BASE + MHU_V2_ACCESS_READY)
+					& 1))
+			;
+	}
+
 	SCMI_RING_DOORBELL(ch->info->db_reg_addr, ch->info->db_modify_mask,
 					ch->info->db_preserve_mask);
 
@@ -150,6 +159,7 @@ void *scmi_init(scmi_channel_t *ch)
 	assert(ch->info->db_reg_addr);
 	assert(ch->info->db_modify_mask);
 	assert(ch->info->db_preserve_mask);
+	assert(ch->info->db_mhu_ver);
 
 	assert(ch->lock);
 

--- a/plat/arm/css/drivers/scp/css_pm_scmi.c
+++ b/plat/arm/css/drivers/scp/css_pm_scmi.c
@@ -52,6 +52,12 @@
 		(((pwr_state) >> (SCMI_PWR_STATE_LVL_WIDTH * (lvl))) &	\
 				SCMI_PWR_STATE_LVL_MASK)
 
+/******************************************************************************
+ * The following structure is defined as weak to allow a platform to override
+ * the way the Door Bell parameters of MHU are initialised for SCMI.
+ *****************************************************************************/
+#pragma weak plat_css_scmi_plat_info
+
 /*
  * The SCMI power state enumeration for a power domain level
  */
@@ -308,6 +314,7 @@ scmi_channel_plat_info_t plat_css_scmi_plat_info = {
 		.db_reg_addr = PLAT_CSS_MHU_BASE + CSS_SCMI_MHU_DB_REG_OFF,
 		.db_preserve_mask = 0xfffffffe,
 		.db_modify_mask = 0x1,
+		.db_mhu_ver = MHU_V1,
 };
 
 void plat_arm_pwrc_setup(void)


### PR DESCRIPTION
Updated scmi driver to allow support for multiple generations of MHU
controller available in ARM systems.

As per MHUv2 specification implemented in latest ARM sub-systems, the
sender side must wake the receiver before initiating any data transfer
over MHUv2. The same requirement has been incorporated with this patch
for supporting transactions over MHUv2.

Also, defined plat_css_scmi_plat_info as weak structure to allow a
platform to override the way Door Bell parameters of MHU are
initialised for SCMI.

Signed-off-by: Samarth Parikh <samarth.parikh@arm.com>