### PR TITLE
Add interface for hash functions in crypto module

### DIFF
--- a/drivers/auth/crypto_mod.c
+++ b/drivers/auth/crypto_mod.c
@@ -103,3 +103,52 @@ int crypto_mod_verify_hash(void *data_ptr, unsigned int data_len,
 	return crypto_lib_desc.verify_hash(data_ptr, data_len,
 					   digest_info_ptr, digest_info_len);
 }
+
+/*
+ * Initilaize context of the hash function
+ *
+ * Parameters:
+ *
+ *   algo: Hash algorithm
+ *   ctx: Context to be initialized
+ */
+int crypto_hash_init(enum hash_algo algo, void **ctx)
+{
+	return crypto_lib_desc.hash_init(algo, ctx);
+}
+
+/*
+ * Calculate hash of chunk of data
+ *
+ * Parameters:
+ *
+ *   algo: Hash algorithm
+ *   ctx: Context to be initialized
+ *   data_ptr, data_len: data to be hashed
+ */
+int crypto_hash_update(enum hash_algo algo, void *ctx, void *data_ptr,
+		       unsigned int data_len)
+{
+	assert(data_ptr != NULL);
+	assert(data_len != 0);
+	assert(ctx != NULL);
+	return crypto_lib_desc.hash_update(algo, ctx, data_ptr, data_len);
+}
+
+/*
+ * Return hash of the chunks added via hash_update function
+ *
+ * Parameters:
+ *
+ *   algo: Hash algorithm
+ *   ctx: Context to be initialized
+ *   hash_ptr, hash_len: Calculated hash 
+ */
+int crypto_hash_final(enum hash_algo algo, void *ctx, void *hash_ptr,
+		      unsigned int hash_len)
+{
+	assert(hash_ptr != NULL);
+	assert(hash_len != 0);
+	assert(ctx != NULL);
+	return crypto_lib_desc.hash_final(algo, ctx, hash_ptr, hash_len);
+}

--- a/drivers/auth/cryptocell/cryptocell_crypto.c
+++ b/drivers/auth/cryptocell/cryptocell_crypto.c
@@ -299,6 +299,7 @@ static int verify_hash(void *data_ptr, unsigned int data_len,
 /*
  * Register crypto library descriptor
  */
-REGISTER_CRYPTO_LIB(LIB_NAME, init, verify_signature, verify_hash);
+REGISTER_CRYPTO_LIB(LIB_NAME, init, verify_signature, verify_hash,
+		    NULL, NULL, NULL);
 
 

--- a/drivers/auth/mbedtls/mbedtls_crypto.c
+++ b/drivers/auth/mbedtls/mbedtls_crypto.c
@@ -207,4 +207,5 @@ static int verify_hash(void *data_ptr, unsigned int data_len,
 /*
  * Register crypto library descriptor
  */
-REGISTER_CRYPTO_LIB(LIB_NAME, init, verify_signature, verify_hash);
+REGISTER_CRYPTO_LIB(LIB_NAME, init, verify_signature, verify_hash,
+		    NULL, NULL, NULL);

--- a/include/drivers/auth/crypto_mod.h
+++ b/include/drivers/auth/crypto_mod.h
@@ -16,6 +16,13 @@ enum crypto_ret_value {
 	CRYPTO_ERR_UNKNOWN
 };
 
+/* List of hash algorithms */
+enum hash_algo {
+	SHA1 = 0,
+	SHA256,
+	SHA512
+};
+
 /*
  * Cryptographic library descriptor
  */
@@ -37,6 +44,17 @@ typedef struct crypto_lib_desc_s {
 	/* Verify a hash. Return one of the 'enum crypto_ret_value' options */
 	int (*verify_hash)(void *data_ptr, unsigned int data_len,
 			   void *digest_info_ptr, unsigned int digest_info_len);
+
+	/* Initilaize the context for hash function */
+	int (*hash_init)(enum hash_algo algo, void **ctx);
+
+	/* Add chunk of data to be hashed */
+	int (*hash_update)(enum hash_algo algo, void *ctx,
+			   void *data_ptr, unsigned int data_len);
+
+	/* Place the final digest in hash_ptr */
+	int (*hash_final)(enum hash_algo algo, void *ctx, void *hash_ptr,
+			  unsigned int hash_len);
 } crypto_lib_desc_t;
 
 /* Public functions */
@@ -47,14 +65,23 @@ int crypto_mod_verify_signature(void *data_ptr, unsigned int data_len,
 				void *pk_ptr, unsigned int pk_len);
 int crypto_mod_verify_hash(void *data_ptr, unsigned int data_len,
 			   void *digest_info_ptr, unsigned int digest_info_len);
+int crypto_hash_init(enum hash_algo algo, void **ctx);
+int crypto_hash_update(enum hash_algo algo, void *ctx,
+		       void *data_ptr, unsigned int data_len);
+int crypto_hash_final(enum hash_algo algo, void *ctx, void *hash_ptr,
+		      unsigned int hash_len);
 
 /* Macro to register a cryptographic library */
-#define REGISTER_CRYPTO_LIB(_name, _init, _verify_signature, _verify_hash) \
+#define REGISTER_CRYPTO_LIB(_name, _init, _verify_signature, _verify_hash, \
+			    _hash_init, _hash_update, _hash_final) \
 	const crypto_lib_desc_t crypto_lib_desc = { \
 		.name = _name, \
 		.init = _init, \
 		.verify_signature = _verify_signature, \
-		.verify_hash = _verify_hash \
+		.verify_hash = _verify_hash, \
+		.hash_init = _hash_init, \
+		.hash_update = _hash_update, \
+		.hash_final = _hash_final \
 	}
 
 #endif /* __CRYPTO_MOD_H__ */


### PR DESCRIPTION
There may be scenarios where platform specific implementation
need to calculate hash of discontiguous data during image auth.
The patch exposes hash function form the crypto module which
can be used to do such calculations.

Signed-off-by: Ruchika Gupta <ruchika.gupta@nxp.com>