### PR TITLE
hikey960: add delay before reset

### DIFF
--- a/plat/hisilicon/hikey960/hikey960_pm.c
+++ b/plat/hisilicon/hikey960/hikey960_pm.c
@@ -9,6 +9,7 @@
 #include <cci.h>
 #include <console.h>
 #include <debug.h>
+#include <delay_timer.h>
 #include <gicv2.h>
 #include <hi3660.h>
 #include <hi3660_crg.h>
@@ -114,6 +115,9 @@ void hikey960_pwr_domain_off(const psci_power_state_t *target_state)
 
 static void __dead2 hikey960_system_reset(void)
 {
+	dsb();
+	isb();
+	mdelay(2000);
 	mmio_write_32(SCTRL_SCPEREN1_REG,
 		      SCPEREN1_WAIT_DDR_SELFREFRESH_DONE_BYPASS);
 	mmio_write_32(SCTRL_SCSYSSTAT_REG, 0xdeadbeef);


### PR DESCRIPTION
If system is still accessing storage device, reboot operation
may cause data broken. So add the flush and delay operation
before system reset.

Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>