### PR TITLE
Add documentation about plat_try_next_boot_source to bl1_platform_setup

### DIFF
--- a/docs/porting-guide.rst
+++ b/docs/porting-guide.rst
@@ -1128,6 +1128,9 @@ This function executes with the MMU and data caches enabled. It is responsible
 for performing any remaining platform-specific setup that can occur after the
 MMU and data cache have been enabled.
 
+if support for multiple boot sources is required, it initializes the boot
+sequence used by plat\_try\_next\_boot\_source().
+
 In ARM standard platforms, this function initializes the storage abstraction
 layer used to load the next bootloader image.
 


### PR DESCRIPTION
If boot redundancy is required in BL1 then the initialization
of the boot sequence must be done in bl1_platform_setup. In BL2,
we had to add a new function, bl2_preload_setup, because
bl2_platform_setup is called after the images are loaded, making it
invalid for the boot sequence initialization.

Change-Id: I5c177ff142608ed38b4192288b06614343b2b83b
Signed-off-by: Roberto Vargas <roberto.vargas@arm.com>