### PR TITLE
Remove sp_min functions from plat_common.c

### DIFF
--- a/bl32/sp_min/sp_min.mk
+++ b/bl32/sp_min/sp_min.mk
@@ -15,6 +15,7 @@ INCLUDES		+=	-Iinclude/bl32/sp_min
 BL32_SOURCES		+=	bl32/sp_min/sp_min_main.c		\
 				bl32/sp_min/aarch32/entrypoint.S	\
 				common/runtime_svc.c			\
+				plat/common/aarch32/plat_sp_min_common.c\
 				services/std_svc/std_svc_setup.c	\
 				${PSCI_LIB_SOURCES}
 

--- a/include/plat/arm/common/plat_arm.h
+++ b/include/plat/arm/common/plat_arm.h
@@ -237,6 +237,10 @@ int arm_execution_state_switch(unsigned int smc_fid,
 		uint32_t cookie_lo,
 		void *handle);
 
+/* Optional functions for SP_MIN */
+void plat_arm_sp_min_early_platform_setup(u_register_t arg0, u_register_t arg1,
+			u_register_t arg2, u_register_t arg3);
+
 /* global variables */
 extern plat_psci_ops_t plat_arm_psci_pm_ops;
 extern const mmap_region_t plat_arm_mmap[];

--- a/plat/arm/board/fvp/sp_min/fvp_sp_min_setup.c
+++ b/plat/arm/board/fvp/sp_min/fvp_sp_min_setup.c
@@ -7,7 +7,7 @@
 #include <plat_arm.h>
 #include "../fvp_private.h"
 
-void sp_min_early_platform_setup2(u_register_t arg0, u_register_t arg1,
+void plat_arm_sp_min_early_platform_setup(u_register_t arg0, u_register_t arg1,
 			u_register_t arg2, u_register_t arg3)
 {
 	arm_sp_min_early_platform_setup((void *)arg0, arg1, arg2, (void *)arg3);

--- a/plat/arm/common/sp_min/arm_sp_min_setup.c
+++ b/plat/arm/common/sp_min/arm_sp_min_setup.c
@@ -18,9 +18,9 @@
 static entry_point_info_t bl33_image_ep_info;
 
 /* Weak definitions may be overridden in specific ARM standard platform */
-#pragma weak sp_min_early_platform_setup2
 #pragma weak sp_min_platform_setup
 #pragma weak sp_min_plat_arch_setup
+#pragma weak plat_arm_sp_min_early_platform_setup
 
 
 /*******************************************************************************
@@ -46,7 +46,7 @@ entry_point_info_t *sp_min_plat_get_bl33_ep_info(void)
 }
 
 /*******************************************************************************
- * Perform early platform setup.
+ * Utility function to perform early platform setup.
  ******************************************************************************/
 void arm_sp_min_early_platform_setup(void *from_bl2, uintptr_t tos_fw_config,
 			uintptr_t hw_config, void *plat_params_from_bl2)
@@ -105,7 +105,10 @@ void arm_sp_min_early_platform_setup(void *from_bl2, uintptr_t tos_fw_config,
 
 }
 
-void sp_min_early_platform_setup2(u_register_t arg0, u_register_t arg1,
+/*******************************************************************************
+ * Default implementation for sp_min_platform_setup2() for ARM platforms
+ ******************************************************************************/
+void plat_arm_sp_min_early_platform_setup(u_register_t arg0, u_register_t arg1,
 			u_register_t arg2, u_register_t arg3)
 {
 	arm_sp_min_early_platform_setup((void *)arg0, arg1, arg2, (void *)arg3);
@@ -125,6 +128,12 @@ void sp_min_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 	 * clusters.
 	 */
 	plat_arm_interconnect_enter_coherency();
+}
+
+void sp_min_early_platform_setup2(u_register_t arg0, u_register_t arg1,
+			u_register_t arg2, u_register_t arg3)
+{
+	plat_arm_sp_min_early_platform_setup(arg0, arg1, arg2, arg3);
 }
 
 /*******************************************************************************

--- a/plat/common/aarch32/plat_common.c
+++ b/plat/common/aarch32/plat_common.c
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <console.h>
 #include <platform.h>
-#include <platform_sp_min.h>
 #include <xlat_mmu_helpers.h>
 
 /*
@@ -15,29 +13,9 @@
  * platforms but may also be overridden by a platform if required.
  */
 #pragma weak bl32_plat_enable_mmu
-#pragma weak sp_min_plat_runtime_setup
+
 
 void bl32_plat_enable_mmu(uint32_t flags)
 {
 	enable_mmu_secure(flags);
 }
-
-void sp_min_plat_runtime_setup(void)
-{
-	/*
-	 * Finish the use of console driver in SP_MIN so that any runtime logs
-	 * from SP_MIN will be suppressed.
-	 */
-	console_uninit();
-}
-
-#if !ERROR_DEPRECATED
-
-#pragma weak sp_min_early_platform_setup2
-
-void sp_min_early_platform_setup2(u_register_t arg0, u_register_t arg1,
-			u_register_t arg2, u_register_t arg3)
-{
-	sp_min_early_platform_setup((void *) arg0, (void *)arg1);
-}
-#endif

--- a/plat/common/aarch32/plat_sp_min_common.c
+++ b/plat/common/aarch32/plat_sp_min_common.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <console.h>
+#include <platform.h>
+#include <platform_sp_min.h>
+
+/*
+ * The following platform setup functions are weakly defined. They
+ * provide typical implementations that may be re-used by multiple
+ * platforms but may also be overridden by a platform if required.
+ */
+#pragma weak sp_min_plat_runtime_setup
+
+void sp_min_plat_runtime_setup(void)
+{
+	/*
+	 * Finish the use of console driver in SP_MIN so that any runtime logs
+	 * from SP_MIN will be suppressed.
+	 */
+	console_uninit();
+}
+
+#if !ERROR_DEPRECATED
+
+#pragma weak sp_min_early_platform_setup2
+
+void sp_min_early_platform_setup2(u_register_t arg0, u_register_t arg1,
+			u_register_t arg2, u_register_t arg3)
+{
+	sp_min_early_platform_setup((void *)arg0, (void *)arg1);
+}
+#endif


### PR DESCRIPTION
This patch removes default platform implementations of sp_min
platform APIs from plat/common/aarch32/plat_common.c. The APIs
are now implemented in `plat_sp_min_common.c` file within the
same folder.

The ARM platform layer had a weak definition of sp_min_platform_setup2()
which conflicted with the weak definition in the common file. Hence this
patch fixes that by introducing a `plat_arm_` version of the API thus
allowing individual boards within ARM platforms to override it if they
wish to.

Fixes ARM-Software/tf-issues#559

Change-Id: I11a74ecae8191878ccc7ea03f12bdd5ae88faba5
Signed-off-by: Soby Mathew <soby.mathew@arm.com>