### PR TITLE
lib/cpus: fix branching in reset function for cortex-a72 AARCH32 mode

### DIFF
--- a/lib/cpus/aarch32/cortex_a72.S
+++ b/lib/cpus/aarch32/cortex_a72.S
@@ -109,7 +109,7 @@ func cortex_a72_reset_func
 	orr64_imm	r0, r1, CORTEX_A72_ECTLR_SMP_BIT
 	stcopr16	r0, r1,	CORTEX_A72_ECTLR
 	isb
-	bx	lr
+	bx	r5
 endfunc cortex_a72_reset_func
 
 	/* ----------------------------------------------------


### PR DESCRIPTION
In AARCH32 mode, cortex_a72_reset_func branches to address in lr
register instead of r5 register. This leads to linux boot failure
of Cortex-A72 cores in AARCH32 mode on Juno-R2 board.

This patch fixes the branching of cortex_a72_reset_func to r5
register as in cortex_a57_reset_func implementation.

Signed-off-by: Manoj Kumar <manoj.kumar3@arm.com>