### PR TITLE
RK3399 GIC save/restore

### DIFF
--- a/drivers/arm/gic/v3/arm_gicv3_common.c
+++ b/drivers/arm/gic/v3/arm_gicv3_common.c
@@ -84,6 +84,15 @@ void arm_gicv3_distif_post_restore(unsigned int rdist_proc_num)
 	assert(gicr_base);
 
 	/*
+	 * If the GIC had power removed, the GICR_WAKER state will be reset.
+	 * Since the GICR_WAKER.Sleep and GICR_WAKER.Quiescent bits are cleared,
+	 * we can exit early. This also prevents the following assert from
+	 * erroneously triggering.
+	 */
+	if (!(gicr_read_waker(gicr_base) & WAKER_SL_BIT))
+		return;
+
+	/*
 	 * Writes to GICR_WAKER.Sleep bit are ignored if GICR_WAKER.Quiescent
 	 * bit is not set. We should be alright on power on path, therefore
 	 * coming out of sleep and Quiescent should be set, but we assert in

--- a/plat/rockchip/common/plat_pm.c
+++ b/plat/rockchip/common/plat_pm.c
@@ -246,13 +246,13 @@ void rockchip_pwr_domain_suspend(const psci_power_state_t *target_state)
 	if (RK_CORE_PWR_STATE(target_state) != PLAT_MAX_OFF_STATE)
 		return;
 
+	/* Prevent interrupts from spuriously waking up this cpu */
+	plat_rockchip_gic_cpuif_disable();
+
 	if (RK_SYSTEM_PWR_STATE(target_state) == PLAT_MAX_OFF_STATE)
 		rockchip_soc_sys_pwr_dm_suspend();
 	else
 		rockchip_soc_cores_pwr_dm_suspend();
-
-	/* Prevent interrupts from spuriously waking up this cpu */
-	plat_rockchip_gic_cpuif_disable();
 
 	/* Perform the common cluster specific operations */
 	if (RK_CLUSTER_PWR_STATE(target_state) == PLAT_MAX_OFF_STATE)

--- a/plat/rockchip/rk3399/drivers/pmu/pmu.c
+++ b/plat/rockchip/rk3399/drivers/pmu/pmu.c
@@ -95,7 +95,7 @@ static void pmu_bus_idle_req(uint32_t bus, uint32_t state)
 
 struct pmu_slpdata_s pmu_slpdata;
 
-static void qos_save(void)
+static void qos_restore(void)
 {
 	if (pmu_power_domain_st(PD_GPU) == pmu_pd_on)
 		RESTORE_QOS(pmu_slpdata.gpu_qos, GPU);
@@ -161,7 +161,7 @@ static void qos_save(void)
 	}
 }
 
-static void qos_restore(void)
+static void qos_save(void)
 {
 	if (pmu_power_domain_st(PD_GPU) == pmu_pd_on)
 		SAVE_QOS(pmu_slpdata.gpu_qos, GPU);

--- a/plat/rockchip/rk3399/drivers/pmu/pmu.c
+++ b/plat/rockchip/rk3399/drivers/pmu/pmu.c
@@ -79,9 +79,12 @@ static void pmu_bus_idle_req(uint32_t bus, uint32_t state)
 	do {
 		bus_state = mmio_read_32(PMU_BASE + PMU_BUS_IDLE_ST) & bus_id;
 		bus_ack = mmio_read_32(PMU_BASE + PMU_BUS_IDLE_ACK) & bus_id;
+		if (bus_state == bus_req && bus_ack == bus_req)
+			break;
+
 		wait_cnt++;
-	} while ((bus_state != bus_req || bus_ack != bus_req) &&
-		 (wait_cnt < MAX_WAIT_COUNT));
+		udelay(1);
+	} while (wait_cnt < MAX_WAIT_COUNT);
 
 	if (bus_state != bus_req || bus_ack != bus_req) {
 		INFO("%s:st=%x(%x)\n", __func__,
@@ -430,6 +433,7 @@ static void pmu_scu_b_pwrdn(void)
 	while (!(mmio_read_32(PMU_BASE + PMU_CORE_PWR_ST) &
 		 BIT(STANDBY_BY_WFIL2_CLUSTER_B))) {
 		wait_cnt++;
+		udelay(1);
 		if (wait_cnt >= MAX_WAIT_COUNT)
 			ERROR("%s:wait cluster-b l2(%x)\n", __func__,
 			      mmio_read_32(PMU_BASE + PMU_CORE_PWR_ST));
@@ -1369,6 +1373,7 @@ int rockchip_soc_sys_pwr_dm_suspend(void)
 			      mmio_read_32(PMU_BASE + PMU_ADB400_ST));
 			panic();
 		}
+		udelay(1);
 	}
 	mmio_setbits_32(PMU_BASE + PMU_PWRDN_CON, BIT(PMU_SCU_B_PWRDWN_EN));
 
@@ -1462,6 +1467,7 @@ int rockchip_soc_sys_pwr_dm_resume(void)
 			      mmio_read_32(PMU_BASE + PMU_ADB400_ST));
 			panic();
 		}
+		udelay(1);
 	}
 
 	pmu_sgrf_rst_hld_release();

--- a/plat/rockchip/rk3399/drivers/pmu/pmu.h
+++ b/plat/rockchip/rk3399/drivers/pmu/pmu.h
@@ -53,7 +53,7 @@ enum pmu_core_pwrst_shift {
 #define TSADC_INT_PIN		38
 #define CORES_PM_DISABLE	0x0
 
-#define PD_CTR_LOOP		500
+#define PD_CTR_LOOP		10000
 #define CHK_CPU_LOOP		500
 #define MAX_WAIT_COUNT		1000
 

--- a/plat/rockchip/rk3399/platform.mk
+++ b/plat/rockchip/rk3399/platform.mk
@@ -23,6 +23,8 @@ PLAT_INCLUDES		:=	-I${RK_PLAT_COMMON}/			\
 				-I${RK_PLAT_SOC}/include/shared/	\
 
 RK_GIC_SOURCES		:=	drivers/arm/gic/common/gic_common.c	\
+				drivers/arm/gic/v3/arm_gicv3_common.c	\
+				drivers/arm/gic/v3/gic500.c		\
 				drivers/arm/gic/v3/gicv3_main.c		\
 				drivers/arm/gic/v3/gicv3_helpers.c	\
 				plat/common/plat_gicv3.c		\


### PR DESCRIPTION
This fixes several things in generic GICv3 code and RK3399 specific code. It then enables save/restore for the GICv3 on RK3399.