### PR TITLE
Change PLATFORM_ROOT to TF_PLATFORM_ROOT

### DIFF
--- a/make_helpers/plat_helpers.mk
+++ b/make_helpers/plat_helpers.mk
@@ -15,14 +15,14 @@ ifndef PLAT_HELPERS_MK
         $(error "Error: Unknown platform. Please use PLAT=<platform name> to specify the platform")
     endif
 
-    # PLATFORM_ROOT can be overridden for when building tools directly
-    PLATFORM_ROOT               ?= plat/
+    # TF_PLATFORM_ROOT can be overridden for when building tools directly
+    TF_PLATFORM_ROOT               ?= plat/
     PLAT_MAKEFILE               := platform.mk
 
     # Generate the platforms list by recursively searching for all directories
     # under /plat containing a PLAT_MAKEFILE. Append each platform with a `|`
     # char and strip out the final '|'.
-    ALL_PLATFORM_MK_FILES       := $(call rwildcard,${PLATFORM_ROOT},${PLAT_MAKEFILE})
+    ALL_PLATFORM_MK_FILES       := $(call rwildcard,${TF_PLATFORM_ROOT},${PLAT_MAKEFILE})
     ALL_PLATFORM_DIRS           := $(patsubst %/,%,$(dir ${ALL_PLATFORM_MK_FILES}))
     ALL_PLATFORMS               := $(sort $(notdir ${ALL_PLATFORM_DIRS}))
 

--- a/tools/cert_create/Makefile
+++ b/tools/cert_create/Makefile
@@ -35,7 +35,7 @@ PLAT_INCLUDE		:=	../../include/tools_share
 else
 PLAT_MSG		:=	${PLAT}
 
-PLATFORM_ROOT		:=	../../plat/
+TF_PLATFORM_ROOT		:=	../../plat/
 include ${MAKE_HELPERS_DIRECTORY}plat_helpers.mk
 
 PLAT_INCLUDE		:=	$(wildcard ${PLAT_DIR}include)


### PR DESCRIPTION
Since we use "?=" to set PLATFORM_ROOT, it is better to change the
name to be more special, or else it may override by some environment
variables, such as in some CI build environments.

Signed-off-by: Heyi Guo <heyi.guo@linaro.org>