### PR TITLE
Correct the Makefile logic for disabling PIE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ TF_CFLAGS		+=	$(CPPFLAGS) $(TF_CFLAGS_$(ARCH))		\
 GCC_V_OUTPUT		:=	$(shell $(CC) -v 2>&1)
 PIE_FOUND		:=	$(findstring --enable-default-pie,${GCC_V_OUTPUT})
 
-ifeq ($(PIE_FOUND),1)
+ifneq ($(PIE_FOUND),)
 TF_CFLAGS		+=	-fno-PIE
 endif
 


### PR DESCRIPTION
In the Makefile we use findstring to locate gcc toolchains
that have PIE enabled by default.

Unfortunately the result of findstring is compared against
an integer, 1, rather than a non-empty string; the logic to
disable PIE then doesn't get applied.

This patch fixes the flag test.