### PR TITLE
bl2-el3: Fix bl32 lr_svc used for bl33 entry address

### DIFF
--- a/bl2/aarch32/bl2_el3_entrypoint.S
+++ b/bl2/aarch32/bl2_el3_entrypoint.S
@@ -78,6 +78,11 @@ func bl2_run_next_image
 	ldr	r1, [r8, #(ENTRY_POINT_INFO_PC_OFFSET + 4)]
 	msr	spsr, r1
 
+	/* Some BL32 stages expect lr_svc to provide the BL33 entry address */
+	cps	#MODE32_svc
+	ldr	lr, [r8, #ENTRY_POINT_INFO_LR_SVC_OFFSET]
+	cps	#MODE32_mon
+
 	add	r8, r8, #ENTRY_POINT_INFO_ARGS_OFFSET
 	ldm	r8, {r0, r1, r2, r3}
 	eret


### PR DESCRIPTION
When using BL2_EL3, we need to ensure that lr_svc is
properly given to bl32 as it was previously made by bl1.

Fixes ARM-Software/tf-issues#562

Signed-off-by: Lionel Debieve <lionel.debieve@st.com>