### PR TITLE
Select SCMI/SDS drivers by default on Juno

### DIFF
--- a/plat/arm/board/juno/platform.mk
+++ b/plat/arm/board/juno/platform.mk
@@ -102,6 +102,10 @@ ARM_BOARD_OPTIMISE_MEM		:=	1
 # Do not enable SVE
 ENABLE_SVE_FOR_NS		:=	0
 
+# Select SCMI/SDS drivers instead of SCPI/BOM driver for communicating with the
+# SCP during power management operations and for SCP RAM Firmware transfer.
+CSS_USE_SCMI_SDS_DRIVER		:=	1
+
 include plat/arm/board/common/board_css.mk
 include plat/arm/common/arm_common.mk
 include plat/arm/soc/common/soc_css.mk


### PR DESCRIPTION
The SCP binaries provided in the 17.10 Linaro release (and onwards)
have migrated to the SCMI/SDS protocols. Therefore, the ARM TF should
now use the corresponding drivers by default.

This patch changes the default value of the CSS_USE_SCMI_SDS_DRIVER
build option to 1 for Juno.
