### PR TITLE
css/sgi575: enable ARM_PLAT_MT flag

### DIFF
--- a/plat/arm/css/sgi/sgi-common.mk
+++ b/plat/arm/css/sgi/sgi-common.mk
@@ -45,6 +45,7 @@ $(eval $(call add_define,SGI_PLAT))
 override CSS_LOAD_SCP_IMAGES	:=	0
 override NEED_BL2U		:=	no
 override ARM_BL31_IN_DRAM	:=	1
+override ARM_PLAT_MT		:=	1
 
 # System coherency is managed in hardware
 HW_ASSISTED_COHERENCY	:=	1


### PR DESCRIPTION
SGI-575 platform is based on Cortex-A75 processor which has its MT bit
in the MPIDR register set to '1'. So the Arm platform layer code has
to be made aware of this.

Signed-off-by: Sudipto Paul <sudipto.paul@arm.com>