### PR TITLE
plat/common: remove fall-through on release build

### DIFF
--- a/plat/common/plat_gicv3.c
+++ b/plat/common/plat_gicv3.c
@@ -158,15 +158,14 @@ uint32_t plat_interrupt_type_to_line(uint32_t type,
 			return __builtin_ctz(SCR_FIQ_BIT);
 		else
 			return __builtin_ctz(SCR_IRQ_BIT);
-	default:
-		assert(0);
-		/* Fall through in the release build */
 	case INTR_TYPE_EL3:
 		/*
 		 * The EL3 interrupts are signaled as FIQ in both S-EL0/1 and
 		 * NS-EL0/1/2 contexts
 		 */
 		return __builtin_ctz(SCR_FIQ_BIT);
+	default:
+		panic();
 	}
 }
 


### PR DESCRIPTION
Removes fall-through in switch statement on unknown interrupt type in
release builds.

Previous behaviour was to assert(0) on default case in debug builds but
fall through and interpret the unknown interrupt type as
INTR_TYPE_EL3 in release builds.

Change-Id: I05fb0299608efda0f9eda2288d3e56e5625e05c9
Signed-off-by: Jonathan Wright <jonathan.wright@arm.com>