### PR TITLE
Remove URLs from comments

### DIFF
--- a/drivers/arm/tzc/tzc400.c
+++ b/drivers/arm/tzc/tzc400.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -205,13 +205,16 @@ void tzc400_enable_filters(void)
 	for (filter = 0; filter < tzc400.num_filters; filter++) {
 		state = _tzc400_get_gate_keeper(tzc400.base, filter);
 		if (state) {
-			/* The TZC filter is already configured. Changing the
+			/*
+			 * The TZC filter is already configured. Changing the
 			 * programmer's view in an active system can cause
 			 * unpredictable behavior therefore panic for now rather
 			 * than try to determine whether this is safe in this
-			 * instance. See:
-			 * http://infocenter.arm.com/help/index.jsp?\
-			 * topic=/com.arm.doc.ddi0504c/CJHHECBF.html */
+			 * instance.
+			 *
+			 * See the 'ARM (R) CoreLink TM TZC-400 TrustZone (R)
+			 * Address Space Controller' Technical Reference Manual.
+			 */
 			ERROR("TZC-400 : Filter %d Gatekeeper already"
 				" enabled.\n", filter);
 			panic();

--- a/drivers/io/io_fip.c
+++ b/drivers/io/io_fip.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -28,10 +28,6 @@
 		x.node[4], x.node[5]
 
 typedef struct {
-	/* Put file_pos above the struct to allow {0} on static init.
-	 * It is a workaround for a known bug in GCC
-	 * http://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119
-	 */
 	unsigned int file_pos;
 	fip_toc_entry_t entry;
 } file_state_t;

--- a/services/std_svc/sdei/sdei_state.c
+++ b/services/std_svc/sdei/sdei_state.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -46,9 +46,7 @@ CASSERT(NOP_ > REG_, sdei_state_overlap_nop);
 
 /*
  * SDEI handler state machine: refer to sections 6.1 and 6.1.2 of the SDEI v1.0
- * specification:
- *
- * http://infocenter.arm.com/help/topic/com.arm.doc.den0054a/ARM_DEN0054A_Software_Delegated_Exception_Interface.pdf
+ * specification (ARM DEN0054A).
  *
  * Not all calls contribute to handler state transition. This table is also used
  * to validate whether a call is permissible at a given handler state:


### PR DESCRIPTION
This fixes all defects according to MISRA Rule 3.1: "The character sequences /* and // shall not be used within a comment". This affects all URLs in comments, so they have been removed:

- The link in `sdei_state.c` can also be found in the documentation file `docs/sdei.rst`.

- The bug that the file `io_fip.c` talks about doesn't affect the currently supported version of GCC, so it doesn't make sense to keep the comment. Note that the version of GCC officially supported is the one that comes with Linaro Release 17.10, which is GCC 6.2.

- The link in `tzc400.c` was broken, and it didn't correctly direct to the Technical Reference Manual it should. The link has been replaced by the title of the document, which is more convenient when looking for the document.