### PR TITLE
Fixup SMCCC_FEATURES return value for SMCCC_ARCH_WORKAROUND_1

### DIFF
--- a/docs/cpu-specific-build-macros.rst
+++ b/docs/cpu-specific-build-macros.rst
@@ -18,7 +18,11 @@ TF-A exports a series of build flags which control which security
 vulnerability workarounds should be applied at runtime.
 
 -  ``WORKAROUND_CVE_2017_5715``: Enables the security workaround for
-   `CVE-2017-5715`_. Defaults to 1.
+   `CVE-2017-5715`_. This flag can be set to 0 by the platform if none
+   of the PEs in the system need the workaround. Setting this flag to 0 provides
+   no performance benefit for non-affected platforms, it just helps to comply
+   with the recommendation in the spec regarding workaround discovery.
+   Defaults to 1.
 
 CPU Errata Workarounds
 ----------------------

--- a/services/arm_arch_svc/arm_arch_svc_setup.c
+++ b/services/arm_arch_svc/arm_arch_svc_setup.c
@@ -19,19 +19,16 @@ static int32_t smccc_version(void)
 
 static int32_t smccc_arch_features(u_register_t arg)
 {
-	int ret;
-
 	switch (arg) {
 	case SMCCC_VERSION:
 	case SMCCC_ARCH_FEATURES:
 		return SMC_OK;
+#if WORKAROUND_CVE_2017_5715
 	case SMCCC_ARCH_WORKAROUND_1:
-		ret = check_workaround_cve_2017_5715();
-		if (ret == ERRATA_APPLIES)
-			return 0;
-		else if (ret == ERRATA_NOT_APPLIES)
+		if (check_workaround_cve_2017_5715() == ERRATA_NOT_APPLIES)
 			return 1;
-		return -1; /* ERRATA_MISSING */
+		return 0; /* ERRATA_APPLIES || ERRATA_MISSING */
+#endif
 	default:
 		return SMC_UNK;
 	}


### PR DESCRIPTION
Only return -1 if the workaround for CVE-2017-5715 is not compiled in.

Change-Id: I1bd07c57d22b4a13cf51b35be141a1f1ffb065ff
Signed-off-by: Dimitris Papastamos <dimitris.papastamos@arm.com>