### PR TITLE
rpi3: Migrate to the multi console API

### DIFF
--- a/docs/plat/rpi3.rst
+++ b/docs/plat/rpi3.rst
@@ -247,6 +247,11 @@ The following is not currently supported:
 
 - ``LOAD_IMAGE_V2=0``: Only version 2 is supported.
 
+- ``MULTI_CONSOLE_API=0``: The multi console API must be enabled. Note that the
+  crash console uses the internal 16550 driver functions directly in order to be
+  able to print error messages during early crashes before setting up the
+  multi console API.
+
 AArch64 kernel build instructions
 ---------------------------------
 
@@ -300,7 +305,7 @@ Setup SD card
 
 The instructions assume that you have an SD card with a fresh install of
 `Raspbian`_ (or that, at least, the ``boot`` partition is untouched, or nearly
-untouched). They have been tested with the image available in 2017-09-07.
+untouched). They have been tested with the image available in 2018-03-13.
 
 1. Insert the SD card and open the ``boot`` partition.
 

--- a/drivers/ti/uart/aarch64/16550_console.S
+++ b/drivers/ti/uart/aarch64/16550_console.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -17,10 +17,11 @@
 	.globl console_16550_core_init
 	.globl console_16550_core_putc
 	.globl console_16550_core_getc
+	.globl console_16550_core_flush
 
 	.globl console_16550_putc
 	.globl console_16550_getc
-
+	.globl console_16550_flush
 
 	/* -----------------------------------------------
 	 * int console_16550_core_init(uintptr_t base_addr,
@@ -119,6 +120,7 @@ endfunc console_16550_register
 	.equ console_core_init,console_16550_core_init
 	.equ console_core_putc,console_16550_core_putc
 	.equ console_core_getc,console_16550_core_getc
+	.equ console_core_flush,console_16550_core_flush
 #endif
 
 	/* --------------------------------------------------------
@@ -222,8 +224,7 @@ func console_16550_getc
 endfunc console_16550_getc
 
 	/* ---------------------------------------------
-	 * int console_core_flush(uintptr_t base_addr)
-	 * DEPRECATED: Not used with MULTI_CONSOLE_API!
+	 * int console_16550_core_flush(uintptr_t base_addr)
 	 * Function to force a write of all buffered
 	 * data that hasn't been output.
 	 * In : x0 - console base address
@@ -231,8 +232,36 @@ endfunc console_16550_getc
 	 * Clobber list : x0, x1
 	 * ---------------------------------------------
 	 */
-func console_core_flush
-	/* Placeholder */
+func console_16550_core_flush
+#if ENABLE_ASSERTIONS
+	cmp	x0, #0
+	ASM_ASSERT(ne)
+#endif /* ENABLE_ASSERTIONS */
+
+	/* Loop until the transmit FIFO is empty */
+1:	ldr	w1, [x0, #UARTLSR]
+	and	w1, w1, #(UARTLSR_TEMT | UARTLSR_THRE)
+	cmp	w1, #(UARTLSR_TEMT | UARTLSR_THRE)
+	b.ne	1b
+
 	mov	w0, #0
 	ret
-endfunc console_core_flush
+endfunc console_16550_core_flush
+
+	/* ---------------------------------------------
+	 * int console_16550_flush(console_pl011_t *console)
+	 * Function to force a write of all buffered
+	 * data that hasn't been output.
+	 * In : x0 - pointer to console_t structure
+	 * Out : return -1 on error else return 0.
+	 * Clobber list : x0, x1
+	 * ---------------------------------------------
+	 */
+func console_16550_flush
+#if ENABLE_ASSERTIONS
+	cmp	x0, #0
+	ASM_ASSERT(ne)
+#endif /* ENABLE_ASSERTIONS */
+	ldr	x0, [x0, #CONSOLE_T_16550_BASE]
+	b	console_16550_core_flush
+endfunc console_16550_flush

--- a/plat/rpi3/aarch64/plat_helpers.S
+++ b/plat/rpi3/aarch64/plat_helpers.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -137,7 +137,7 @@ func plat_crash_console_init
 	mov_imm	x0, PLAT_RPI3_UART_BASE
 	mov_imm	x1, PLAT_RPI3_UART_CLK_IN_HZ
 	mov_imm	x2, PLAT_RPI3_UART_BAUDRATE
-	b	console_core_init
+	b	console_16550_core_init
 endfunc plat_crash_console_init
 
 	/* ---------------------------------------------
@@ -149,7 +149,7 @@ endfunc plat_crash_console_init
 	 */
 func plat_crash_console_putc
 	mov_imm	x1, PLAT_RPI3_UART_BASE
-	b	console_core_putc
+	b	console_16550_core_putc
 endfunc plat_crash_console_putc
 
 	/* ---------------------------------------------
@@ -161,8 +161,8 @@ endfunc plat_crash_console_putc
 	 * ---------------------------------------------
 	 */
 func plat_crash_console_flush
-	mov_imm	x1, PLAT_RPI3_UART_BASE
-	b	console_core_flush
+	mov_imm	x0, PLAT_RPI3_UART_BASE
+	b	console_16550_core_flush
 endfunc plat_crash_console_flush
 
 	/* ---------------------------------------------

--- a/plat/rpi3/platform.mk
+++ b/plat/rpi3/platform.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -81,6 +81,9 @@ USE_COHERENT_MEM		:= 1
 # Enable new version of image loading
 LOAD_IMAGE_V2			:= 1
 
+# Use multi console API
+MULTI_CONSOLE_API		:= 1
+
 # Platform build flags
 # --------------------
 
@@ -108,6 +111,10 @@ $(eval $(call add_define,RPI3_BL33_IN_AARCH32))
 
 ifneq (${LOAD_IMAGE_V2}, 1)
   $(error Error: rpi3 needs LOAD_IMAGE_V2=1)
+endif
+
+ifneq (${MULTI_CONSOLE_API}, 1)
+  $(error Error: rpi3 needs MULTI_CONSOLE_API=1)
 endif
 
 ifeq (${ARCH},aarch32)

--- a/plat/rpi3/rpi3_bl1_setup.c
+++ b/plat/rpi3/rpi3_bl1_setup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,7 +7,6 @@
 #include <arch.h>
 #include <arch_helpers.h>
 #include <bl_common.h>
-#include <console.h>
 #include <platform_def.h>
 #include <xlat_mmu_helpers.h>
 #include <xlat_tables_defs.h>
@@ -29,8 +28,7 @@ meminfo_t *bl1_plat_sec_mem_layout(void)
 void bl1_early_platform_setup(void)
 {
 	/* Initialize the console to provide early debug support */
-	console_init(PLAT_RPI3_UART_BASE, PLAT_RPI3_UART_CLK_IN_HZ,
-		     PLAT_RPI3_UART_BAUDRATE);
+	rpi3_console_init();
 
 	/* Allow BL1 to see the whole Trusted RAM */
 	bl1_tzram_layout.total_base = BL_RAM_BASE;

--- a/plat/rpi3/rpi3_bl2_setup.c
+++ b/plat/rpi3/rpi3_bl2_setup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,7 +7,6 @@
 #include <arch_helpers.h>
 #include <assert.h>
 #include <bl_common.h>
-#include <console.h>
 #include <debug.h>
 #include <desc_image_load.h>
 #include <platform_def.h>
@@ -27,8 +26,7 @@ static meminfo_t bl2_tzram_layout __aligned(CACHE_WRITEBACK_GRANULE);
 void bl2_early_platform_setup(meminfo_t *mem_layout)
 {
 	/* Initialize the console to provide early debug support */
-	console_init(PLAT_RPI3_UART_BASE, PLAT_RPI3_UART_CLK_IN_HZ,
-		     PLAT_RPI3_UART_BAUDRATE);
+	rpi3_console_init();
 
 	/* Setup the BL2 memory layout */
 	bl2_tzram_layout = *mem_layout;
@@ -40,7 +38,7 @@ void bl2_platform_setup(void)
 {
 	/*
 	 * This is where a TrustZone address space controller and other
-	 * security related peripherals, would be configured.
+	 * security related peripherals would be configured.
 	 */
 }
 

--- a/plat/rpi3/rpi3_bl31_setup.c
+++ b/plat/rpi3/rpi3_bl31_setup.c
@@ -1,12 +1,11 @@
 /*
- * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <assert.h>
 #include <bl_common.h>
-#include <console.h>
 #include <platform.h>
 #include <platform_def.h>
 #include <xlat_mmu_helpers.h>
@@ -58,8 +57,7 @@ void bl31_early_platform_setup(void *from_bl2,
 			       void *plat_params_from_bl2)
 {
 	/* Initialize the console to provide early debug support */
-	console_init(PLAT_RPI3_UART_BASE, PLAT_RPI3_UART_CLK_IN_HZ,
-		     PLAT_RPI3_UART_BAUDRATE);
+	rpi3_console_init();
 
 #if RESET_TO_BL31
 
@@ -158,11 +156,4 @@ void bl31_platform_setup(void)
 #endif /* RESET_TO_BL31 */
 
 	return;
-}
-
-void bl31_plat_runtime_setup(void)
-{
-	/* Initialize the runtime console */
-	console_init(PLAT_RPI3_UART_BASE, PLAT_RPI3_UART_CLK_IN_HZ,
-		     PLAT_RPI3_UART_BAUDRATE);
 }

--- a/plat/rpi3/rpi3_common.c
+++ b/plat/rpi3/rpi3_common.c
@@ -1,14 +1,16 @@
 /*
- * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <arch_helpers.h>
 #include <bl_common.h>
+#include <console.h>
 #include <debug.h>
 #include <interrupt_mgmt.h>
 #include <platform_def.h>
+#include <uart_16550.h>
 #include <xlat_tables_v2.h>
 
 #include "rpi3_hw.h"
@@ -67,6 +69,30 @@ static const mmap_region_t plat_rpi3_mmap[] = {
 	{0}
 };
 #endif
+
+/*******************************************************************************
+ * Function that sets up the console
+ ******************************************************************************/
+static console_16550_t rpi3_console;
+
+void rpi3_console_init(void)
+{
+	int rc = console_16550_register(PLAT_RPI3_UART_BASE,
+					PLAT_RPI3_UART_CLK_IN_HZ,
+					PLAT_RPI3_UART_BAUDRATE,
+					&rpi3_console);
+	if (rc == 0) {
+		/*
+		 * The crash console doesn't use the multi console API, it uses
+		 * the core console functions directly. It is safe to call panic
+		 * and let it print debug information.
+		 */
+		panic();
+	}
+
+	console_set_scope(&rpi3_console.console,
+			  CONSOLE_FLAG_BOOT | CONSOLE_FLAG_RUNTIME);
+}
 
 /*******************************************************************************
  * Function that sets up the translation tables.

--- a/plat/rpi3/rpi3_private.h
+++ b/plat/rpi3/rpi3_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -14,6 +14,7 @@
  ******************************************************************************/
 
 /* Utility functions */
+void rpi3_console_init(void);
 void rpi3_setup_page_tables(uintptr_t total_base, size_t total_size,
 			    uintptr_t code_start, uintptr_t code_limit,
 			    uintptr_t rodata_start, uintptr_t rodata_limit


### PR DESCRIPTION
- Migrate to the new multi console API.
- The flush API was missing in the 16550 console driver. The placeholder has been replaced by an actual implementation.