### PR TITLE
fiptool: Fix use after free

### DIFF
--- a/tools/fiptool/fiptool.c
+++ b/tools/fiptool/fiptool.c
@@ -543,7 +543,6 @@ static int pack_images(const char *filename, uint64_t toc_flags, unsigned long a
 		log_dbgx("Metadata size: %zu bytes", buf_size);
 
 	xfwrite(buf, buf_size, fp, filename);
-	free(buf);
 
 	if (verbose)
 		log_dbgx("Payload size: %zu bytes", payload_size);
@@ -566,6 +565,7 @@ static int pack_images(const char *filename, uint64_t toc_flags, unsigned long a
 	while (pad_size--)
 		fputc(0x0, fp);
 
+	free(buf);
 	fclose(fp);
 	return 0;
 }


### PR DESCRIPTION
Commit 880b9e8b4c99ad99eee14079d5a6162733ef4931 (Add padding at the end
of the last entry) added code using toc_entry pointer, whose memory is
already freed via variable buf. This causes enormous padding on openSUSE.

Free the memory buffer only after padding is done.

This fixes #1204.