### PR TITLE
Increase BL31 memory space by 2 pages

### DIFF
--- a/include/plat/arm/board/common/board_arm_def.h
+++ b/include/plat/arm/board/common/board_arm_def.h
@@ -90,7 +90,7 @@
  * PLAT_ARM_MAX_BL31_SIZE is calculated using the current BL31 debug size plus a
  * little space for growth.
  */
-#define PLAT_ARM_MAX_BL31_SIZE		0x1E000
+#define PLAT_ARM_MAX_BL31_SIZE		0x20000
 
 #ifdef AARCH32
 /*


### PR DESCRIPTION
On some build configurations BL31 is running out of space.  Now that
TSP is moved to secure dram, we have a bit of additional space to use
in BL31.

Change-Id: Ib89fcd8bae99c85c9c5e5d9228bb42fb7048dcb6
Signed-off-by: Dimitris Papastamos <dimitris.papastamos@arm.com>
Signed-off-by: David Cunado <david.cunado@arm.com>