### PR TITLE
Allow API deprecation for uniphier platform

### DIFF
--- a/plat/socionext/uniphier/platform.mk
+++ b/plat/socionext/uniphier/platform.mk
@@ -6,7 +6,6 @@
 
 override COLD_BOOT_SINGLE_CPU	:= 1
 override ENABLE_PLAT_COMPAT	:= 0
-override ERROR_DEPRECATED	:= 1
 override LOAD_IMAGE_V2		:= 1
 override USE_COHERENT_MEM	:= 1
 override USE_TBBR_DEFS		:= 1


### PR DESCRIPTION
The `override ERROR_DEPRECATION = 1` setting in uniphier platform
makes deprecation of API difficult. Hence removing the same. This
flag should be specified on the command line if needed.

Change-Id: I8c82d8d13944e450a8cd636de3326137c04d7560
Signed-off-by: Soby Mathew <soby.mathew@arm.com>