### PR TITLE
qemu: don't use C functions for the crash console callbacks

### DIFF
--- a/include/drivers/console.h
+++ b/include/drivers/console.h
@@ -66,8 +66,6 @@ int console_flush(void);
 /* REMOVED on AArch64 -- use console_<driver>_register() instead! */
 int console_init(uintptr_t base_addr,
 		 unsigned int uart_clk, unsigned int baud_rate);
-int console_core_init(uintptr_t base_addr,
-		      unsigned int uart_clk, unsigned int baud_rate);
 void console_uninit(void);
 #endif
 

--- a/plat/qemu/aarch64/plat_helpers.S
+++ b/plat/qemu/aarch64/plat_helpers.S
@@ -14,9 +14,8 @@
 	.globl	platform_mem_init
 	.globl	plat_qemu_calc_core_pos
 	.globl	plat_crash_console_init
-#if MULTI_CONSOLE_API
 	.globl	plat_crash_console_putc
-#endif /* MULTI_CONSOLE_API */
+	.globl	plat_crash_console_flush
 	.globl  plat_secondary_cold_boot_setup
 	.globl  plat_get_my_entrypoint
 	.globl  plat_is_my_cpu_primary
@@ -97,7 +96,10 @@ endfunc platform_mem_init
 	 * ---------------------------------------------
 	 */
 func plat_crash_console_init
-	b	qemu_crash_console_init
+	mov_imm x0, PLAT_QEMU_CRASH_UART_BASE
+	mov_imm x1, PLAT_QEMU_CRASH_UART_CLK_IN_HZ
+	mov_imm x2, PLAT_QEMU_CONSOLE_BAUDRATE
+	b	console_pl011_core_init
 endfunc plat_crash_console_init
 
 	/* ---------------------------------------------
@@ -107,10 +109,21 @@ endfunc plat_crash_console_init
 	 * Clobber list : x1, x2
 	 * ---------------------------------------------
 	 */
-#if !MULTI_CONSOLE_API
 func plat_crash_console_putc
 	mov_imm	x1, PLAT_QEMU_CRASH_UART_BASE
-	b	console_core_putc
+	b	console_pl011_core_putc
 endfunc plat_crash_console_putc
-#endif /* MULTI_CONSOLE_API */
+
+	/* ---------------------------------------------
+	 * int plat_crash_console_flush(int c)
+	 * Function to force a write of all buffered
+	 * data that hasn't been output.
+	 * Out : return -1 on error else return 0.
+	 * Clobber list : x0, x1
+	 * ---------------------------------------------
+	 */
+func plat_crash_console_flush
+	mov_imm	x0, PLAT_QEMU_CRASH_UART_BASE
+	b	console_pl011_core_flush
+endfunc plat_crash_console_flush
 

--- a/plat/qemu/qemu_console.c
+++ b/plat/qemu/qemu_console.c
@@ -9,7 +9,6 @@
 
 #if MULTI_CONSOLE_API
 static console_pl011_t console;
-static console_pl011_t crash_console;
 #endif /* MULTI_CONSOLE_API */
 
 void qemu_console_init(void)
@@ -18,6 +17,9 @@ void qemu_console_init(void)
 	(void)console_pl011_register(PLAT_QEMU_BOOT_UART_BASE,
 			       PLAT_QEMU_BOOT_UART_CLK_IN_HZ,
 			       PLAT_QEMU_CONSOLE_BAUDRATE, &console);
+
+	console_set_scope(&console.console, CONSOLE_FLAG_BOOT |
+			  CONSOLE_FLAG_RUNTIME);
 #else
 	console_init(PLAT_QEMU_BOOT_UART_BASE,
 		     PLAT_QEMU_BOOT_UART_CLK_IN_HZ,
@@ -25,15 +27,3 @@ void qemu_console_init(void)
 #endif /* MULTI_CONSOLE_API */
 }
 
-void qemu_crash_console_init(void)
-{
-#if MULTI_CONSOLE_API
-	(void)console_pl011_register(PLAT_QEMU_CRASH_UART_BASE,
-			       PLAT_QEMU_CRASH_UART_CLK_IN_HZ,
-			       PLAT_QEMU_CONSOLE_BAUDRATE, &crash_console);
-#else
-	console_core_init(PLAT_QEMU_CRASH_UART_BASE,
-			  PLAT_QEMU_CRASH_UART_CLK_IN_HZ,
-			  PLAT_QEMU_CONSOLE_BAUDRATE);
-#endif /* MULTI_CONSOLE_API */
-}

--- a/plat/qemu/qemu_private.h
+++ b/plat/qemu/qemu_private.h
@@ -35,6 +35,5 @@ int dt_add_psci_node(void *fdt);
 int dt_add_psci_cpu_enable_methods(void *fdt);
 
 void qemu_console_init(void);
-void qemu_crash_console_init(void);
 
 #endif /*__QEMU_PRIVATE_H*/


### PR DESCRIPTION
Use the console_pl011_core_* functions directly in the crash console
callbacks.

This bypasses the MULTI_CONSOLE_API for the crash console (UART1), but
allows using the crash console before the C runtime has been initialized
(eg to call ASM_ASSERT). This retains backwards compatibilty with respect
to functionality when the old API is used.

Use the MULTI_CONSOLE_API to register UART0 as the boot and runtime
console.

Fixes ARM-software/tf-issues#572

Signed-off-by: Michalis Pappas <mpappas@fastmail.fm>