### PR TITLE
qemu: MULTI_CONSOLE_API=0 causes build error

### DIFF
--- a/include/drivers/console.h
+++ b/include/drivers/console.h
@@ -66,6 +66,8 @@ int console_flush(void);
 /* REMOVED on AArch64 -- use console_<driver>_register() instead! */
 int console_init(uintptr_t base_addr,
 		 unsigned int uart_clk, unsigned int baud_rate);
+int console_core_init(uintptr_t base_addr,
+		      unsigned int uart_clk, unsigned int baud_rate);
 void console_uninit(void);
 #endif
 

--- a/plat/qemu/platform.mk
+++ b/plat/qemu/platform.mk
@@ -169,7 +169,12 @@ $(eval $(call TOOL_ADD_IMG,bl32_extra2,--tos-fw-extra2))
 endif
 
 SEPARATE_CODE_AND_RODATA := 1
-MULTI_CONSOLE_API	 := 1
+
+# Use MULTI_CONSOLE_API by default only on AArch64
+# as it is not yet supported on AArch32
+ifeq ($(ARCH),aarch64)
+MULTI_CONSOLE_API	:= 1
+endif
 
 # Disable the PSCI platform compatibility layer
 ENABLE_PLAT_COMPAT	:= 	0

--- a/plat/qemu/qemu_console.c
+++ b/plat/qemu/qemu_console.c
@@ -7,8 +7,10 @@
 #include <pl011.h>
 #include <platform_def.h>
 
+#if MULTI_CONSOLE_API
 static console_pl011_t console;
 static console_pl011_t crash_console;
+#endif /* MULTI_CONSOLE_API */
 
 void qemu_console_init(void)
 {


### PR DESCRIPTION
Add crash_console_init declaration to console.h
Only enable MULTI_CONSOLE_API for AArch64

Fixes ARM-software/tf-issues#571

Signed-off-by: Michalis Pappas <mpappas@fastmail.fm>