### PR TITLE
rockchip/rk3399: Fix memory corruptions or illegal memory access

### DIFF
--- a/plat/rockchip/rk3399/drivers/pmu/pmu.c
+++ b/plat/rockchip/rk3399/drivers/pmu/pmu.c
@@ -32,7 +32,7 @@ DEFINE_BAKERY_LOCK(rockchip_pd_lock);
 
 static uint32_t cpu_warm_boot_addr;
 static char store_sram[SRAM_BIN_LIMIT + SRAM_TEXT_LIMIT + SRAM_DATA_LIMIT];
-static uint32_t store_cru[CRU_SDIO0_CON1 / 4];
+static uint32_t store_cru[CRU_SDIO0_CON1 / 4 + 1];
 static uint32_t store_usbphy0[7];
 static uint32_t store_usbphy1[7];
 static uint32_t store_grf_io_vsel;


### PR DESCRIPTION
Coverity scan done for the coreboot project found the issue:
Coverity (*** CID 1385418: Memory - illegal accesses (OVERRUN))
Coverity (*** CID 1385419: Memory - corruptions  (OVERRUN))

Fix the Converity error issue with store_cru[] loop needs to be one
element bigger.

Fixes: ARM-software/tf-issues#544

Change-Id: I420f0a660b24baaa5fc5e78fca242cf750c9bbc7
Signed-off-by: Caesar Wang <wxt@rock-chips.com>