### PR TITLE
FVP: restrict dynamic config to Unix build environment

### DIFF
--- a/plat/arm/board/fvp/platform.mk
+++ b/plat/arm/board/fvp/platform.mk
@@ -159,7 +159,8 @@ BL31_SOURCES		+=	drivers/arm/smmu/smmu_v3.c			\
 				${FVP_INTERCONNECT_SOURCES}			\
 				${FVP_SECURITY_SOURCES}
 
-# Add the FDT_SOURCES and options for Dynamic Config
+# Add the FDT_SOURCES and options for Dynamic Config (only for Unix env)
+ifdef UNIX_MK
 FVP_HW_CONFIG_DTS	:=	fdts/${FVP_DT_PREFIX}.dts
 FDT_SOURCES		+=	plat/arm/board/fvp/fdts/${PLAT}_tb_fw_config.dts
 FVP_TB_FW_CONFIG	:=	${BUILD_PLAT}/fdts/${PLAT}_tb_fw_config.dtb
@@ -172,6 +173,7 @@ $(eval FVP_HW_CONFIG	:=	${BUILD_PLAT}/$(patsubst %.dts,%.dtb,$(FVP_HW_CONFIG_DTS
 
 # Add the HW_CONFIG to FIP and specify the same to certtool
 $(eval $(call TOOL_ADD_PAYLOAD,${FVP_HW_CONFIG},--hw-config))
+endif
 
 # Disable the PSCI platform compatibility layer
 ENABLE_PLAT_COMPAT	:= 	0


### PR DESCRIPTION
This patch restricts building the dynamic config DTBs to the Unix
build environment as the Device Tree compiler may not be available
on other build environments.

Change-Id: Ie690e80010a174300e966240fd977b37561156e0
Signed-off-by: Soby Mathew <soby.mathew@arm.com>