### PR TITLE
plat/arm: Add MHUv2 support to SCMI driver

### DIFF
--- a/plat/arm/css/common/css_common.mk
+++ b/plat/arm/css/common/css_common.mk
@@ -28,13 +28,14 @@ BL31_SOURCES		+=	plat/arm/css/common/css_pm.c			\
 
 ifeq (${CSS_USE_SCMI_SDS_DRIVER},0)
 BL31_SOURCES		+=	plat/arm/css/drivers/scp/css_pm_scpi.c		\
-				plat/arm/css/drivers/scpi/css_mhu.c		\
+				plat/arm/css/drivers/mhu/css_mhu.c		\
 				plat/arm/css/drivers/scpi/css_scpi.c
 else
 BL31_SOURCES		+=	plat/arm/css/drivers/scp/css_pm_scmi.c		\
 				plat/arm/css/drivers/scmi/scmi_common.c		\
 				plat/arm/css/drivers/scmi/scmi_pwr_dmn_proto.c	\
-				plat/arm/css/drivers/scmi/scmi_sys_pwr_proto.c
+				plat/arm/css/drivers/scmi/scmi_sys_pwr_proto.c	\
+				plat/arm/css/drivers/mhu/css_mhu_doorbell.c
 endif
 
 ifneq (${RESET_TO_BL31},0)
@@ -60,11 +61,11 @@ ifeq (${CSS_LOAD_SCP_IMAGES},1)
 				plat/arm/css/drivers/sds/sds.c
   else
     BL2U_SOURCES	+=	plat/arm/css/drivers/scp/css_bom_bootloader.c	\
-				plat/arm/css/drivers/scpi/css_mhu.c		\
+				plat/arm/css/drivers/mhu/css_mhu.c		\
 				plat/arm/css/drivers/scpi/css_scpi.c
 
     BL2_SOURCES		+=	plat/arm/css/drivers/scp/css_bom_bootloader.c	\
-				plat/arm/css/drivers/scpi/css_mhu.c		\
+				plat/arm/css/drivers/mhu/css_mhu.c		\
 				plat/arm/css/drivers/scpi/css_scpi.c
     # Enable option to detect whether the SCP ROM firmware in use predates version
     # 1.7.0 and therefore, is incompatible.

--- a/plat/arm/css/common/sp_min/css_sp_min.mk
+++ b/plat/arm/css/common/sp_min/css_sp_min.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -10,11 +10,12 @@ BL32_SOURCES		+=	plat/arm/css/common/css_pm.c			\
 
 ifeq (${CSS_USE_SCMI_SDS_DRIVER},0)
 BL32_SOURCES		+=	plat/arm/css/drivers/scp/css_pm_scpi.c		\
-				plat/arm/css/drivers/scpi/css_mhu.c		\
+				plat/arm/css/drivers/mhu/css_mhu.c		\
 				plat/arm/css/drivers/scpi/css_scpi.c
 else
 BL32_SOURCES		+=	plat/arm/css/drivers/scp/css_pm_scmi.c		\
 				plat/arm/css/drivers/scmi/scmi_common.c		\
 				plat/arm/css/drivers/scmi/scmi_pwr_dmn_proto.c	\
-				plat/arm/css/drivers/scmi/scmi_sys_pwr_proto.c
+				plat/arm/css/drivers/scmi/scmi_sys_pwr_proto.c	\
+				plat/arm/css/drivers/mhu/css_mhu_doorbell.c
 endif

--- a/plat/arm/css/drivers/mhu/css_mhu.c
+++ b/plat/arm/css/drivers/mhu/css_mhu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/plat/arm/css/drivers/mhu/css_mhu.h
+++ b/plat/arm/css/drivers/mhu/css_mhu.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */

--- a/plat/arm/css/drivers/mhu/css_mhu_doorbell.c
+++ b/plat/arm/css/drivers/mhu/css_mhu_doorbell.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2014-2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <arch_helpers.h>
+#include <platform_def.h>
+#include "css_mhu_doorbell.h"
+#include "../scmi/scmi.h"
+
+void mhu_ring_doorbell(scmi_channel_plat_info_t *plat_info)
+{
+	MHU_RING_DOORBELL(plat_info->db_reg_addr,
+			plat_info->db_modify_mask,
+			plat_info->db_preserve_mask);
+	return;
+}
+
+void mhuv2_ring_doorbell(scmi_channel_plat_info_t *plat_info)
+{
+	/* wake receiver */
+	MHU_V2_ACCESS_REQUEST(MHUV2_BASE_ADDR);
+
+	/* wait for receiver to acknowledge its ready */
+	while (MHU_V2_IS_ACCESS_READY(MHUV2_BASE_ADDR) == 0)
+		;
+
+	MHU_RING_DOORBELL(plat_info->db_reg_addr,
+			plat_info->db_modify_mask,
+			plat_info->db_preserve_mask);
+
+	/* clear the access request for the recevier */
+	MHU_V2_CLEAR_REQUEST(MHUV2_BASE_ADDR);
+
+	return;
+}

--- a/plat/arm/css/drivers/mhu/css_mhu_doorbell.h
+++ b/plat/arm/css/drivers/mhu/css_mhu_doorbell.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014-2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef CSS_MHU_DOORBELL_H
+#define CSS_MHU_DOORBELL_H
+
+#include <mmio.h>
+#include <stdint.h>
+
+/* MHUv2 Base Address */
+#define MHUV2_BASE_ADDR		PLAT_CSS_MHU_BASE
+
+/* MHUv2 Control Registers Offsets */
+#define MHU_V2_MSG_NO_CAP_OFFSET		0xF80
+#define MHU_V2_ACCESS_REQ_OFFSET		0xF88
+#define MHU_V2_ACCESS_READY_OFFSET		0xF8C
+
+#define SENDER_REG_STAT(CHANNEL)	(0x20 * (CHANNEL))
+#define SENDER_REG_SET(CHANNEL)		(0x20 * (CHANNEL)) + 0xC
+
+/* Helper macro to ring doorbell */
+#define MHU_RING_DOORBELL(addr, modify_mask, preserve_mask)	do {	\
+		uint32_t db = mmio_read_32(addr) & (preserve_mask);	\
+		mmio_write_32(addr, db | (modify_mask));		\
+	} while (0)
+
+#define MHU_V2_ACCESS_REQUEST(addr)	\
+	mmio_write_32((addr) + MHU_V2_ACCESS_REQ_OFFSET, 0x1)
+
+#define MHU_V2_CLEAR_REQUEST(addr)	\
+	mmio_write_32((addr) + MHU_V2_ACCESS_REQ_OFFSET, 0x0)
+
+#define MHU_V2_IS_ACCESS_READY(addr)	\
+	(mmio_read_32((addr) + MHU_V2_ACCESS_READY_OFFSET) & 0x1)
+
+struct scmi_channel_plat_info;
+void mhu_ring_doorbell(struct scmi_channel_plat_info *plat_info);
+void mhuv2_ring_doorbell(struct scmi_channel_plat_info *plat_info);
+
+#endif	/* CSS_MHU_DOORBELL_H */

--- a/plat/arm/css/drivers/scmi/scmi.h
+++ b/plat/arm/css/drivers/scmi/scmi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -96,6 +96,10 @@ typedef struct scmi_channel_plat_info {
 	uint32_t db_preserve_mask;
 	/* The bit mask that need to be set to ring doorbell */
 	uint32_t db_modify_mask;
+	/* The handler for ringing doorbell */
+	void (*ring_doorbell)(struct scmi_channel_plat_info *plat_info);
+	/* cookie is unused now. But added for future enhancements. */
+	void *cookie;
 } scmi_channel_plat_info_t;
 
 /*

--- a/plat/arm/css/drivers/scmi/scmi_common.c
+++ b/plat/arm/css/drivers/scmi/scmi_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -39,9 +39,7 @@ void scmi_send_sync_command(scmi_channel_t *ch)
 	 */
 	dmbst();
 
-	SCMI_RING_DOORBELL(ch->info->db_reg_addr, ch->info->db_modify_mask,
-					ch->info->db_preserve_mask);
-
+	ch->info->ring_doorbell(ch->info);
 	/*
 	 * Ensure that the write to the doorbell register is ordered prior to
 	 * checking whether the channel is free.
@@ -150,6 +148,7 @@ void *scmi_init(scmi_channel_t *ch)
 	assert(ch->info->db_reg_addr);
 	assert(ch->info->db_modify_mask);
 	assert(ch->info->db_preserve_mask);
+	assert(ch->info->ring_doorbell != NULL);
 
 	assert(ch->lock);
 

--- a/plat/arm/css/drivers/scmi/scmi_private.h
+++ b/plat/arm/css/drivers/scmi/scmi_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -111,12 +111,6 @@
 #define SCMI_PAYLOAD_RET_VAL3(payld_arr, val1, val2, val3)	do {	\
 		SCMI_PAYLOAD_RET_VAL2(payld_arr, val1, val2);		\
 		(val3) = mmio_read_32((uintptr_t)&payld_arr[2]);	\
-	} while (0)
-
-/* Helper macro to ring doorbell */
-#define SCMI_RING_DOORBELL(addr, modify_mask, preserve_mask)	do {	\
-		uint32_t db = mmio_read_32(addr) & (preserve_mask);	\
-		mmio_write_32(addr, db | (modify_mask));		\
 	} while (0)
 
 /*

--- a/plat/arm/css/drivers/scp/css_bom_bootloader.c
+++ b/plat/arm/css/drivers/scp/css_bom_bootloader.c
@@ -10,7 +10,7 @@
 #include <debug.h>
 #include <platform.h>
 #include <stdint.h>
-#include "../scpi/css_mhu.h"
+#include "../mhu/css_mhu.h"
 #include "../scpi/css_scpi.h"
 #include "css_scp.h"
 

--- a/plat/arm/css/drivers/scp/css_pm_scmi.c
+++ b/plat/arm/css/drivers/scp/css_pm_scmi.c
@@ -13,6 +13,7 @@
 #include <platform.h>
 #include <string.h>
 #include "../scmi/scmi.h"
+#include "../mhu/css_mhu_doorbell.h"
 #include "css_scp.h"
 
 /*
@@ -302,6 +303,7 @@ scmi_channel_plat_info_t plat_css_scmi_plat_info = {
 		.db_reg_addr = PLAT_CSS_MHU_BASE + CSS_SCMI_MHU_DB_REG_OFF,
 		.db_preserve_mask = 0xfffffffe,
 		.db_modify_mask = 0x1,
+		.ring_doorbell = &mhu_ring_doorbell,
 };
 
 void plat_arm_pwrc_setup(void)

--- a/plat/arm/css/drivers/scpi/css_scpi.c
+++ b/plat/arm/css/drivers/scpi/css_scpi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -11,7 +11,7 @@
 #include <platform.h>
 #include <string.h>
 #include <utils.h>
-#include "css_mhu.h"
+#include "../mhu/css_mhu.h"
 #include "css_scpi.h"
 
 #define SCPI_SHARED_MEM_SCP_TO_AP	PLAT_CSS_SCP_COM_SHARED_MEM_BASE


### PR DESCRIPTION
Currently the SCMI driver supports MHUv1, but Arm platforms may have
varied versions of MHU driver, with MHUv2 controllers being in the
latest Arm platforms.

This patch updates the SCMI driver to support MHUv2, specifically that
the sender must send the wake-up to the receiver before initiating any
data transfer.

Also, the existing mhu driver files, css_mhu.c and css_mhu.h, have been
moved from the scpi directory to a new directory, css/drivers/mhu.

Change-Id: I9b46b492a3e1d9e26db12d83a9773958a8c8402f
Signed-off-by: Samarth Parikh <samarth.parikh@arm.com>