### PR TITLE
Trusty: Fix sanity check on NS entry point

### DIFF
--- a/services/spd/trusty/trusty.c
+++ b/services/spd/trusty/trusty.c
@@ -451,7 +451,7 @@ static int32_t trusty_setup(void)
 		uint32_t spsr;
 
 		ns_ep_info = bl31_plat_get_next_image_ep_info(NON_SECURE);
-		if (!ep_info) {
+		if (ns_ep_info == NULL) {
 			NOTICE("Trusty: non-secure image missing.\n");
 			return -1;
 		}


### PR DESCRIPTION
This patch fixes the sanity check on the non-secure entrypoint value
returned by bl31_plat_get_next_image_ep_info(). This issue has been
reported by Coverity Scan Online:

  CID 264893 (#1 of 1): Dereference null return value (NULL_RETURNS)
  Dereferencing a null pointer ns_ep_info.
