### PR TITLE
SPM: Allow secondary CPUs to use the Secure Partition

### DIFF
--- a/services/std_svc/spm/spm_private.h
+++ b/services/std_svc/spm/spm_private.h
@@ -32,6 +32,7 @@
 
 #ifndef __ASSEMBLY__
 
+#include <spinlock.h>
 #include <stdint.h>
 #include <xlat_tables_v2.h>
 
@@ -44,6 +45,7 @@ typedef struct secure_partition_context {
 	uint64_t c_rt_ctx;
 	cpu_context_t cpu_ctx;
 	unsigned int sp_init_in_progress;
+	spinlock_t lock;
 } secure_partition_context_t;
 
 uint64_t spm_secure_partition_enter(uint64_t *c_rt_ctx);

--- a/services/std_svc/spm/spm_private.h
+++ b/services/std_svc/spm/spm_private.h
@@ -43,6 +43,7 @@ struct entry_point_info;
 typedef struct secure_partition_context {
 	uint64_t c_rt_ctx;
 	cpu_context_t cpu_ctx;
+	unsigned int sp_init_in_progress;
 } secure_partition_context_t;
 
 uint64_t spm_secure_partition_enter(uint64_t *c_rt_ctx);


### PR DESCRIPTION
The Secure Partition should be able to be used from any CPU, not just the lead one. This patch point the secure contexts of all secondary CPUs to the same one used by the lead CPU for the Secure Partition. This way, they can also use it.

In order to prevent more than one CPU from using the Secure Partition at the same time, a lock has been added.