### PR TITLE
plat/hikey: split boot memory layout to dedicated file

### DIFF
--- a/plat/hisilicon/hikey/aarch64/hikey_common.c
+++ b/plat/hisilicon/hikey/aarch64/hikey_common.c
@@ -9,12 +9,11 @@
 #include <assert.h>
 #include <bl_common.h>
 #include <debug.h>
+#include <hikey_def.h>
+#include <hikey_layout.h>
 #include <mmio.h>
 #include <platform.h>
-#include <platform_def.h>
 #include <xlat_tables.h>
-
-#include "../hikey_def.h"
 
 #define MAP_DDR		MAP_REGION_FLAT(DDR_BASE,			\
 					DDR_SIZE - DDR_SEC_SIZE,	\

--- a/plat/hisilicon/hikey/aarch64/hikey_helpers.S
+++ b/plat/hisilicon/hikey/aarch64/hikey_helpers.S
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <arch.h>
 #include <asm_macros.S>
-#include "../hikey_def.h"
+#include <hikey_def.h>
 
 	.globl	plat_my_core_pos
 	.globl	platform_mem_init

--- a/plat/hisilicon/hikey/hikey_bl1_setup.c
+++ b/plat/hisilicon/hikey/hikey_bl1_setup.c
@@ -13,14 +13,14 @@
 #include <emmc.h>
 #include <errno.h>
 #include <hi6220.h>
+#include <hikey_def.h>
+#include <hikey_layout.h>
 #include <mmio.h>
 #include <platform.h>
-#include <platform_def.h>
 #include <string.h>
 #include <tbbr/tbbr_img_desc.h>
 
 #include "../../bl1/bl1_private.h"
-#include "hikey_def.h"
 #include "hikey_private.h"
 
 /*

--- a/plat/hisilicon/hikey/hikey_bl2_mem_params_desc.c
+++ b/plat/hisilicon/hikey/hikey_bl2_mem_params_desc.c
@@ -7,7 +7,7 @@
 #include <bl_common.h>
 #include <desc_image_load.h>
 #include <platform.h>
-#include <platform_def.h>
+#include <platform_def.h>	/* also includes hikey_def.h and hikey_layout.h*/
 
 
 /*******************************************************************************

--- a/plat/hisilicon/hikey/hikey_bl2_setup.c
+++ b/plat/hisilicon/hikey/hikey_bl2_setup.c
@@ -21,10 +21,9 @@
 #include <optee_utils.h>
 #endif
 #include <platform.h>
-#include <platform_def.h>
+#include <platform_def.h>	/* also includes hikey_def.h and hikey_layout.h*/
 #include <string.h>
 
-#include "hikey_def.h"
 #include "hikey_private.h"
 
 /*

--- a/plat/hisilicon/hikey/hikey_bl31_setup.c
+++ b/plat/hisilicon/hikey/hikey_bl31_setup.c
@@ -14,12 +14,12 @@
 #include <errno.h>
 #include <gicv2.h>
 #include <hi6220.h>
+#include <hikey_def.h>
 #include <hisi_ipc.h>
 #include <hisi_pwrc.h>
 #include <mmio.h>
 #include <platform_def.h>
 
-#include "hikey_def.h"
 #include "hikey_private.h"
 
 /*

--- a/plat/hisilicon/hikey/hikey_pm.c
+++ b/plat/hisilicon/hikey/hikey_pm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,14 +10,13 @@
 #include <debug.h>
 #include <gicv2.h>
 #include <hi6220.h>
+#include <hikey_def.h>
 #include <hisi_ipc.h>
 #include <hisi_pwrc.h>
 #include <hisi_sram_map.h>
 #include <mmio.h>
 #include <psci.h>
 #include <sp804_delay_timer.h>
-
-#include "hikey_def.h"
 
 #define CORE_PWR_STATE(state) \
 	((state)->pwr_domain_state[MPIDR_AFFLVL0])

--- a/plat/hisilicon/hikey/include/hikey_def.h
+++ b/plat/hisilicon/hikey/include/hikey_def.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,18 +7,12 @@
 #ifndef __HIKEY_DEF_H__
 #define __HIKEY_DEF_H__
 
-#include <common_def.h>
-#include <tbbr_img_def.h>
-
 /* Always assume DDR is 1GB size. */
 #define DDR_BASE			0x0
 #define DDR_SIZE			0x40000000
 
 #define DEVICE_BASE			0xF4000000
 #define DEVICE_SIZE			0x05800000
-
-#define XG2RAM0_BASE			0xF9800000
-#define XG2RAM0_SIZE			0x00400000
 
 /* Memory location options for TSP */
 #define HIKEY_SRAM_ID		0
@@ -41,13 +35,6 @@
 
 #define SRAM_BASE			0xFFF80000
 #define SRAM_SIZE			0x00012000
-
-/*
- * BL1 is stored in XG2RAM0_HIRQ that is 784KB large (0xF980_0000~0xF98C_4000).
- */
-#define ONCHIPROM_PARAM_BASE		(XG2RAM0_BASE + 0x700)
-#define LOADER_RAM_BASE			(XG2RAM0_BASE + 0x800)
-#define BL1_XG2RAM0_OFFSET		0x1000
 
 /*
  * PL011 related constants

--- a/plat/hisilicon/hikey/include/hikey_layout.h
+++ b/plat/hisilicon/hikey/include/hikey_layout.h
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef __HIKEY_LAYOUT_H
+#define __HIKEY_LAYOUT_H
+
+/*
+ * Platform memory map related constants
+ */
+#define XG2RAM0_BASE		0xF9800000
+#define XG2RAM0_SIZE		0x00400000
+
+/*
+ * BL1 is stored in XG2RAM0_HIRQ that is 784KB large (0xF980_0000~0xF98C_4000).
+ */
+#define ONCHIPROM_PARAM_BASE		(XG2RAM0_BASE + 0x700)
+#define LOADER_RAM_BASE			(XG2RAM0_BASE + 0x800)
+#define BL1_XG2RAM0_OFFSET		0x1000
+
+/*
+ * BL1 specific defines.
+ *
+ * Both loader and BL1_RO region stay in SRAM since they are used to simulate
+ * ROM.
+ * Loader is used to switch Hi6220 SoC from 32-bit to 64-bit mode.
+ *
+ * ++++++++++  0xF980_0000
+ * + loader +
+ * ++++++++++  0xF980_1000
+ * + BL1_RO +
+ * ++++++++++  0xF981_0000
+ * + BL1_RW +
+ * ++++++++++  0xF989_8000
+ */
+#define BL1_RO_BASE			(XG2RAM0_BASE + BL1_XG2RAM0_OFFSET)
+#define BL1_RO_LIMIT			(XG2RAM0_BASE + 0x10000)
+#define BL1_RW_BASE			(BL1_RO_LIMIT)	/* 0xf981_0000 */
+#define BL1_RW_SIZE			(0x00088000)
+#define BL1_RW_LIMIT			(0xF9898000)
+
+/*
+ * Non-Secure BL1U specific defines.
+ */
+#define NS_BL1U_BASE			(0xf9818000)
+#define NS_BL1U_SIZE			(0x00010000)
+#define NS_BL1U_LIMIT			(NS_BL1U_BASE + NS_BL1U_SIZE)
+
+/*
+ * BL2 specific defines.
+ *
+ * Both loader and BL2 region stay in SRAM.
+ * Loader is used to switch Hi6220 SoC from 32-bit to 64-bit mode.
+ *
+ * ++++++++++ 0xF980_0000
+ * + loader +
+ * ++++++++++ 0xF980_1000
+ * +  BL2   +
+ * ++++++++++ 0xF981_8000
+ */
+#define BL2_BASE			(BL1_RO_BASE)		/* 0xf980_1000 */
+#define BL2_LIMIT			(0xF9818000)		/* 0xf981_8000 */
+
+/*
+ * SCP_BL2 specific defines.
+ * In HiKey, SCP_BL2 means MCU firmware. It's loaded into the temporary buffer
+ * at 0x0100_0000. Then BL2 will parse the sections and loaded them into
+ * predefined separated buffers.
+ */
+#define SCP_BL2_BASE			(DDR_BASE + 0x01000000)
+#define SCP_BL2_LIMIT			(SCP_BL2_BASE + 0x00100000)
+#define SCP_BL2_SIZE			(SCP_BL2_LIMIT - SCP_BL2_BASE)
+
+/*
+ * BL31 specific defines.
+ */
+#define BL31_BASE			(0xF9858000)		/* 0xf985_8000 */
+#define BL31_LIMIT			(0xF9898000)
+
+/*
+ * BL3-2 specific defines.
+ */
+
+/*
+ * The TSP currently executes from TZC secured area of DRAM or SRAM.
+ */
+#define BL32_SRAM_BASE			BL31_LIMIT
+#define BL32_SRAM_LIMIT			(BL31_LIMIT+0x80000) /* 512K */
+
+#define BL32_DRAM_BASE			DDR_SEC_BASE
+#define BL32_DRAM_LIMIT			(DDR_SEC_BASE+DDR_SEC_SIZE)
+
+#ifdef SPD_opteed
+/* Load pageable part of OP-TEE at end of allocated DRAM space for BL32 */
+#define HIKEY_OPTEE_PAGEABLE_LOAD_BASE	(BL32_DRAM_LIMIT - HIKEY_OPTEE_PAGEABLE_LOAD_SIZE) /* 0x3FC0_0000 */
+#define HIKEY_OPTEE_PAGEABLE_LOAD_SIZE	0x400000 /* 4MB */
+#endif
+
+#if (HIKEY_TSP_RAM_LOCATION_ID == HIKEY_DRAM_ID)
+#define TSP_SEC_MEM_BASE		BL32_DRAM_BASE
+#define TSP_SEC_MEM_SIZE		(BL32_DRAM_LIMIT - BL32_DRAM_BASE)
+#define BL32_BASE			BL32_DRAM_BASE
+#define BL32_LIMIT			BL32_DRAM_LIMIT
+#elif (HIKEY_TSP_RAM_LOCATION_ID == HIKEY_SRAM_ID)
+#define TSP_SEC_MEM_BASE		BL32_SRAM_BASE
+#define TSP_SEC_MEM_SIZE		(BL32_SRAM_LIMIT - BL32_SRAM_BASE)
+#define BL32_BASE			BL32_SRAM_BASE
+#define BL32_LIMIT			BL32_SRAM_LIMIT
+#else
+#error "Currently unsupported HIKEY_TSP_LOCATION_ID value"
+#endif
+
+/* BL32 is mandatory in AArch32 */
+#ifndef AARCH32
+#ifdef SPD_none
+#undef BL32_BASE
+#endif /* SPD_none */
+#endif
+
+#endif /* !__HIKEY_LAYOUT_H */

--- a/plat/hisilicon/hikey/include/platform_def.h
+++ b/plat/hisilicon/hikey/include/platform_def.h
@@ -8,7 +8,10 @@
 #define __PLATFORM_DEF_H__
 
 #include <arch.h>
-#include "../hikey_def.h"
+#include <common_def.h>
+#include <hikey_def.h>
+#include <hikey_layout.h>		/* BL memory region sizes, etc */
+#include <tbbr_img_def.h>
 
 /* Special value used to verify platform parameters from BL2 to BL3-1 */
 #define HIKEY_BL31_PLAT_PARAM_VAL	0x0f1e2d3c4b5a6978ULL
@@ -27,7 +30,7 @@
 #define PLATFORM_CORE_COUNT_PER_CLUSTER	4
 #define PLATFORM_CORE_COUNT		(PLATFORM_CLUSTER_COUNT *	\
 					 PLATFORM_CORE_COUNT_PER_CLUSTER)
-#define PLAT_MAX_PWR_LVL		MPIDR_AFFLVL2
+#define PLAT_MAX_PWR_LVL		(MPIDR_AFFLVL2)
 #define PLAT_NUM_PWR_DOMAINS		(PLATFORM_CORE_COUNT + \
 					 PLATFORM_CLUSTER_COUNT + 1)
 
@@ -44,114 +47,6 @@
 #define PLAT_ARM_GICC_BASE		0xF6802000
 #define PLAT_ARM_GICH_BASE		0xF6804000
 #define PLAT_ARM_GICV_BASE		0xF6806000
-
-
-/*
- * Platform memory map related constants
- */
-
-/*
- * BL1 is stored in XG2RAM0_HIRQ that is 784KB large (0xF980_0000~0xF98C_4000).
- */
-#define ONCHIPROM_PARAM_BASE		(XG2RAM0_BASE + 0x700)
-#define LOADER_RAM_BASE			(XG2RAM0_BASE + 0x800)
-#define BL1_XG2RAM0_OFFSET		0x1000
-
-/*
- * BL1 specific defines.
- *
- * Both loader and BL1_RO region stay in SRAM since they are used to simulate
- * ROM.
- * Loader is used to switch Hi6220 SoC from 32-bit to 64-bit mode.
- *
- * ++++++++++  0xF980_0000
- * + loader +
- * ++++++++++  0xF980_1000
- * + BL1_RO +
- * ++++++++++  0xF981_0000
- * + BL1_RW +
- * ++++++++++  0xF989_8000
- */
-#define BL1_RO_BASE			(XG2RAM0_BASE + BL1_XG2RAM0_OFFSET)
-#define BL1_RO_LIMIT			(XG2RAM0_BASE + 0x10000)
-#define BL1_RW_BASE			(BL1_RO_LIMIT)	/* 0xf981_0000 */
-#define BL1_RW_SIZE			(0x00088000)
-#define BL1_RW_LIMIT			(0xF9898000)
-
-/*
- * BL2 specific defines.
- *
- * Both loader and BL2 region stay in SRAM.
- * Loader is used to switch Hi6220 SoC from 32-bit to 64-bit mode.
- *
- * ++++++++++ 0xF980_0000
- * + loader +
- * ++++++++++ 0xF980_1000
- * +  BL2   +
- * ++++++++++ 0xF981_8000
- */
-#define BL2_BASE			(BL1_RO_BASE)		/* 0xf980_1000 */
-#define BL2_LIMIT			(0xF9818000)		/* 0xf981_8000 */
-
-/*
- * SCP_BL2 specific defines.
- * In HiKey, SCP_BL2 means MCU firmware. It's loaded into the temporary buffer
- * at 0x0100_0000. Then BL2 will parse the sections and loaded them into
- * predefined separated buffers.
- */
-#define SCP_BL2_BASE			(DDR_BASE + 0x01000000)
-#define SCP_BL2_LIMIT			(SCP_BL2_BASE + 0x00100000)
-#define SCP_BL2_SIZE			(SCP_BL2_LIMIT - SCP_BL2_BASE)
-
-/*
- * BL31 specific defines.
- */
-#define BL31_BASE			(0xF9858000)		/* 0xf985_8000 */
-#define BL31_LIMIT			(0xF9898000)
-
-/*
- * BL3-2 specific defines.
- */
-
-/*
- * The TSP currently executes from TZC secured area of DRAM or SRAM.
- */
-#define BL32_SRAM_BASE			BL31_LIMIT
-#define BL32_SRAM_LIMIT			(BL31_LIMIT+0x80000) /* 512K */
-
-#define BL32_DRAM_BASE			DDR_SEC_BASE
-#define BL32_DRAM_LIMIT			(DDR_SEC_BASE+DDR_SEC_SIZE)
-
-#ifdef SPD_opteed
-/* Load pageable part of OP-TEE at end of allocated DRAM space for BL32 */
-#define HIKEY_OPTEE_PAGEABLE_LOAD_BASE	(BL32_DRAM_LIMIT - HIKEY_OPTEE_PAGEABLE_LOAD_SIZE) /* 0x3FC0_0000 */
-#define HIKEY_OPTEE_PAGEABLE_LOAD_SIZE	0x400000 /* 4MB */
-#endif
-
-#if (HIKEY_TSP_RAM_LOCATION_ID == HIKEY_DRAM_ID)
-#define TSP_SEC_MEM_BASE		BL32_DRAM_BASE
-#define TSP_SEC_MEM_SIZE		(BL32_DRAM_LIMIT - BL32_DRAM_BASE)
-#define BL32_BASE			BL32_DRAM_BASE
-#define BL32_LIMIT			BL32_DRAM_LIMIT
-#elif (HIKEY_TSP_RAM_LOCATION_ID == HIKEY_SRAM_ID)
-#define TSP_SEC_MEM_BASE		BL32_SRAM_BASE
-#define TSP_SEC_MEM_SIZE		(BL32_SRAM_LIMIT - BL32_SRAM_BASE)
-#define BL32_BASE			BL32_SRAM_BASE
-#define BL32_LIMIT			BL32_SRAM_LIMIT
-#else
-#error "Currently unsupported HIKEY_TSP_LOCATION_ID value"
-#endif
-
-/* BL32 is mandatory in AArch32 */
-#ifndef AARCH32
-#ifdef SPD_none
-#undef BL32_BASE
-#endif /* SPD_none */
-#endif
-
-#define NS_BL1U_BASE			(0xf9818000)
-#define NS_BL1U_SIZE			(0x00010000)
-#define NS_BL1U_LIMIT			(NS_BL1U_BASE + NS_BL1U_SIZE)
 
 /*
  * Platform specific page table and MMU setup constants
@@ -171,8 +66,6 @@
 #endif
 
 #define MAX_MMAP_REGIONS		16
-
-#define HIKEY_NS_IMAGE_OFFSET		(DDR_BASE + 0x35000000)
 
 /*
  * Declarations and constants to access the mailboxes safely. Each mailbox is


### PR DESCRIPTION
Boot Memory Layout is specific for a platform, but should not be mixed up with other platform specific attributes. A separate file is much cleaner and better to compare with other platforms. Take a look at plat/poplar where it is done the same way.

hikey_def.h and hikey_private.h should also be in the include folder.