### PR TITLE
Fix udelay issues that can make duration slightly too short

### DIFF
--- a/drivers/delay_timer/delay_timer.c
+++ b/drivers/delay_timer/delay_timer.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <delay_timer.h>
 #include <platform_def.h>
+#include <utils_def.h>
 
 /***********************************************************
  * The delay timer implementation
@@ -30,7 +31,8 @@ void udelay(uint32_t usec)
 
 	start = ops->get_timer_value();
 
-	total_delta = (usec * ops->clk_div) / ops->clk_mult;
+	/* Add an extra tick to avoid delaying less than requested. */
+	total_delta = div_round_up(usec * ops->clk_div, ops->clk_mult) + 1;
 
 	do {
 		/*

--- a/include/lib/utils_def.h
+++ b/include/lib/utils_def.h
@@ -24,6 +24,11 @@
  */
 #define DIV_ROUND_UP_2EVAL(n, d)	(((n) + (d) - 1) / (d))
 
+#define div_round_up(val, div) __extension__ ({	\
+	__typeof__(div) _div = (div);		\
+	((val) + _div - 1) / _div;		\
+})
+
 #define MIN(x, y) __extension__ ({	\
 	__typeof__(x) _x = (x);		\
 	__typeof__(y) _y = (y);		\
@@ -54,11 +59,6 @@
 
 #define round_down(value, boundary)		\
 	((value) & ~round_boundary(value, boundary))
-
-#define div_round_up(val, div) __extension__ ({	\
-	__typeof__(div) _div = (div);		\
-	round_up((val), _div)/_div;		\
-})
 
 /*
  * Evaluates to 1 if (ptr + inc) overflows, 0 otherwise.


### PR DESCRIPTION
This fixes a minor problem we noticed that can result in udelay() calls delaying for slightly less time than the programmer intended.