### PR TITLE
SPM: Declare explicit width based types in secure_partition_boot_info…

### DIFF
--- a/include/services/secure_partition.h
+++ b/include/services/secure_partition.h
@@ -35,27 +35,27 @@ extern uintptr_t __SP_IMAGE_XLAT_TABLES_END__;
  * partition.
  */
 typedef struct secure_partition_mp_info {
-	u_register_t		mpidr;
-	unsigned int		linear_id;
-	unsigned int		flags;
+	uint64_t		mpidr;
+	uint32_t		linear_id;
+	uint32_t		flags;
 } secure_partition_mp_info_t;
 
 typedef struct secure_partition_boot_info {
 	param_header_t		h;
-	uintptr_t		sp_mem_base;
-	uintptr_t		sp_mem_limit;
-	uintptr_t		sp_image_base;
-	uintptr_t		sp_stack_base;
-	uintptr_t		sp_heap_base;
-	uintptr_t		sp_ns_comm_buf_base;
-	uintptr_t		sp_shared_buf_base;
-	size_t			sp_image_size;
-	size_t			sp_pcpu_stack_size;
-	size_t			sp_heap_size;
-	size_t			sp_ns_comm_buf_size;
-	size_t			sp_shared_buf_size;
-	unsigned int		num_sp_mem_regions;
-	unsigned int		num_cpus;
+	uint64_t		sp_mem_base;
+	uint64_t		sp_mem_limit;
+	uint64_t		sp_image_base;
+	uint64_t		sp_stack_base;
+	uint64_t		sp_heap_base;
+	uint64_t		sp_ns_comm_buf_base;
+	uint64_t		sp_shared_buf_base;
+	uint64_t		sp_image_size;
+	uint64_t		sp_pcpu_stack_size;
+	uint64_t		sp_heap_size;
+	uint64_t		sp_ns_comm_buf_size;
+	uint64_t		sp_shared_buf_size;
+	uint32_t		num_sp_mem_regions;
+	uint32_t		num_cpus;
 	secure_partition_mp_info_t	*mp_info;
 } secure_partition_boot_info_t;
 


### PR DESCRIPTION
…_t structure

The secure_partition_boot_info_t structure is used to communicate boot
parameters with the StandaloneMM code executing at S-EL0 through a
shared buffer. Certain data types used for members of this structure
are opaque with their size depending on the toolchain being used.

Declare the members of the structure with explicit width based data
types, which would maintain compatibility across toolchains.

Signed-off-by: Sughosh Ganu <sughosh.ganu@arm.com>