### PR TITLE
Fixup AArch32 errata printing framework

### DIFF
--- a/lib/cpus/aarch32/cpu_helpers.S
+++ b/lib/cpus/aarch32/cpu_helpers.S
@@ -206,7 +206,8 @@ endfunc cpu_rev_var_hs
  */
 	.globl print_errata_status
 func print_errata_status
-	push	{r4, lr}
+	/* r12 is pushed only for the sake of 8-byte stack alignment */
+	push	{r4, r5, r12, lr}
 #ifdef IMAGE_BL1
 	/*
 	 * BL1 doesn't have per-CPU data. So retrieve the CPU operations
@@ -241,6 +242,6 @@ func print_errata_status
 	blxne	r4
 1:
 #endif
-	pop	{r4, pc}
+	pop	{r4, r5, r12, pc}
 endfunc print_errata_status
 #endif


### PR DESCRIPTION
The AArch32 assembly implementation of `print_errata_status` did not save
a register which was getting clobbered by a `get_cpu_ops_ptr`. This
patch fixes that.

Change-Id: Id0711e46b7c685a18a10328d4b513e952a5d860b
Signed-off-by: Soby Mathew <soby.mathew@arm.com>