### PR TITLE
xlat v2: Correctly unmap regions on map error

### DIFF
--- a/lib/xlat_tables_v2/xlat_tables_internal.c
+++ b/lib/xlat_tables_v2/xlat_tables_internal.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -893,7 +893,7 @@ int mmap_add_dynamic_region_ctx(xlat_ctx_t *ctx, mmap_region_t *mm)
 			 * Check if the mapping function actually managed to map
 			 * anything. If not, just return now.
 			 */
-			if (mm_cursor->base_va >= end_va)
+			if (mm->base_va >= end_va)
 				return -ENOMEM;
 
 			/*


### PR DESCRIPTION
`mm_cursor` doesn't have the needed data because the `memmove()` that is called right before it overwrites that information. In order to get the information of the region that was being mapped, `mm` has to be used instead (like it is done to fill the fields of `unmap_mm`).

If the incorrect information is read, this check isn't reliable and `xlat_tables_unmap_region` may be requested to unmap memory that isn't mapped at all, triggering assertions.