### PR TITLE
SPM: Fix version header definitions

### DIFF
--- a/include/services/mm_svc.h
+++ b/include/services/mm_svc.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __MM_SVC_H__
+#define __MM_SVC_H__
+
+#include <utils_def.h>
+
+#define MM_VERSION_MAJOR	U(1)
+#define MM_VERSION_MAJOR_SHIFT	16
+#define MM_VERSION_MAJOR_MASK	U(0x7FFF)
+#define MM_VERSION_MINOR	U(0)
+#define MM_VERSION_MINOR_SHIFT	0
+#define MM_VERSION_MINOR_MASK	U(0xFFFF)
+#define MM_VERSION_FORM(major, minor)	((major << MM_VERSION_MAJOR_SHIFT) | (minor))
+#define MM_VERSION_COMPILED	MM_VERSION_FORM(MM_VERSION_MAJOR, MM_VERSION_MINOR)
+
+/*
+ * SMC IDs defined in [1] for accessing MM services from the Non-secure world.
+ * These FIDs occupy the range 0x40 - 0x5f.
+ * [1] DEN0060A_ARM_MM_Interface_Specification.pdf
+ */
+#define MM_VERSION_AARCH32		U(0x84000040)
+
+#define MM_COMMUNICATE_AARCH64		U(0xC4000041)
+#define MM_COMMUNICATE_AARCH32		U(0x84000041)
+
+#endif /* __MM_SVC_H__ */

--- a/include/services/spm_svc.h
+++ b/include/services/spm_svc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,14 +10,13 @@
 #include <utils_def.h>
 
 #define SPM_VERSION_MAJOR	U(0)
+#define SPM_VERSION_MAJOR_SHIFT	16
+#define SPM_VERSION_MAJOR_MASK	U(0x7FFF)
 #define SPM_VERSION_MINOR	U(1)
-#define SPM_VERSION_FORM(major, minor)	((major << 16) | (minor))
+#define SPM_VERSION_MINOR_SHIFT	0
+#define SPM_VERSION_MINOR_MASK	U(0xFFFF)
+#define SPM_VERSION_FORM(major, minor)	((major << SPM_VERSION_MAJOR_SHIFT) | (minor))
 #define SPM_VERSION_COMPILED	SPM_VERSION_FORM(SPM_VERSION_MAJOR, SPM_VERSION_MINOR)
-
-#define SP_VERSION_MAJOR	U(1)
-#define SP_VERSION_MINOR	U(0)
-#define SP_VERSION_FORM(major, minor)	((major << 16) | (minor))
-#define SP_VERSION_COMPILED	SP_VERSION_FORM(SP_VERSION_MAJOR, SP_VERSION_MINOR)
 
 /* The macros below are used to identify SPM calls from the SMC function ID */
 #define SPM_FID_MASK			U(0xffff)
@@ -31,6 +30,7 @@
  * SMC IDs defined for accessing services implemented by the Secure Partition
  * Manager from the Secure Partition(s). These services enable a partition to
  * handle delegated events and request privileged operations from the manager.
+ * They occupy the range 0x60-0x7f.
  */
 #define SPM_VERSION_AARCH32			U(0x84000060)
 #define SP_EVENT_COMPLETE_AARCH64		U(0xC4000061)
@@ -51,16 +51,6 @@
 #define SP_MEMORY_ATTRIBUTES_EXEC		(U(0) << 2)
 #define SP_MEMORY_ATTRIBUTES_NON_EXEC		(U(1) << 2)
 
-/*
- * SMC IDs defined in [1] for accessing secure partition services from the
- * Non-secure world. These FIDs occupy the range 0x40 - 0x5f
- * [1] DEN0060A_ARM_MM_Interface_Specification.pdf
- */
-#define SP_VERSION_AARCH64		U(0xC4000040)
-#define SP_VERSION_AARCH32		U(0x84000040)
-
-#define MM_COMMUNICATE_AARCH64		U(0xC4000041)
-#define MM_COMMUNICATE_AARCH32		U(0x84000041)
 
 /* SPM error codes. */
 #define SPM_SUCCESS		0

--- a/services/std_svc/spm/spm_main.c
+++ b/services/std_svc/spm/spm_main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,6 +10,7 @@
 #include <context_mgmt.h>
 #include <debug.h>
 #include <errno.h>
+#include <mm_svc.h>
 #include <platform.h>
 #include <runtime_svc.h>
 #include <secure_partition.h>
@@ -423,9 +424,8 @@ uint64_t spm_smc_handler(uint32_t smc_fid,
 
 		switch (smc_fid) {
 
-		case SP_VERSION_AARCH64:
-		case SP_VERSION_AARCH32:
-			SMC_RET1(handle, SP_VERSION_COMPILED);
+		case MM_VERSION_AARCH32:
+			SMC_RET1(handle, MM_VERSION_COMPILED);
 
 		case MM_COMMUNICATE_AARCH32:
 		case MM_COMMUNICATE_AARCH64:


### PR DESCRIPTION
Rename SP_VERSION macros to MM_VERSION, which is the name used in the MM specification [1]. Also, a few more helper macros have been added.

MM-specific definitions have been moved to their own header file.

[1] http://infocenter.arm.com/help/topic/com.arm.doc.den0060a/DEN0060A_ARM_MM_Interface_Specification.pdf