### PR TITLE
Ensure read and write of flags defined in the console struct are 32 bit

### DIFF
--- a/drivers/console/aarch64/multi_console.S
+++ b/drivers/console/aarch64/multi_console.S
@@ -200,7 +200,7 @@ putc_loop:
 	cbz	x14, putc_done
 	adrp	x1, console_state
 	ldrb	w1, [x1, :lo12:console_state]
-	ldr	x2, [x14, #CONSOLE_T_FLAGS]
+	ldr	w2, [x14, #CONSOLE_T_FLAGS]
 	tst	w1, w2
 	b.eq	putc_continue
 	ldr	x2, [x14, #CONSOLE_T_PUTC]
@@ -246,7 +246,7 @@ getc_try_again:
 getc_loop:
 	adrp	x0, console_state
 	ldrb	w0, [x0, :lo12:console_state]
-	ldr	x1, [x14, #CONSOLE_T_FLAGS]
+	ldr	w1, [x14, #CONSOLE_T_FLAGS]
 	tst	w0, w1
 	b.eq	getc_continue
 	ldr	x1, [x14, #CONSOLE_T_GETC]
@@ -287,7 +287,7 @@ flush_loop:
 	cbz	x14, flush_done
 	adrp	x1, console_state
 	ldrb	w1, [x1, :lo12:console_state]
-	ldr	x2, [x14, #CONSOLE_T_FLAGS]
+	ldr	w2, [x14, #CONSOLE_T_FLAGS]
 	tst	w1, w2
 	b.eq	flush_continue
 	ldr	x1, [x14, #CONSOLE_T_FLUSH]

--- a/include/drivers/console.h
+++ b/include/drivers/console.h
@@ -34,13 +34,17 @@
 
 typedef struct console {
 	struct console *next;
+	/*
+	 * Only the low 32 bits are used. The type is u_register_t to align the
+	 * fields of the struct to 64 bits in AArch64 and 32 bits in AArch32
+	 */
 	u_register_t flags;
 	int (*putc)(int character, struct console *console);
 	int (*getc)(struct console *console);
 	int (*flush)(struct console *console);
 	/* Additional private driver data may follow here. */
 } console_t;
-#include <console_assertions.h>	/* offset macro assertions for console_t */
+#include <console_assertions.h> /* offset macro assertions for console_t */
 
 /*
  * NOTE: There is no publicly accessible console_register() function. Consoles


### PR DESCRIPTION
Change type of scope from unsigned int to match the type of flags in console_t