### PR TITLE
qemu: Support MULTI_CONSOLE_API

### DIFF
--- a/drivers/arm/pl011/aarch64/pl011_console.S
+++ b/drivers/arm/pl011/aarch64/pl011_console.S
@@ -6,6 +6,7 @@
 #include <arch.h>
 #include <asm_macros.S>
 #include <assert_macros.S>
+#include <console_macros.S>
 #include <pl011.h>
 
 /*

--- a/plat/qemu/aarch64/plat_helpers.S
+++ b/plat/qemu/aarch64/plat_helpers.S
@@ -14,11 +14,12 @@
 	.globl	platform_mem_init
 	.globl	plat_qemu_calc_core_pos
 	.globl	plat_crash_console_init
+#if MULTI_CONSOLE_API
 	.globl	plat_crash_console_putc
+#endif /* MULTI_CONSOLE_API */
 	.globl  plat_secondary_cold_boot_setup
 	.globl  plat_get_my_entrypoint
 	.globl  plat_is_my_cpu_primary
-
 
 func plat_my_core_pos
 	mrs	x0, mpidr_el1
@@ -96,10 +97,7 @@ endfunc platform_mem_init
 	 * ---------------------------------------------
 	 */
 func plat_crash_console_init
-	mov_imm	x0, PLAT_QEMU_CRASH_UART_BASE
-	mov_imm	x1, PLAT_QEMU_CRASH_UART_CLK_IN_HZ
-	mov_imm	x2, PLAT_QEMU_CONSOLE_BAUDRATE
-	b	console_core_init
+	b	qemu_crash_console_init
 endfunc plat_crash_console_init
 
 	/* ---------------------------------------------
@@ -109,9 +107,10 @@ endfunc plat_crash_console_init
 	 * Clobber list : x1, x2
 	 * ---------------------------------------------
 	 */
+#if !MULTI_CONSOLE_API
 func plat_crash_console_putc
 	mov_imm	x1, PLAT_QEMU_CRASH_UART_BASE
 	b	console_core_putc
 endfunc plat_crash_console_putc
-
+#endif /* MULTI_CONSOLE_API */
 

--- a/plat/qemu/platform.mk
+++ b/plat/qemu/platform.mk
@@ -47,8 +47,9 @@ $(eval $(call assert_boolean,ARM_XLAT_TABLES_LIB_V1))
 $(eval $(call add_define,ARM_XLAT_TABLES_LIB_V1))
 
 
-PLAT_BL_COMMON_SOURCES	:=	plat/qemu/qemu_common.c			\
-				drivers/arm/pl011/${ARCH}/pl011_console.S
+PLAT_BL_COMMON_SOURCES	:=	plat/qemu/qemu_common.c			  \
+				plat/qemu/qemu_console.c		  \
+				drivers/arm/pl011/${ARCH}/pl011_console.S \
 
 ifeq (${ARM_XLAT_TABLES_LIB_V1}, 1)
 PLAT_BL_COMMON_SOURCES	+=	lib/xlat_tables/xlat_tables_common.c		\
@@ -168,6 +169,7 @@ $(eval $(call TOOL_ADD_IMG,bl32_extra2,--tos-fw-extra2))
 endif
 
 SEPARATE_CODE_AND_RODATA := 1
+MULTI_CONSOLE_API	 := 1
 
 # Disable the PSCI platform compatibility layer
 ENABLE_PLAT_COMPAT	:= 	0

--- a/plat/qemu/qemu_bl1_setup.c
+++ b/plat/qemu/qemu_bl1_setup.c
@@ -8,7 +8,6 @@
 #include <arch_helpers.h>
 #include <assert.h>
 #include <bl_common.h>
-#include <console.h>
 #include <platform_def.h>
 #include "qemu_private.h"
 
@@ -27,8 +26,7 @@ meminfo_t *bl1_plat_sec_mem_layout(void)
 void bl1_early_platform_setup(void)
 {
 	/* Initialize the console to provide early debug support */
-	console_init(PLAT_QEMU_BOOT_UART_BASE, PLAT_QEMU_BOOT_UART_CLK_IN_HZ,
-		     PLAT_QEMU_CONSOLE_BAUDRATE);
+	qemu_console_init();
 
 	/* Allow BL1 to see the whole Trusted RAM */
 	bl1_tzram_layout.total_base = BL_RAM_BASE;

--- a/plat/qemu/qemu_bl2_setup.c
+++ b/plat/qemu/qemu_bl2_setup.c
@@ -6,7 +6,6 @@
 #include <arch_helpers.h>
 #include <assert.h>
 #include <bl_common.h>
-#include <console.h>
 #include <debug.h>
 #include <desc_image_load.h>
 #include <optee_utils.h>
@@ -123,8 +122,7 @@ struct entry_point_info *bl2_plat_get_bl31_ep_info(void)
 void bl2_early_platform_setup(meminfo_t *mem_layout)
 {
 	/* Initialize the console to provide early debug support */
-	console_init(PLAT_QEMU_BOOT_UART_BASE, PLAT_QEMU_BOOT_UART_CLK_IN_HZ,
-			PLAT_QEMU_CONSOLE_BAUDRATE);
+	qemu_console_init();
 
 	/* Setup the BL2 memory layout */
 	bl2_tzram_layout = *mem_layout;

--- a/plat/qemu/qemu_bl31_setup.c
+++ b/plat/qemu/qemu_bl31_setup.c
@@ -6,7 +6,6 @@
 
 #include <assert.h>
 #include <bl_common.h>
-#include <console.h>
 #include <gic_common.h>
 #include <gicv2.h>
 #include <platform_def.h>
@@ -45,8 +44,7 @@ void bl31_early_platform_setup(bl31_params_t *from_bl2,
 #endif
 {
 	/* Initialize the console to provide early debug support */
-	console_init(PLAT_QEMU_BOOT_UART_BASE, PLAT_QEMU_BOOT_UART_CLK_IN_HZ,
-			PLAT_QEMU_CONSOLE_BAUDRATE);
+	qemu_console_init();
 
 #if LOAD_IMAGE_V2
 	/*

--- a/plat/qemu/qemu_console.c
+++ b/plat/qemu/qemu_console.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include <console.h>
+#include <pl011.h>
+#include <platform_def.h>
+
+static console_pl011_t console;
+static console_pl011_t crash_console;
+
+void qemu_console_init(void)
+{
+#if MULTI_CONSOLE_API
+	(void)console_pl011_register(PLAT_QEMU_BOOT_UART_BASE,
+			       PLAT_QEMU_BOOT_UART_CLK_IN_HZ,
+			       PLAT_QEMU_CONSOLE_BAUDRATE, &console);
+#else
+	console_init(PLAT_QEMU_BOOT_UART_BASE,
+		     PLAT_QEMU_BOOT_UART_CLK_IN_HZ,
+		     PLAT_QEMU_CONSOLE_BAUDRATE);
+#endif /* MULTI_CONSOLE_API */
+}
+
+void qemu_crash_console_init(void)
+{
+#if MULTI_CONSOLE_API
+	(void)console_pl011_register(PLAT_QEMU_CRASH_UART_BASE,
+			       PLAT_QEMU_CRASH_UART_CLK_IN_HZ,
+			       PLAT_QEMU_CONSOLE_BAUDRATE, &crash_console);
+#else
+	console_core_init(PLAT_QEMU_CRASH_UART_BASE,
+			  PLAT_QEMU_CRASH_UART_CLK_IN_HZ,
+			  PLAT_QEMU_CONSOLE_BAUDRATE);
+#endif /* MULTI_CONSOLE_API */
+}

--- a/plat/qemu/qemu_private.h
+++ b/plat/qemu/qemu_private.h
@@ -34,4 +34,7 @@ unsigned int plat_qemu_calc_core_pos(u_register_t mpidr);
 int dt_add_psci_node(void *fdt);
 int dt_add_psci_cpu_enable_methods(void *fdt);
 
+void qemu_console_init(void);
+void qemu_crash_console_init(void);
+
 #endif /*__QEMU_PRIVATE_H*/


### PR DESCRIPTION
Hi,

I moved all console initialization to C, as I found it cleaner than the way recommended in the Porting Guide, ie
```
.section .data.crash_console      /* Reserve space for console structure */
crash_console:
.zero 6 * 8                       /* console_16550_t has 6 8-byte words */
```
