### PR TITLE
Revert "Make all build results depend on all makefiles"

### DIFF
--- a/make_helpers/build_macros.mk
+++ b/make_helpers/build_macros.mk
@@ -199,7 +199,7 @@ $(eval OBJ := $(1)/$(patsubst %.c,%.o,$(notdir $(2))))
 $(eval DEP := $(patsubst %.o,%.d,$(OBJ)))
 $(eval IMAGE := IMAGE_BL$(call uppercase,$(3)))
 
-$(OBJ): $(2) $(MAKEFILE_LIST) | bl$(3)_dirs
+$(OBJ): $(2) | bl$(3)_dirs
 	@echo "  CC      $$<"
 	$$(Q)$$(CC) $$(TF_CFLAGS) $$(CFLAGS) -D$(IMAGE) $(MAKE_DEP) -c $$< -o $$@
 
@@ -218,7 +218,7 @@ $(eval OBJ := $(1)/$(patsubst %.S,%.o,$(notdir $(2))))
 $(eval DEP := $(patsubst %.o,%.d,$(OBJ)))
 $(eval IMAGE := IMAGE_BL$(call uppercase,$(3)))
 
-$(OBJ): $(2) $(MAKEFILE_LIST) | bl$(3)_dirs
+$(OBJ): $(2) | bl$(3)_dirs
 	@echo "  AS      $$<"
 	$$(Q)$$(AS) $$(ASFLAGS) -D$(IMAGE) $(MAKE_DEP) -c $$< -o $$@
 
@@ -235,7 +235,7 @@ define MAKE_LD
 
 $(eval DEP := $(1).d)
 
-$(1): $(2) $(MAKEFILE_LIST) | bl$(3)_dirs
+$(1): $(2) | bl$(3)_dirs
 	@echo "  PP      $$<"
 	$$(Q)$$(CPP) $$(CPPFLAGS) -P -D__ASSEMBLY__ -D__LINKER__ $(MAKE_DEP) -o $$@ $$<
 
@@ -374,7 +374,7 @@ define MAKE_DTB
 $(eval DOBJ := $(addprefix $(1)/,$(call SOURCES_TO_DTBS,$(2))))
 $(eval DEP := $(patsubst %.dtb,%.d,$(DOBJ)))
 
-$(DOBJ): $(2) $(MAKEFILE_LIST) | fdt_dirs
+$(DOBJ): $(2) | fdt_dirs
 	@echo "  DTC     $$<"
 	$$(Q)$$(DTC) $$(DTC_FLAGS) -d $(DEP) -o $$@ $$<
 


### PR DESCRIPTION
Seems to have unintended side-effects on the build system such as
rebuilding certain parts of TF even though nothing has changed.

This reverts commit c6f651f9a3322857c8e1f8250274a0984c024283.

Change-Id: I1472e6c630cb6371ec629b7d97a5748d9a6fd096
Signed-off-by: Dimitris Papastamos <dimitris.papastamos@arm.com>