### PR TITLE
Dynamic cfg: Do not populate args if already initialized

### DIFF
--- a/common/desc_image_load.c
+++ b/common/desc_image_load.c
@@ -239,14 +239,23 @@ void populate_next_bl_params_config(bl_params_t *bl2_to_next_bl_params)
 		/*
 		 * Pass hw and tb_fw config addresses to next images. NOTE - for
 		 * EL3 runtime images (BL31 for AArch64 and BL32 for AArch32),
-		 * arg0 is already used by generic code.
+		 * arg0 is already used by generic code. Take care of not
+		 * overwriting the previous initialisations.
 		 */
 		if (params_node == bl2_to_next_bl_params->head) {
-			params_node->ep_info->args.arg1 = fw_config_base;
-			params_node->ep_info->args.arg2 = hw_config_base;
+			if (params_node->ep_info->args.arg1 == 0)
+				params_node->ep_info->args.arg1 =
+								fw_config_base;
+			if (params_node->ep_info->args.arg2 == 0)
+				params_node->ep_info->args.arg2 =
+								hw_config_base;
 		} else {
-			params_node->ep_info->args.arg0 = fw_config_base;
-			params_node->ep_info->args.arg1 = hw_config_base;
+			if (params_node->ep_info->args.arg0 == 0)
+				params_node->ep_info->args.arg0 =
+								fw_config_base;
+			if (params_node->ep_info->args.arg1 == 0)
+				params_node->ep_info->args.arg1 =
+								hw_config_base;
 		}
 	}
 }


### PR DESCRIPTION
This patch modifies the common utility function
`populate_next_bl_params_config()` to only modify the entrypoint arguments
to an executable image only if they are not initialized earlier.
This issue was detected while testing Optee on ARM platforms which needed
the current arguments to be preserved in the absence of corresponding
config files.

Change-Id: I1e3fb4be8176fc173959e72442396dd33a99a316
Signed-off-by: Amit Daniel Kachhap <amit.kachhap@arm.com>
Signed-off-by: David Cunado <david.cunado@arm.com>