### PR TITLE
Resolve TZC400 build issue when DEBUG=1 and ENABLE_ASSERTIONS=0

### DIFF
--- a/drivers/arm/tzc/tzc_common_private.h
+++ b/drivers/arm/tzc/tzc_common_private.h
@@ -169,8 +169,6 @@
 						nsaid_permissions);	\
 	}
 
-#if ENABLE_ASSERTIONS
-
 static inline unsigned int _tzc_read_peripheral_id(uintptr_t base)
 {
 	unsigned int id;
@@ -182,6 +180,7 @@ static inline unsigned int _tzc_read_peripheral_id(uintptr_t base)
 	return id;
 }
 
+#if ENABLE_ASSERTIONS
 #ifdef AARCH32
 static inline unsigned long long _tzc_get_max_top_addr(int addr_width)
 {


### PR DESCRIPTION
Previously the definition of `_tzc_read_peripheral_id()` was wrapped
in ENABLE_ASSERTIONS build flag. This causes build issue for TZC400 driver
when DEBUG=1 and ENABLE_ASSERTIONS=0. This patch fixes the same by
moving the definitions outside the ENABLE_ASSERTIONS build flag.

Change-Id: Ic1cad69f02ce65ac34aefd39eaa96d5781043152
Signed-off-by: Soby Mathew <soby.mathew@arm.com>