### PR TITLE
Makefile: Use ld.bfd linker if available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,12 @@ OD			:=	${CROSS_COMPILE}objdump
 NM			:=	${CROSS_COMPILE}nm
 PP			:=	${CROSS_COMPILE}gcc -E
 
+# Use ${LD}.bfd instead if it exists (as absolute path or together with $PATH).
+ifneq ($(strip $(wildcard ${LD}.bfd) \
+	$(foreach dir,$(subst :, ,${PATH}),$(wildcard ${dir}/${LD}.bfd))),)
+LD			:=	${LD}.bfd
+endif
+
 ifeq (${ARM_ARCH_MAJOR},7)
 target32-directive	= 	-target arm-none-eabi
 # Will set march32-directive from platform configuration


### PR DESCRIPTION
Some toolchain distributions install both the BFD and GOLD linkers under
the names [target]-ld.bfd and [target]-ld.gold. [target]-ld will then be
a symlink that may point to either one of these.

Trusted Firmware should always be linked with the BFD linker, since GOLD
is meant primarily for userspace programs and doesn't support many of
the more obscure linker script features that may be needed for firmware.
With this patch the Makefile will auto-detect if ld.bfd is available and
use it explicitly in that case.

Change-Id: I7017055f67db3bd57d191d20a7af06ca646937d7
Signed-off-by: Julius Werner <jwerner@chromium.org>