### PR TITLE
emmc/dw_mmc: fix the assert on HLE bit

### DIFF
--- a/drivers/synopsys/emmc/dw_mmc.c
+++ b/drivers/synopsys/emmc/dw_mmc.c
@@ -146,7 +146,7 @@ static void dw_update_clk(void)
 		if ((data & CMD_START) == 0)
 			break;
 		data = mmio_read_32(dw_params.reg_base + DWMMC_RINTSTS);
-		assert(data & INT_HLE);
+		assert((data & INT_HLE) == 0);
 	}
 }
 


### PR DESCRIPTION
When check HLE bit in interrupt register, it should check whether
HLE bit is set, not clear.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>