### PR TITLE
rockchip/rk3399: Fix sram_udelay

### DIFF
--- a/plat/rockchip/rk3399/drivers/dram/suspend.c
+++ b/plat/rockchip/rk3399/drivers/dram/suspend.c
@@ -85,10 +85,11 @@ static __pmusramfunc uint32_t sram_get_timer_value(void)
 
 static __pmusramfunc void sram_udelay(uint32_t usec)
 {
-	uint32_t start, cnt, delta, delta_us;
+	uint32_t start, cnt, delta, total_ticks;
 
 	/* counter is decreasing */
 	start = sram_get_timer_value();
+	total_ticks = usec * SYS_COUNTER_FREQ_IN_MHZ;
 	do {
 		cnt = sram_get_timer_value();
 		if (cnt > start) {
@@ -96,8 +97,7 @@ static __pmusramfunc void sram_udelay(uint32_t usec)
 			delta += start;
 		} else
 			delta = start - cnt;
-		delta_us = (delta * SYS_COUNTER_FREQ_IN_MHZ);
-	} while (delta_us < usec);
+	} while (delta <= total_ticks);
 }
 
 static __pmusramfunc void configure_sgrf(void)


### PR DESCRIPTION
This fixes an off by 576x bug the the sram_udelay code. The wrong
value was multipled by the system ticks per mhz value (which is 24),
so we delayed for 1/576th of the requested time.

Signed-off-by: Derek Basehore <dbasehore@chromium.org>