### PR TITLE
Redefine SMC_UNK as -1 instead of 0xFFFFFFFF

### DIFF
--- a/bl31/aarch64/runtime_exceptions.S
+++ b/bl31/aarch64/runtime_exceptions.S
@@ -390,12 +390,12 @@ smc_unknown:
 	 * content). Either way, we aren't leaking any secure information
 	 * through them.
 	 */
-	mov	w0, #SMC_UNK
+	mov	x0, #SMC_UNK
 	b	restore_gp_registers_callee_eret
 
 smc_prohibited:
 	ldr	x30, [sp, #CTX_GPREGS_OFFSET + CTX_GPREG_LR]
-	mov	w0, #SMC_UNK
+	mov	x0, #SMC_UNK
 	eret
 
 rt_svc_fw_critical_error:

--- a/include/lib/smcc.h
+++ b/include/lib/smcc.h
@@ -35,13 +35,13 @@
 #define SMC_64				U(1)
 #define SMC_32				U(0)
 #define SMC_OK				U(0)
-#define SMC_UNK				U(0xffffffff)
+#define SMC_UNK				-1
 #define SMC_TYPE_FAST			ULL(1)
 #if !ERROR_DEPRECATED
 #define SMC_TYPE_STD			ULL(0)
 #endif
 #define SMC_TYPE_YIELD			U(0)
-#define SMC_PREEMPTED		U(0xfffffffe)
+#define SMC_PREEMPTED			-2
 /*******************************************************************************
  * Owning entity number definitions inside the function id as per the SMC
  * calling convention
@@ -99,7 +99,7 @@
  */
 #define DEFINE_SVC_UUID(_name, _tl, _tm, _th, _cl, _ch, \
 		_n0, _n1, _n2, _n3, _n4, _n5) \
-	CASSERT(_tl != SMC_UNK, invalid_svc_uuid);\
+	CASSERT((uint32_t)(_tl) != (uint32_t) SMC_UNK, invalid_svc_uuid);\
 	static const uuid_t _name = { \
 		_tl, _tm, _th, _cl, _ch, \
 		{ _n0, _n1, _n2, _n3, _n4, _n5 } \


### PR DESCRIPTION
According to the SMC Calling Convention (ARM DEN0028B):

> The Unknown SMC Function Identifier is a sign-extended value of (-1) that is returned in R0, W0 or X0 register.

The value wasn't sign-extended because it was defined as a 32-bit unsigned value (`0xFFFFFFFF`).

`SMC_PREEMPT` has been redefined as -2 for the same reason.

NOTE: This might be a compatibility break for some AArch64 platforms that don't follow the previous version of the SMCCC (ARM DEN0028A) correctly. That document specifies that only the bottom 32 bits of the returned value must be checked. If a platform relies on the top 32 bits of the result being 0 (so that `SMC_UNK` is `0x00000000FFFFFFFF`), it will have to fix its code to comply with the SMCCC.