### PR TITLE
Move TSP to TZC secured DRAM

### DIFF
--- a/include/plat/arm/board/common/board_arm_def.h
+++ b/include/plat/arm/board/common/board_arm_def.h
@@ -90,7 +90,7 @@
  * PLAT_ARM_MAX_BL31_SIZE is calculated using the current BL31 debug size plus a
  * little space for growth.
  */
-#define PLAT_ARM_MAX_BL31_SIZE		0x1D000
+#define PLAT_ARM_MAX_BL31_SIZE		0x1E000
 
 #ifdef AARCH32
 /*

--- a/plat/arm/common/arm_common.mk
+++ b/plat/arm/common/arm_common.mk
@@ -7,13 +7,9 @@
 ifeq (${ARCH}, aarch64)
   # On ARM standard platorms, the TSP can execute from Trusted SRAM, Trusted
   # DRAM (if available) or the TZC secured area of DRAM.
-  # Trusted SRAM is the default.
+  # TZC secured DRAM is the default.
 
-  ifneq (${TRUSTED_BOARD_BOOT},0)
-    ARM_TSP_RAM_LOCATION	?=	dram
-  else
-    ARM_TSP_RAM_LOCATION	?=	tsram
-  endif
+  ARM_TSP_RAM_LOCATION	?=	dram
 
   ifeq (${ARM_TSP_RAM_LOCATION}, tsram)
     ARM_TSP_RAM_LOCATION_ID = ARM_TRUSTED_SRAM_ID


### PR DESCRIPTION
To allow BL31 to grow in SRAM, move TSP in TZC secured DRAM
by default.

Increase the BL31 max limit by one page.

Change-Id: Idd3479be02f0f9bafac2f275376d7db0c2015431
Signed-off-by: Dimitris Papastamos <dimitris.papastamos@arm.com>