### PR TITLE
Tegra: Fix assert on mapping memory regions

### DIFF
--- a/plat/nvidia/tegra/include/tegra_private.h
+++ b/plat/nvidia/tegra/include/tegra_private.h
@@ -10,7 +10,7 @@
 #include <arch.h>
 #include <platform_def.h>
 #include <psci.h>
-#include <xlat_tables.h>
+#include <xlat_tables_v2.h>
 
 /*******************************************************************************
  * Tegra DRAM memory base address

--- a/plat/nvidia/tegra/soc/t210/plat_setup.c
+++ b/plat/nvidia/tegra/soc/t210/plat_setup.c
@@ -9,7 +9,7 @@
 #include <console.h>
 #include <tegra_def.h>
 #include <tegra_private.h>
-#include <xlat_tables.h>
+#include <xlat_tables_v2.h>
 
 /*******************************************************************************
  * The Tegra power domain tree has a single system level power domain i.e. a


### PR DESCRIPTION
The tegra memory controller driver uses the "xlat_tables_v2.h" include.

See:
plat/nvidia/tegra/common/drivers/memctrl/memctrl_v1.c
plat/nvidia/tegra/common/drivers/memctrl/memctrl_v2.c

But other tegra specific parts use "xlat_tables.h".

Use the same include in common tegra code.

This fixes:
ERROR:   mmap_add_region_check() failed. error -22
ASSERT: lib/xlat_tables_v2/xlat_tables_internal.c:752:0

Signed-off-by: Andre Heider <a.heider@gmail.com>