### PR TITLE
AMU: Remove unnecessary WARN()

### DIFF
--- a/lib/extensions/amu/aarch32/amu.c
+++ b/lib/extensions/amu/aarch32/amu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,7 +7,6 @@
 #include <amu.h>
 #include <arch.h>
 #include <arch_helpers.h>
-#include <debug.h>
 #include <platform.h>
 #include <pubsub_events.h>
 
@@ -24,10 +23,8 @@ void amu_enable(int el2_unused)
 	uint64_t features;
 
 	features = read_id_pfr0() >> ID_PFR0_AMU_SHIFT;
-	if ((features & ID_PFR0_AMU_MASK) != 1) {
-		WARN("Cannot enable AMU - not supported\n");
+	if ((features & ID_PFR0_AMU_MASK) != 1)
 		return;
-	}
 
 	if (el2_unused) {
 		uint64_t v;

--- a/lib/extensions/amu/aarch64/amu.c
+++ b/lib/extensions/amu/aarch64/amu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -9,7 +9,6 @@
 #include <arch.h>
 #include <arch_helpers.h>
 #include <assert.h>
-#include <debug.h>
 #include <platform.h>
 #include <pubsub_events.h>
 
@@ -38,10 +37,8 @@ void amu_enable(int el2_unused)
 {
 	uint64_t v;
 
-	if (!amu_supported()) {
-		WARN("Cannot enable AMU - not supported\n");
+	if (!amu_supported())
 		return;
-	}
 
 	if (el2_unused) {
 		/*


### PR DESCRIPTION
If AMU is not supported by the hardware but it is enabled in Trusted
Firmware, the console will be spammed with warnings every time a CPU
is brought up with a CPU ON call.

Remove the warning message as this is more in line with how other
extensions like SPE and SVE are handled.

Change-Id: Iba6d367e4d1375ab554d23d2eaceab3ae1362c5a
Signed-off-by: Dimitris Papastamos <dimitris.papastamos@arm.com>