### PR TITLE
Analyze coding style of patches individually

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -48,6 +48,10 @@
 #      drivers/arm/gic/arm_gic.c:160:
 --showfile
 
+# Don't show some messages like the list of ignored types or the suggestion to
+# use "--fix" or report changes to the maintainers.
+--quiet
+
 #
 # Ignore the following message types, as they don't necessarily make sense in
 # the context of the Trusted Firmware.
@@ -77,6 +81,9 @@
 # "do not add new typedefs"
 # We allow adding new typedefs in TF.
 --ignore NEW_TYPEDEFS
+
+# Avoid "Does not appear to be a unified-diff format patch" message
+--ignore NOT_UNIFIED_DIFF
 
 # VOLATILE reports this kind of messages:
 # "Use of volatile is usually wrong: see Documentation/volatile-considered-harmful.txt"

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -674,7 +674,14 @@ checkcodebase:		locate-checkpatch
 
 checkpatch:		locate-checkpatch
 	@echo "  CHECKING STYLE"
-	${Q}git format-patch --stdout ${BASE_COMMIT}..HEAD -- ${CHECK_PATHS} | ${CHECKPATCH} - || true
+	${Q}COMMON_COMMIT=$$(git merge-base HEAD ${BASE_COMMIT});	\
+	for commit in `git rev-list $$COMMON_COMMIT..HEAD`; do		\
+		printf "\n[*] Checking style of '$$commit'\n\n";	\
+		git log --format=email "$$commit~..$$commit"		\
+			-- ${CHECK_PATHS} | ${CHECKPATCH} - || true;	\
+		git diff --format=email "$$commit~..$$commit"		\
+			-- ${CHECK_PATHS} | ${CHECKPATCH} - || true;	\
+	done
 
 certtool: ${CRTTOOL}
 


### PR DESCRIPTION
With the old system `checkpatch.pl` gets one sole input that consists of the commit message and commit diff of each commit between BASE_COMMIT and HEAD. It also filters out changes in some files, which makes `git format-patch` completely ignore that commit, even the commit message.

With the new system the commit message and commit diff are analyzed separately. This means that, even if all the files modified by a commit are filtered out, the commit message will still be analyzed.

Also, all commits are analyzed individually. This way it's easier to know which commit caused the problem, and there are no warnings about repeated "Signed-off-by" lines.