### PR TITLE
qemu: Accessing UART1 causes a data abort

### DIFF
--- a/plat/qemu/include/platform_def.h
+++ b/plat/qemu/include/platform_def.h
@@ -198,7 +198,7 @@
 #define DEVICE0_BASE			0x08000000
 #define DEVICE0_SIZE			0x00021000
 #define DEVICE1_BASE			0x09000000
-#define DEVICE1_SIZE			0x00011000
+#define DEVICE1_SIZE			0x00041000
 
 /*
  * GIC related constants


### PR DESCRIPTION
The register address range of UART1 (crash console) are outside the
address ranges mapped for MMIO, resulting to an MMU abort when the
device registers are accessed.

Increase the size of DEVICE1 memory to include the range of UART1.

Fixes ARM-software/tf-issues#560

Signed-off-by: Michalis Pappas <mpappas@fastmail.fm>