### PR TITLE
Ensure the correct execution of TLBI instructions

### DIFF
--- a/bl1/aarch64/bl1_exceptions.S
+++ b/bl1/aarch64/bl1_exceptions.S
@@ -187,6 +187,7 @@ func smc_handler64
 
 	bl	disable_mmu_icache_el3
 	tlbi	alle3
+	dsb	ish /* ERET implies ISB, so it is not needed here */
 
 #if SPIN_ON_BL1_EXIT
 	bl	print_debug_loop_message

--- a/plat/rockchip/rk3328/drivers/pmu/pmu.c
+++ b/plat/rockchip/rk3328/drivers/pmu/pmu.c
@@ -591,8 +591,10 @@ err_loop:
 __sramfunc void sram_suspend(void)
 {
 	/* disable mmu and icache */
-	tlbialle3();
 	disable_mmu_icache_el3();
+	tlbialle3();
+	dsbsy();
+	isb();
 
 	mmio_write_32(SGRF_BASE + SGRF_SOC_CON(1),
 		      ((uintptr_t)&pmu_cpuson_entrypoint >> CPU_BOOT_ADDR_ALIGN) |

--- a/services/std_svc/spm/secure_partition_setup.c
+++ b/services/std_svc/spm/secure_partition_setup.c
@@ -54,6 +54,7 @@ void secure_partition_setup(void)
 
 	/* Invalidate TLBs at EL1. */
 	tlbivmalle1();
+	dsbish();
 
 	/*
 	 * General-Purpose registers


### PR DESCRIPTION
After executing a TLBI a DSB is needed to ensure completion of the TLBI.

rk3328: The MMU is allowed to load TLB entries for as long as it is enabled. Because of this, the correct place to execute a TLBI is right after disabling the MMU.

@TonyXie06, @Caesar-github, could you explain why this TLBI is needed in the first place?