### PR TITLE
FVP AArch32: Fix flash access in BL32 for mem_protect

### DIFF
--- a/plat/arm/board/fvp/fvp_common.c
+++ b/plat/arm/board/fvp/fvp_common.c
@@ -145,6 +145,7 @@ const mmap_region_t plat_arm_secure_partition_mmap[] = {
 const mmap_region_t plat_arm_mmap[] = {
 #ifdef AARCH32
 	ARM_MAP_SHARED_RAM,
+	ARM_V2M_MAP_MEM_PROTECT,
 #endif
 	V2M_MAP_IOFPGA,
 	MAP_DEVICE0,


### PR DESCRIPTION
The FVP platform port for SP_MIN (BL32) didn't map the flash memory
in BL32 for storing the mem_protect enable state information leading
to synchronous exception. The patch fixes it by adding the region to
the BL32 mmap tables.

Change-Id: I37eec83c3e1ea43d1b5504d3683eebc32a57eadf
Signed-off-by: Joel Hutton <Joel.Hutton@Arm.com>