### PR TITLE
ARM platforms: Fix console address for flush

### DIFF
--- a/plat/arm/common/aarch32/arm_helpers.S
+++ b/plat/arm/common/aarch32/arm_helpers.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -68,10 +68,10 @@ endfunc plat_crash_console_putc
 	 * Function to force a write of all buffered
 	 * data that hasn't been output.
 	 * Out : return -1 on error else return 0.
-	 * Clobber list : r0 - r1
+	 * Clobber list : r0
 	 * ---------------------------------------------
 	 */
 func plat_crash_console_flush
-	ldr	r1, =PLAT_ARM_CRASH_UART_BASE
+	ldr	r0, =PLAT_ARM_CRASH_UART_BASE
 	b	console_core_flush
 endfunc plat_crash_console_flush

--- a/plat/arm/common/aarch64/arm_helpers.S
+++ b/plat/arm/common/aarch64/arm_helpers.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -70,11 +70,11 @@ endfunc plat_crash_console_putc
 	 * Function to force a write of all buffered
 	 * data that hasn't been output.
 	 * Out : return -1 on error else return 0.
-	 * Clobber list : r0 - r1
+	 * Clobber list : r0
 	 * ---------------------------------------------
 	 */
 func plat_crash_console_flush
-	mov_imm	x1, PLAT_ARM_CRASH_UART_BASE
+	mov_imm	x0, PLAT_ARM_CRASH_UART_BASE
 	b	console_core_flush
 endfunc plat_crash_console_flush
 


### PR DESCRIPTION
The console core flush API expects the base address in the first
register, but ARM helpers currently sets the second register with the
base address. This causes an assert failure.

This patch fixes that.

Change-Id: Ic54c423cd60f2756902ab3cfc77b3de2ac45481e
Signed-off-by: Jeenu Viswambharan <jeenu.viswambharan@arm.com>