### PR TITLE
emmc: add macros CMD21, BUS_WIDTH_DDR_4 and BUS_WIDTH_DDR_8

### DIFF
--- a/drivers/emmc/emmc.c
+++ b/drivers/emmc/emmc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  *
@@ -353,7 +353,9 @@ void emmc_init(const emmc_ops_t *ops_ptr, int clk, int width,
 	       (clk != 0) &&
 	       ((width == EMMC_BUS_WIDTH_1) ||
 		(width == EMMC_BUS_WIDTH_4) ||
-		(width == EMMC_BUS_WIDTH_8)));
+		(width == EMMC_BUS_WIDTH_8) ||
+		(width == EMMC_BUS_WIDTH_DDR_4) ||
+		(width == EMMC_BUS_WIDTH_DDR_8)));
 	ops = ops_ptr;
 	emmc_flags = flags;
 

--- a/include/drivers/emmc.h
+++ b/include/drivers/emmc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -25,6 +25,7 @@
 #define EMMC_CMD13			13
 #define EMMC_CMD17			17
 #define EMMC_CMD18			18
+#define EMMC_CMD21			21
 #define EMMC_CMD23			23
 #define EMMC_CMD24			24
 #define EMMC_CMD25			25
@@ -61,6 +62,8 @@
 #define EMMC_BUS_WIDTH_1		0
 #define EMMC_BUS_WIDTH_4		1
 #define EMMC_BUS_WIDTH_8		2
+#define EMMC_BUS_WIDTH_DDR_4		5
+#define EMMC_BUS_WIDTH_DDR_8		6
 #define EMMC_BOOT_MODE_BACKWARD		(0 << 3)
 #define EMMC_BOOT_MODE_HS_TIMING	(1 << 3)
 #define EMMC_BOOT_MODE_DDR		(2 << 3)


### PR DESCRIPTION
Add some macros according to JEDEC Standard Embedded Multi-Media
Card (eMMC) Electrical Standard (5.1)": Table 145 - Bus Mode
Selection.
The specification could be downloaded from here:
https://www.jedec.org/sites/default/files/docs/JESD84-B51.pdf
