### PR TITLE
Replace assert(0) with refactored panic() macro

### DIFF
--- a/bl1/bl1_fwu.c
+++ b/bl1/bl1_fwu.c
@@ -90,8 +90,7 @@ register_t bl1_fwu_smc_handler(unsigned int smc_fid,
 		break;
 
 	default:
-		assert(0);
-		break;
+		panic();
 	}
 
 	SMC_RET1(handle, SMC_UNK);
@@ -693,7 +692,7 @@ __dead2 static void bl1_fwu_done(void *client_cookie, void *reserved)
 	 * Call platform done function.
 	 */
 	bl1_plat_fwu_done(client_cookie, reserved);
-	assert(0);
+	panic();
 }
 
 /*******************************************************************************
@@ -747,8 +746,7 @@ static int bl1_fwu_image_reset(unsigned int image_id, unsigned int flags)
 
 	case IMAGE_STATE_EXECUTED:
 	default:
-		assert(0);
-		break;
+		panic();
 	}
 
 	return 0;

--- a/drivers/arm/gic/v2/gicv2_main.c
+++ b/drivers/arm/gic/v2/gicv2_main.c
@@ -458,8 +458,7 @@ void gicv2_set_interrupt_type(unsigned int id, unsigned int type)
 		gicd_clr_igroupr(driver_data->gicd_base, id);
 		break;
 	default:
-		assert(0);
-		break;
+		panic();
 	}
 	spin_unlock(&gic_lock);
 }

--- a/drivers/arm/gic/v3/gicv3_main.c
+++ b/drivers/arm/gic/v3/gicv3_main.c
@@ -1003,8 +1003,7 @@ void gicv3_set_interrupt_type(unsigned int id, unsigned int proc_num,
 		grpmod = 0;
 		break;
 	default:
-		assert(0);
-		break;
+		panic();
 	}
 
 	if (id < MIN_SPI_ID) {

--- a/drivers/synopsys/emmc/dw_mmc.c
+++ b/drivers/synopsys/emmc/dw_mmc.c
@@ -320,8 +320,7 @@ static int dw_set_ios(int clk, int width)
 		mmio_write_32(dw_params.reg_base + DWMMC_CTYPE, CTYPE_8BIT);
 		break;
 	default:
-		assert(0);
-		break;
+		panic();
 	}
 	dw_set_clk(clk);
 	return 0;

--- a/drivers/ufs/ufs.c
+++ b/drivers/ufs/ufs.c
@@ -270,8 +270,7 @@ static int ufs_prepare_cmd(utp_utrd_t *utrd, uint8_t op, uint8_t lun,
 		upiu->cdb[8] = lba_cnt & 0xff;
 		break;
 	default:
-		assert(0);
-		break;
+		panic();
 	}
 	if (hd->dd == DD_IN)
 		flush_dcache_range(buf, length);
@@ -359,8 +358,7 @@ static int ufs_prepare_query(utp_utrd_t *utrd, uint8_t op, uint8_t idn,
 		memcpy((void *)&query_upiu->ts.attr.value, (void *)buf, length);
 		break;
 	default:
-		assert(0);
-		break;
+		panic();
 	}
 	flush_dcache_range((uintptr_t)utrd, sizeof(utp_utrd_t));
 	flush_dcache_range((uintptr_t)utrd->header, UFS_DESC_SIZE);

--- a/include/common/debug.h
+++ b/include/common/debug.h
@@ -68,9 +68,6 @@
 # define VERBOSE(...)
 #endif
 
-void __dead2 do_panic(void);
-#define panic()	do_panic()
-
 /* Function called when stack protection check code detects a corrupted stack */
 void __dead2 __stack_chk_fail(void);
 
@@ -80,6 +77,16 @@ int tf_snprintf(char *s, size_t n, const char *fmt, ...) __printflike(3, 4);
 void tf_vprintf(const char *fmt, va_list args);
 void tf_string_print(const char *str);
 void tf_log_set_max_level(unsigned int log_level);
+
+void __dead2 do_panic(void);
+#if LOG_LEVEL >= LOG_LEVEL_INFO
+#define panic() do {                                                \
+    tf_printf("PANIC: %s:%d\n", __FILE__, __LINE__);  \
+    do_panic();                                                     \
+} while (0)
+#else
+#define panic()	do_panic()
+#endif
 
 #endif /* __ASSEMBLY__ */
 #endif /* __DEBUG_H__ */

--- a/lib/extensions/sve/sve.c
+++ b/lib/extensions/sve/sve.c
@@ -6,6 +6,7 @@
 
 #include <arch.h>
 #include <arch_helpers.h>
+#include <debug.h>
 #include <pubsub.h>
 #include <sve.h>
 
@@ -74,7 +75,7 @@ void sve_enable(int el2_unused)
 	/*
 	 * CTX_INCLUDE_FPREGS is not supported on SVE enabled systems.
 	 */
-	assert(0);
+	panic();
 #endif
 	/*
 	 * Update CPTR_EL3 to enable access to SVE functionality for the

--- a/lib/xlat_tables_v2/xlat_tables_internal.c
+++ b/lib/xlat_tables_v2/xlat_tables_internal.c
@@ -67,9 +67,7 @@ static int xlat_table_get_index(xlat_ctx_t *ctx, const uint64_t *table)
 	 * Maybe we were asked to get the index of the base level table, which
 	 * should never happen.
 	 */
-	assert(0);
-
-	return -1;
+	panic();
 }
 
 /* Returns a pointer to an empty translation table. */
@@ -750,8 +748,7 @@ void mmap_add_region_ctx(xlat_ctx_t *ctx, const mmap_region_t *mm)
 	ret = mmap_add_region_check(ctx, mm);
 	if (ret != 0) {
 		ERROR("mmap_add_region_check() failed. error %d\n", ret);
-		assert(0);
-		return;
+		panic();
 	}
 
 	/*
@@ -1404,9 +1401,7 @@ static uint64_t *find_xlat_table_entry(uintptr_t virtual_addr,
 	 * This shouldn't be reached, the translation table walk should end at
 	 * most at level XLAT_TABLE_LEVEL_MAX and return from inside the loop.
 	 */
-	assert(0);
-
-	return NULL;
+	panic();
 }
 
 

--- a/plat/common/plat_bl1_common.c
+++ b/plat/common/plat_bl1_common.c
@@ -68,8 +68,7 @@ __dead2 void bl1_plat_fwu_done(void *client_cookie, void *reserved)
 int bl1_plat_mem_check(uintptr_t mem_base, unsigned int mem_size,
 		unsigned int flags)
 {
-	assert(0);
-	return -ENOMEM;
+	panic();
 }
 
 /*

--- a/plat/common/plat_gicv2.c
+++ b/plat/common/plat_gicv2.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <assert.h>
+#include <debug.h>
 #include <gic_common.h>
 #include <gicv2.h>
 #include <interrupt_mgmt.h>
@@ -226,8 +227,7 @@ void plat_ic_set_interrupt_type(unsigned int id, unsigned int type)
 		gicv2_type = GICV2_INTR_GROUP1;
 		break;
 	default:
-		assert(0);
-		break;
+		panic();
 	}
 
 	gicv2_set_interrupt_type(id, gicv2_type);
@@ -247,7 +247,7 @@ void plat_ic_raise_el3_sgi(int sgi_num, u_register_t target)
 
 	gicv2_raise_sgi(sgi_num, id);
 #else
-	assert(0);
+	panic();
 #endif
 }
 
@@ -266,8 +266,7 @@ void plat_ic_set_spi_routing(unsigned int id, unsigned int routing_mode,
 		proc_num = -1;
 		break;
 	default:
-		assert(0);
-		break;
+		panic();
 	}
 
 	gicv2_set_spi_routing(id, proc_num);

--- a/plat/common/plat_gicv3.c
+++ b/plat/common/plat_gicv3.c
@@ -7,6 +7,7 @@
 #include <assert.h>
 #include <bl_common.h>
 #include <cassert.h>
+#include <debug.h>
 #include <gic_common.h>
 #include <gicv3.h>
 #include <interrupt_mgmt.h>
@@ -246,8 +247,7 @@ void plat_ic_set_spi_routing(unsigned int id, unsigned int routing_mode,
 		irm = GICV3_IRM_ANY;
 		break;
 	default:
-		assert(0);
-		break;
+		panic();
 	}
 
 	gicv3_set_spi_routing(id, irm, mpidr);

--- a/plat/compat/plat_pm_compat.c
+++ b/plat/compat/plat_pm_compat.c
@@ -6,6 +6,7 @@
 
 #include <arch_helpers.h>
 #include <assert.h>
+#include <debug.h>
 #include <errno.h>
 #include <platform.h>
 #include <psci.h>
@@ -122,7 +123,7 @@ void get_sys_suspend_power_state_compat(psci_power_state_t *req_state)
 	set_psci_power_state_compat(power_state);
 
 	if (parse_power_state(power_state, req_state) != PSCI_E_SUCCESS)
-		assert(0);
+		panic();
 }
 
 /*******************************************************************************

--- a/plat/hisilicon/poplar/plat_pm.c
+++ b/plat/hisilicon/poplar/plat_pm.c
@@ -63,12 +63,12 @@ static int poplar_pwr_domain_on(u_register_t mpidr)
 
 static void poplar_pwr_domain_off(const psci_power_state_t *target_state)
 {
-	assert(0);
+	panic();
 }
 
 static void poplar_pwr_domain_suspend(const psci_power_state_t *target_state)
 {
-	assert(0);
+	panic();
 }
 
 static void poplar_pwr_domain_on_finish(const psci_power_state_t *target_state)
@@ -86,7 +86,7 @@ static void poplar_pwr_domain_on_finish(const psci_power_state_t *target_state)
 static void poplar_pwr_domain_suspend_finish(
 		const psci_power_state_t *target_state)
 {
-	assert(0);
+	panic();
 }
 
 static void __dead2 poplar_system_off(void)

--- a/plat/mediatek/mt8173/drivers/rtc/rtc.c
+++ b/plat/mediatek/mt8173/drivers/rtc/rtc.c
@@ -71,8 +71,8 @@ void rtc_bbpu_power_down(void)
 	if (Writeif_unlock()) {
 		RTC_Write(RTC_BBPU, bbpu);
 		if (!Write_trigger())
-			assert(0);
+			panic();
 	} else {
-		assert(0);
+		panic();
 	}
 }

--- a/plat/qemu/qemu_pm.c
+++ b/plat/qemu/qemu_pm.c
@@ -149,7 +149,7 @@ static int qemu_pwr_domain_on(u_register_t mpidr)
  ******************************************************************************/
 void qemu_pwr_domain_off(const psci_power_state_t *target_state)
 {
-	assert(0);
+	panic();
 }
 
 /*******************************************************************************
@@ -158,7 +158,7 @@ void qemu_pwr_domain_off(const psci_power_state_t *target_state)
  ******************************************************************************/
 void qemu_pwr_domain_suspend(const psci_power_state_t *target_state)
 {
-	assert(0);
+	panic();
 }
 
 /*******************************************************************************
@@ -185,7 +185,7 @@ void qemu_pwr_domain_on_finish(const psci_power_state_t *target_state)
  ******************************************************************************/
 void qemu_pwr_domain_suspend_finish(const psci_power_state_t *target_state)
 {
-	assert(0);
+	panic();
 }
 
 /*******************************************************************************

--- a/services/spd/opteed/opteed_common.c
+++ b/services/spd/opteed/opteed_common.c
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <bl_common.h>
 #include <context_mgmt.h>
+#include <debug.h>
 #include <string.h>
 #include <utils.h>
 #include "opteed_private.h"
@@ -105,5 +106,5 @@ void opteed_synchronous_sp_exit(optee_context_t *optee_ctx, uint64_t ret)
 	opteed_exit_sp(optee_ctx->c_rt_ctx, ret);
 
 	/* Should never reach here */
-	assert(0);
+	panic();
 }

--- a/services/spd/tlkd/tlkd_common.c
+++ b/services/spd/tlkd/tlkd_common.c
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <bl_common.h>
 #include <context_mgmt.h>
+#include <debug.h>
 #include <string.h>
 #include "tlkd_private.h"
 
@@ -48,8 +49,7 @@ uint64_t tlkd_va_translate(uintptr_t va, int type)
 		ats12e0w(va);
 		break;
 	default:
-		assert(0);
-		break;
+		panic();
 	}
 
 	/* get the (NS/S) physical address */
@@ -160,5 +160,5 @@ void tlkd_synchronous_sp_exit(tlk_context_t *tlk_ctx, uint64_t ret)
 	tlkd_exit_sp(tlk_ctx->c_rt_ctx, ret);
 
 	/* Should never reach here */
-	assert(0);
+	panic();
 }

--- a/services/spd/tspd/tspd_common.c
+++ b/services/spd/tspd/tspd_common.c
@@ -106,7 +106,7 @@ void tspd_synchronous_sp_exit(tsp_context_t *tsp_ctx, uint64_t ret)
 	tspd_exit_sp(tsp_ctx->c_rt_ctx, ret);
 
 	/* Should never reach here */
-	assert(0);
+	panic();
 }
 
 /*******************************************************************************

--- a/services/spd/tspd/tspd_main.c
+++ b/services/spd/tspd/tspd_main.c
@@ -600,8 +600,7 @@ uint64_t tspd_smc_handler(uint32_t smc_fid,
 	case TSP_FID_ABORT:
 		/* ABORT should only be invoked by normal world */
 		if (!ns) {
-			assert(0);
-			break;
+			panic();
 		}
 
 		assert(handle == cm_get_context(NON_SECURE));
@@ -632,8 +631,7 @@ uint64_t tspd_smc_handler(uint32_t smc_fid,
 	case TSP_FID_RESUME:
 		/* RESUME should be invoked only by normal world */
 		if (!ns) {
-			assert(0);
-			break;
+			panic();
 		}
 
 		/*

--- a/services/std_svc/spm/spm_main.c
+++ b/services/std_svc/spm/spm_main.c
@@ -94,7 +94,7 @@ static void __dead2 spm_synchronous_sp_exit(
 	spm_secure_partition_exit(sp_ctx_ptr->c_rt_ctx, ret);
 
 	/* Should never reach here */
-	assert(0);
+	panic();
 }
 
 /*******************************************************************************
@@ -374,7 +374,6 @@ uint64_t spm_smc_handler(uint32_t smc_fid,
 				 * runtime context.
 				 */
 				spm_synchronous_sp_exit(&sp_ctx, x1);
-				assert(0);
 			}
 
 			/* Release the Secure Partition context */


### PR DESCRIPTION
Replaces all instances of assert(0) with panic(). Assert should only be
used to check program invariants; not signal unconditional failure.

The panic() macro has been refactored such that it prints the file and
line number of the panic() when LOG_LEVEL >= LOG_LEVEL_INFO.

Change-Id: Iaed085b85a7772d855b28f604a343dd7fb8198ec
Signed-off-by: Jonathan Wright <jonathan.wright@arm.com>