### PR TITLE
Hikey960: Enable exception handling framework

### DIFF
--- a/plat/hisilicon/hikey960/aarch64/hikey960_ehf.c
+++ b/plat/hisilicon/hikey960/aarch64/hikey960_ehf.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <ehf.h>
+#include "../hikey960_def.h"
+
+/*
+ * Enumeration of priority levels on ARM platforms.
+ */
+ehf_pri_desc_t hikey960_exceptions[] = {
+	/* Critical priority */
+	EHF_PRI_DESC(PLAT_GIC_PRI_BITS, PLAT_GIC_CRITICAL_PRI),
+
+	/* Normal priority */
+	EHF_PRI_DESC(PLAT_GIC_PRI_BITS, PLAT_GIC_NORMAL_PRI),
+};
+
+/* Plug in exceptions to Exception Handling Framework. */
+EHF_REGISTER_PRIORITIES(hikey960_exceptions, ARRAY_SIZE(hikey960_exceptions),
+			PLAT_GIC_PRI_BITS);

--- a/plat/hisilicon/hikey960/hikey960_def.h
+++ b/plat/hisilicon/hikey960/hikey960_def.h
@@ -53,4 +53,9 @@
 #define HIKEY960_UFS_DATA_BASE		0x10000000
 #define HIKEY960_UFS_DATA_SIZE		0x0A000000	/* 160MB */
 
+/* Priority levels for GICv2 */
+#define PLAT_GIC_CRITICAL_PRI		0x60
+#define PLAT_GIC_NORMAL_PRI		0x70
+#define PLAT_GIC_PRI_BITS		3
+
 #endif /* __HIKEY960_DEF_H__ */

--- a/plat/hisilicon/hikey960/platform.mk
+++ b/plat/hisilicon/hikey960/platform.mk
@@ -95,6 +95,7 @@ BL31_SOURCES		+=	drivers/arm/cci/cci.c			\
 				plat/hisilicon/hikey960/hikey960_topology.c \
 				plat/hisilicon/hikey960/drivers/pwrc/hisi_pwrc.c \
 				plat/hisilicon/hikey960/drivers/ipc/hisi_ipc.c \
+				plat/hisilicon/hikey960/aarch64/hikey960_ehf.c \
 				${HIKEY960_GIC_SOURCES}
 
 # Enable workarounds for selected Cortex-A53 errata.


### PR DESCRIPTION
When some interrupts are configured as group 1 in GICv2, these
interrupts trigger FIQ signal; this results in the Linux kernel panic
by reporting log: "Bad mode in FIQ handler detected on CPU0, code
0x00000000 -- Unknown/Uncategorized".  Unfortunately from kernel side it
has no permission to read the GIC register for group 1 interrupts so we
have no chance to get to know which interrupt is configured as secure
interrupt and cause the kernel panic.

For upper reason, we can enable exception handling framework in ARM-TF;
after enable the EHF then the FIQ is to be routed into EL3 level for
exception handling and EL3 has permission to read interrupt number so
can easily locate which interrupt causes issue. For enabling EHF, except
this patch we also need pass below parameters for ARM-TF building:

  "EL3_EXCEPTION_HANDLING=1 GICV2_G0_FOR_EL3=1"

If we need integrate service into ARM-TF with specific interrupt routing
model, we can simply remove building options "EL3_EXCEPTION_HANDLING=1
GICV2_G0_FOR_EL3=1" so can avoid conflict issue.

Signed-off-by: Leo Yan <leo.yan@linaro.org>