### PR TITLE
DMC500: Add platform support to set system interface count

### DIFF
--- a/drivers/arm/tzc/tzc_dmc500.c
+++ b/drivers/arm/tzc/tzc_dmc500.c
@@ -24,7 +24,7 @@
 #define TZC_DMC500_ACTION_OFF				0x50
 
 /* Pointer to the tzc_dmc500_driver_data structure populated by the platform */
-static const tzc_dmc500_driver_data_t *g_driver_data;
+static tzc_dmc500_driver_data_t *g_driver_data;
 
 #define verify_region_attr(region, attr)	\
 		((g_conf_regions[(region)].sec_attr ==			\
@@ -88,7 +88,7 @@ void tzc_dmc500_config_complete(void)
 
 	for (dmc_inst = 0; dmc_inst < g_driver_data->dmc_count; dmc_inst++) {
 		assert(DMC_INST_BASE_ADDR(dmc_inst));
-		for (sys_if = 0; sys_if < MAX_SYS_IF_COUNT; sys_if++)
+		for (sys_if = 0; sys_if < g_driver_data->sys_if_count; sys_if++)
 			_tzc_dmc500_write_flush_control(
 					DMC_INST_SI_BASE(dmc_inst, sys_if));
 	}
@@ -119,7 +119,7 @@ int tzc_dmc500_verify_complete(void)
 		for (dmc_inst = 0; dmc_inst < g_driver_data->dmc_count;
 								dmc_inst++) {
 			assert(DMC_INST_BASE_ADDR(dmc_inst));
-			for (sys_if = 0; sys_if < MAX_SYS_IF_COUNT;
+			for (sys_if = 0; sys_if < g_driver_data->sys_if_count;
 							sys_if++) {
 				attr = _tzc_dmc500_read_region_attr_0(
 					DMC_INST_SI_BASE(dmc_inst, sys_if),
@@ -154,7 +154,8 @@ void tzc_dmc500_configure_region0(tzc_region_attributes_t sec_attr,
 	/* Configure region_0 in all DMC instances */
 	for (dmc_inst = 0; dmc_inst < g_driver_data->dmc_count; dmc_inst++) {
 		assert(DMC_INST_BASE_ADDR(dmc_inst));
-		for (sys_if = 0; sys_if < MAX_SYS_IF_COUNT; sys_if++)
+		for (sys_if = 0; sys_if < g_driver_data->sys_if_count;
+				sys_if++)
 			_tzc_dmc500_configure_region0(
 					DMC_INST_SI_BASE(dmc_inst, sys_if),
 					sec_attr, nsaid_permissions);
@@ -195,7 +196,7 @@ void tzc_dmc500_configure_region(int region_no,
 
 	for (dmc_inst = 0; dmc_inst < g_driver_data->dmc_count; dmc_inst++) {
 		assert(DMC_INST_BASE_ADDR(dmc_inst));
-		for (sys_if = 0; sys_if < MAX_SYS_IF_COUNT; sys_if++)
+		for (sys_if = 0; sys_if < g_driver_data->sys_if_count; sys_if++)
 			_tzc_dmc500_configure_region(
 					DMC_INST_SI_BASE(dmc_inst, sys_if),
 					TZC_DMC500_REGION_ATTR_F_EN_MASK,
@@ -271,5 +272,13 @@ void tzc_dmc500_driver_init(const tzc_dmc500_driver_data_t *plat_driver_data)
 	 */
 	/* Validates the information passed by platform */
 	validate_plat_driver_data(plat_driver_data);
-	g_driver_data = plat_driver_data;
+
+	g_driver_data = (tzc_dmc500_driver_data_t *)plat_driver_data;
+
+	/* Check valid system interface count */
+	assert(g_driver_data->sys_if_count <= MAX_SYS_IF_COUNT);
+
+	/* If interface count is not present then assume max */
+	if (g_driver_data->sys_if_count == 0U)
+		g_driver_data->sys_if_count = MAX_SYS_IF_COUNT;
 }

--- a/include/drivers/arm/tzc_dmc500.h
+++ b/include/drivers/arm/tzc_dmc500.h
@@ -130,6 +130,7 @@
 typedef struct tzc_dmc500_driver_data {
 	uintptr_t dmc_base[MAX_DMC_COUNT];
 	int dmc_count;
+	unsigned int sys_if_count;
 } tzc_dmc500_driver_data_t;
 
 void tzc_dmc500_driver_init(const tzc_dmc500_driver_data_t *plat_driver_data);


### PR DESCRIPTION
Some low end platforms using DMC500 memory controller do not have
CCI(Cache Coherent Interconnect) interface and only have non-coherent
system interface support. Hence this patch makes the system interface
count configurable from the platforms.

Change-Id: I6d54c90eb72fd18026c6470c1f7fd26c59dc4b9a
Signed-off-by: Amit Daniel Kachhap <amit.kachhap@arm.com>