### PR TITLE
SPM: Map devices in the 1st GB

### DIFF
--- a/plat/arm/board/fvp/fvp_common.c
+++ b/plat/arm/board/fvp/fvp_common.c
@@ -7,6 +7,7 @@
 #include <arm_config.h>
 #include <arm_def.h>
 #include <arm_spm_def.h>
+#include <arm_xlat_tables.h>
 #include <assert.h>
 #include <cci.h>
 #include <ccn.h>
@@ -128,6 +129,9 @@ const mmap_region_t plat_arm_mmap[] = {
 #if ENABLE_SPM && defined(IMAGE_BL31)
 const mmap_region_t plat_arm_secure_partition_mmap[] = {
 	V2M_MAP_IOFPGA_EL0, /* for the UART */
+	MAP_REGION_FLAT(DEVICE0_BASE,				\
+			DEVICE0_SIZE,				\
+			MT_DEVICE | MT_RO | MT_SECURE | MT_USER),
 	ARM_SP_IMAGE_MMAP,
 	ARM_SP_IMAGE_NS_BUF_MMAP,
 	ARM_SP_IMAGE_RW_MMAP,


### PR DESCRIPTION
This patch maps the devices in the first GB of the system address map
on the FVP into the S-EL1&0 translation regime when SPM support is
enabled. This grants the Secure Partition access to the devices in
this region, for example the memory-mapped Generic Timer device.
