### PR TITLE
Disable PIE compilation option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,13 @@ TF_CFLAGS		+=	$(CPPFLAGS) $(TF_CFLAGS_$(ARCH))		\
 				-ffreestanding -fno-builtin -Wall -std=gnu99	\
 				-Os -ffunction-sections -fdata-sections
 
+GCC_V_OUTPUT		:=	$(shell $(CC) -v 2>&1)
+PIE_FOUND		:=	$(findstring --enable-default-pie,${GCC_V_OUTPUT})
+
+ifeq ($(PIE_FOUND),1)
+TF_CFLAGS		+=	-fno-PIE
+endif
+
 TF_LDFLAGS		+=	--fatal-warnings -O1
 TF_LDFLAGS		+=	--gc-sections
 TF_LDFLAGS		+=	$(TF_LDFLAGS_$(ARCH))


### PR DESCRIPTION
ARM TF does not work correctly if built with a version of gcc
that is configured to use PIE by default (e.g. Debian Stretch).

This patch identifies when such a version of gcc is being used
(by searching for --enable-default-pie) and adds -fno-PIE option
to TF_CFLAGS.

fixes arm-software/tf-issues#519

Change-Id: I2322122c49841746d35d152694e14f6f73beb0fd
Signed-off-by: David Cunado <david.cunado@arm.com>
Co-Authored-by: Evan Lloyd <evan.lloyd@arm.com>
Tested-by: Steve Capper <steve.capper@arm.com>
Tested-by: Alexei Fedorov <alexei.fedorov@arm.com>