### PR TITLE
Add padding at the end of the last entry

### DIFF
--- a/docs/firmware-design.rst
+++ b/docs/firmware-design.rst
@@ -1868,9 +1868,11 @@ Firmware Image Package layout
 
 The FIP layout consists of a table of contents (ToC) followed by payload data.
 The ToC itself has a header followed by one or more table entries. The ToC is
-terminated by an end marker entry. All ToC entries describe some payload data
-that has been appended to the end of the binary package. With the information
-provided in the ToC entry the corresponding payload data can be retrieved.
+terminated by an end marker entry, and since the size of the ToC is 0 bytes,
+the offset equals the total size of the FIP file. All ToC entries describe some
+payload data that has been appended to the end of the binary package. With the
+information provided in the ToC entry the corresponding payload data can be
+retrieved.
 
 ::
 


### PR DESCRIPTION
This patch adds padding bytes at the end of the last image in the
fip to be able to transfer by DMA the last image.

Change-Id: I8c6f07dee389cb3d1dc919936d9d52841d7e5723
Signed-off-by: Roberto Vargas <roberto.vargas@arm.com>
Signed-off-by: Dimitris Papastamos <dimitris.papastamos@arm.com>
Signed-off-by: David Cunado <david.cunado@arm.com>
 
docs: Update the ToC end marker description in the document
jtzhou2016 committed with davidcunado-arm on 24 Nov 2017

Change-Id: I2e29a63f08aed3b8ea0bb10170a3d55b8d033e62
Signed-off-by: Jett Zhou <jett.zhou@arm.com>
Signed-off-by: David Cunado <david.cunado@arm.com>