### PR TITLE
aarch32: boot from BL2 in SVC mode

### DIFF
--- a/bl2/aarch32/bl2_el3_entrypoint.S
+++ b/bl2/aarch32/bl2_el3_entrypoint.S
@@ -71,14 +71,16 @@ func bl2_run_next_image
 	bl	bl2_el3_plat_prepare_exit
 
 	/*
-	 * Extract PC and SPSR based on struct `entry_point_info_t`
-	 * and load it in LR and SPSR registers respectively.
+	 * Extract PC, LR and SPSR based on struct `entry_point_info_t`
+	 * and load it in LR and SPSR registers respectively then
+	 * branch to target entry point.
 	 */
-	ldr	lr, [r8, #ENTRY_POINT_INFO_PC_OFFSET]
+	ldr	lr, [r8, #ENTRY_POINT_INFO_LR_SVC_OFFSET]
+	ldr	r9, [r8, #ENTRY_POINT_INFO_PC_OFFSET]
 	ldr	r1, [r8, #(ENTRY_POINT_INFO_PC_OFFSET + 4)]
-	msr	spsr, r1
+	msr	cpsr_fsxc, r1
 
 	add	r8, r8, #ENTRY_POINT_INFO_ARGS_OFFSET
 	ldm	r8, {r0, r1, r2, r3}
-	eret
+	bx	r9
 endfunc bl2_run_next_image

--- a/include/common/aarch32/el3_common_macros.S
+++ b/include/common/aarch32/el3_common_macros.S
@@ -184,9 +184,18 @@
 		isb
 	.endif /* _init_sctlr */
 
-	/* Switch to monitor mode */
+#ifdef IMAGE_BL1
+	/* BL1 executes in monitor and will install SMC service for BL2 to execute BL3x */
 	cps	#MODE32_mon
 	isb
+#endif
+#if defined(IMAGE_BL2) && ENABLE_ASSERTIONS
+	mrs	r0, cpsr
+	lsr	r0, r0, #MODE32_SHIFT
+	and	r0, r0, #MODE32_MASK
+	cmp	r0, #MODE32_svc
+	ASM_ASSERT(eq)
+#endif
 
 	.if \_warm_boot_mailbox
 		/* -------------------------------------------------------------


### PR DESCRIPTION
Hi, 
Related to recent BL2_AT_EL3 feature and constraint on aarhc32 and armv7 platforms, here is a proposal to move such BL2 execution in SVC mode rather than Monitor mode.
* Entry in BL2 do not need to move execution to Monitor mode. This assumes the early platform bootrom stage boots the arm trusted firmware in Supervisor mode.
*  BL2 (in BL2_AT_EL3 config) exits to BL32 is done through a simple branch instruction. The bootrom arguments are passed through cpu registers r0-r3 and the BL33 entry into register lr_svc.