### PR TITLE
qemu: Add support for stack canary protection

### DIFF
--- a/plat/qemu/include/platform_def.h
+++ b/plat/qemu/include/platform_def.h
@@ -75,7 +75,7 @@
 #define NS_DRAM0_SIZE			0x3de00000
 
 #define SEC_SRAM_BASE			0x0e000000
-#define SEC_SRAM_SIZE			0x00040000
+#define SEC_SRAM_SIZE			0x00060000
 
 #define SEC_DRAM_BASE			0x0e100000
 #define SEC_DRAM_SIZE			0x00f00000
@@ -123,7 +123,7 @@
  * Put BL2 just below BL3-1. BL2_BASE is calculated using the current BL2 debug
  * size plus a little space for growth.
  */
-#define BL2_BASE			(BL31_BASE - 0x1D000)
+#define BL2_BASE			(BL31_BASE - 0x25000)
 #define BL2_LIMIT			BL31_BASE
 
 /*

--- a/plat/qemu/platform.mk
+++ b/plat/qemu/platform.mk
@@ -168,6 +168,10 @@ $(eval $(call TOOL_ADD_IMG,bl32_extra2,--tos-fw-extra2))
 endif
 
 SEPARATE_CODE_AND_RODATA := 1
+ENABLE_STACK_PROTECTOR	 := 0
+ifneq ($(ENABLE_STACK_PROTECTOR), 0)
+	PLAT_BL_COMMON_SOURCES += plat/qemu/qemu_stack_protector.c
+endif
 
 # Disable the PSCI platform compatibility layer
 ENABLE_PLAT_COMPAT	:= 	0

--- a/plat/qemu/qemu_stack_protector.c
+++ b/plat/qemu/qemu_stack_protector.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <arch_helpers.h>
+#include <platform.h>
+#include <stdint.h>
+
+#define RANDOM_CANARY_VALUE ((u_register_t) 3288484550995823360ULL)
+
+u_register_t plat_get_stack_protector_canary(void)
+{
+	/*
+	 * Ideally, a random number should be returned instead of the
+	 * combination of a timer's value and a compile-time constant.
+	 * As the virt platform does not have any random number generator,
+	 * this is better than nothing but not necessarily really secure.
+	 */
+	return RANDOM_CANARY_VALUE ^ read_cntpct_el0();
+}
+


### PR DESCRIPTION
Allow qemu users to enable stack protection. Since the virt platform
does not provide an RNG, use a basic, timer-based, canary generation,
similarly to FVP.

Increase SRAM size and BL2 size to fit images when stack protection is
enabled.

Notice that stack protection is not enabled by default in qemu.

Fixes ARM-software/tf-issues#568

Signed-off-by: Michalis Pappas <mpappas@fastmail.fm>