### PR TITLE
Remove dtc warnings

### DIFF
--- a/fdts/fvp-base-gicv3-psci-common.dtsi
+++ b/fdts/fvp-base-gicv3-psci-common.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -228,7 +228,7 @@
 			     <0 63 4>;
 	};
 
-	smb {
+	smb@0,0 {
 		compatible = "simple-bus";
 
 		#address-cells = <2>;
@@ -244,7 +244,7 @@
 	};
 
 	panels {
-		panel@0 {
+		panel {
 			compatible	= "panel";
 			mode		= "XVGA";
 			refresh		= <60>;

--- a/fdts/fvp-foundation-motherboard.dtsi
+++ b/fdts/fvp-foundation-motherboard.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -44,14 +44,14 @@
 			#size-cells = <1>;
 			ranges = <0 3 0 0x200000>;
 
-			v2m_sysreg: sysreg@010000 {
+			v2m_sysreg: sysreg@10000 {
 				compatible = "arm,vexpress-sysreg";
 				reg = <0x010000 0x1000>;
 				gpio-controller;
 				#gpio-cells = <2>;
 			};
 
-			v2m_sysctl: sysctl@020000 {
+			v2m_sysctl: sysctl@20000 {
 				compatible = "arm,sp810", "arm,primecell";
 				reg = <0x020000 0x1000>;
 				clocks = <&v2m_refclk32khz>, <&v2m_refclk1mhz>, <&v2m_clk24mhz>;
@@ -60,7 +60,7 @@
 				clock-output-names = "timerclken0", "timerclken1", "timerclken2", "timerclken3";
 			};
 
-			v2m_serial0: uart@090000 {
+			v2m_serial0: uart@90000 {
 				compatible = "arm,pl011", "arm,primecell";
 				reg = <0x090000 0x1000>;
 				interrupts = <0 5 4>;
@@ -68,7 +68,7 @@
 				clock-names = "uartclk", "apb_pclk";
 			};
 
-			v2m_serial1: uart@0a0000 {
+			v2m_serial1: uart@a0000 {
 				compatible = "arm,pl011", "arm,primecell";
 				reg = <0x0a0000 0x1000>;
 				interrupts = <0 6 4>;
@@ -76,7 +76,7 @@
 				clock-names = "uartclk", "apb_pclk";
 			};
 
-			v2m_serial2: uart@0b0000 {
+			v2m_serial2: uart@b0000 {
 				compatible = "arm,pl011", "arm,primecell";
 				reg = <0x0b0000 0x1000>;
 				interrupts = <0 7 4>;
@@ -84,7 +84,7 @@
 				clock-names = "uartclk", "apb_pclk";
 			};
 
-			v2m_serial3: uart@0c0000 {
+			v2m_serial3: uart@c0000 {
 				compatible = "arm,pl011", "arm,primecell";
 				reg = <0x0c0000 0x1000>;
 				interrupts = <0 8 4>;
@@ -92,7 +92,7 @@
 				clock-names = "uartclk", "apb_pclk";
 			};
 
-			wdt@0f0000 {
+			wdt@f0000 {
 				compatible = "arm,sp805", "arm,primecell";
 				reg = <0x0f0000 0x1000>;
 				interrupts = <0 0 4>;
@@ -124,7 +124,7 @@
 				clock-names = "apb_pclk";
 			};
 
-			virtio_block@0130000 {
+			virtio_block@130000 {
 				compatible = "virtio,mmio";
 				reg = <0x130000 0x1000>;
 				interrupts = <0 0x2a 4>;

--- a/fdts/rtsm_ve-motherboard-aarch32.dtsi
+++ b/fdts/rtsm_ve-motherboard-aarch32.dtsi
@@ -57,14 +57,14 @@
 			#size-cells = <1>;
 			ranges = <0 3 0 0x200000>;
 
-			v2m_sysreg: sysreg@010000 {
+			v2m_sysreg: sysreg@10000 {
 				compatible = "arm,vexpress-sysreg";
 				reg = <0x010000 0x1000>;
 				gpio-controller;
 				#gpio-cells = <2>;
 			};
 
-			v2m_sysctl: sysctl@020000 {
+			v2m_sysctl: sysctl@20000 {
 				compatible = "arm,sp810", "arm,primecell";
 				reg = <0x020000 0x1000>;
 				clocks = <&v2m_refclk32khz>, <&v2m_refclk1mhz>, <&v2m_clk24mhz>;
@@ -73,7 +73,7 @@
 				clock-output-names = "timerclken0", "timerclken1", "timerclken2", "timerclken3";
 			};
 
-			aaci@040000 {
+			aaci@40000 {
 				compatible = "arm,pl041", "arm,primecell";
 				reg = <0x040000 0x1000>;
 				interrupts = <11>;
@@ -81,7 +81,7 @@
 				clock-names = "apb_pclk";
 			};
 
-			mmci@050000 {
+			mmci@50000 {
 				compatible = "arm,pl180", "arm,primecell";
 				reg = <0x050000 0x1000>;
 				interrupts = <9 10>;
@@ -93,7 +93,7 @@
 				clock-names = "mclk", "apb_pclk";
 			};
 
-			kmi@060000 {
+			kmi@60000 {
 				compatible = "arm,pl050", "arm,primecell";
 				reg = <0x060000 0x1000>;
 				interrupts = <12>;
@@ -101,7 +101,7 @@
 				clock-names = "KMIREFCLK", "apb_pclk";
 			};
 
-			kmi@070000 {
+			kmi@70000 {
 				compatible = "arm,pl050", "arm,primecell";
 				reg = <0x070000 0x1000>;
 				interrupts = <13>;
@@ -109,7 +109,7 @@
 				clock-names = "KMIREFCLK", "apb_pclk";
 			};
 
-			v2m_serial0: uart@090000 {
+			v2m_serial0: uart@90000 {
 				compatible = "arm,pl011", "arm,primecell";
 				reg = <0x090000 0x1000>;
 				interrupts = <5>;
@@ -117,7 +117,7 @@
 				clock-names = "uartclk", "apb_pclk";
 			};
 
-			v2m_serial1: uart@0a0000 {
+			v2m_serial1: uart@a0000 {
 				compatible = "arm,pl011", "arm,primecell";
 				reg = <0x0a0000 0x1000>;
 				interrupts = <6>;
@@ -125,7 +125,7 @@
 				clock-names = "uartclk", "apb_pclk";
 			};
 
-			v2m_serial2: uart@0b0000 {
+			v2m_serial2: uart@b0000 {
 				compatible = "arm,pl011", "arm,primecell";
 				reg = <0x0b0000 0x1000>;
 				interrupts = <7>;
@@ -133,7 +133,7 @@
 				clock-names = "uartclk", "apb_pclk";
 			};
 
-			v2m_serial3: uart@0c0000 {
+			v2m_serial3: uart@c0000 {
 				compatible = "arm,pl011", "arm,primecell";
 				reg = <0x0c0000 0x1000>;
 				interrupts = <8>;
@@ -141,7 +141,7 @@
 				clock-names = "uartclk", "apb_pclk";
 			};
 
-			wdt@0f0000 {
+			wdt@f0000 {
 				compatible = "arm,sp805", "arm,primecell";
 				reg = <0x0f0000 0x1000>;
 				interrupts = <0>;
@@ -184,7 +184,7 @@
 				framebuffer = <0x18000000 0x00180000>;
 			};
 
-			virtio_block@0130000 {
+			virtio_block@130000 {
 				compatible = "virtio,mmio";
 				reg = <0x130000 0x1000>;
 				interrupts = <0x2a>;

--- a/fdts/rtsm_ve-motherboard.dtsi
+++ b/fdts/rtsm_ve-motherboard.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -56,14 +56,14 @@
 			#size-cells = <1>;
 			ranges = <0 3 0 0x200000>;
 
-			v2m_sysreg: sysreg@010000 {
+			v2m_sysreg: sysreg@10000 {
 				compatible = "arm,vexpress-sysreg";
 				reg = <0x010000 0x1000>;
 				gpio-controller;
 				#gpio-cells = <2>;
 			};
 
-			v2m_sysctl: sysctl@020000 {
+			v2m_sysctl: sysctl@20000 {
 				compatible = "arm,sp810", "arm,primecell";
 				reg = <0x020000 0x1000>;
 				clocks = <&v2m_refclk32khz>, <&v2m_refclk1mhz>, <&v2m_clk24mhz>;
@@ -72,7 +72,7 @@
 				clock-output-names = "timerclken0", "timerclken1", "timerclken2", "timerclken3";
 			};
 
-			aaci@040000 {
+			aaci@40000 {
 				compatible = "arm,pl041", "arm,primecell";
 				reg = <0x040000 0x1000>;
 				interrupts = <0 11 4>;
@@ -80,7 +80,7 @@
 				clock-names = "apb_pclk";
 			};
 
-			mmci@050000 {
+			mmci@50000 {
 				compatible = "arm,pl180", "arm,primecell";
 				reg = <0x050000 0x1000>;
 				interrupts = <0 9 4 0 10 4>;
@@ -92,7 +92,7 @@
 				clock-names = "mclk", "apb_pclk";
 			};
 
-			kmi@060000 {
+			kmi@60000 {
 				compatible = "arm,pl050", "arm,primecell";
 				reg = <0x060000 0x1000>;
 				interrupts = <0 12 4>;
@@ -100,7 +100,7 @@
 				clock-names = "KMIREFCLK", "apb_pclk";
 			};
 
-			kmi@070000 {
+			kmi@70000 {
 				compatible = "arm,pl050", "arm,primecell";
 				reg = <0x070000 0x1000>;
 				interrupts = <0 13 4>;
@@ -108,7 +108,7 @@
 				clock-names = "KMIREFCLK", "apb_pclk";
 			};
 
-			v2m_serial0: uart@090000 {
+			v2m_serial0: uart@90000 {
 				compatible = "arm,pl011", "arm,primecell";
 				reg = <0x090000 0x1000>;
 				interrupts = <0 5 4>;
@@ -116,7 +116,7 @@
 				clock-names = "uartclk", "apb_pclk";
 			};
 
-			v2m_serial1: uart@0a0000 {
+			v2m_serial1: uart@a0000 {
 				compatible = "arm,pl011", "arm,primecell";
 				reg = <0x0a0000 0x1000>;
 				interrupts = <0 6 4>;
@@ -124,7 +124,7 @@
 				clock-names = "uartclk", "apb_pclk";
 			};
 
-			v2m_serial2: uart@0b0000 {
+			v2m_serial2: uart@b0000 {
 				compatible = "arm,pl011", "arm,primecell";
 				reg = <0x0b0000 0x1000>;
 				interrupts = <0 7 4>;
@@ -132,7 +132,7 @@
 				clock-names = "uartclk", "apb_pclk";
 			};
 
-			v2m_serial3: uart@0c0000 {
+			v2m_serial3: uart@c0000 {
 				compatible = "arm,pl011", "arm,primecell";
 				reg = <0x0c0000 0x1000>;
 				interrupts = <0 8 4>;
@@ -140,7 +140,7 @@
 				clock-names = "uartclk", "apb_pclk";
 			};
 
-			wdt@0f0000 {
+			wdt@f0000 {
 				compatible = "arm,sp805", "arm,primecell";
 				reg = <0x0f0000 0x1000>;
 				interrupts = <0 0 4>;
@@ -183,14 +183,14 @@
 				framebuffer = <0x18000000 0x00180000>;
 			};
 
-			virtio_block@0130000 {
+			virtio_block@130000 {
 				compatible = "virtio,mmio";
 				reg = <0x130000 0x1000>;
 				interrupts = <0 0x2a 4>;
 			};
 		};
 
-		v2m_fixed_3v3: fixedregulator@0 {
+		v2m_fixed_3v3: fixedregulator {
 			compatible = "regulator-fixed";
 			regulator-name = "3V3";
 			regulator-min-microvolt = <3300000>;
@@ -202,7 +202,7 @@
 			compatible = "arm,vexpress,config-bus", "simple-bus";
 			arm,vexpress,config-bridge = <&v2m_sysreg>;
 
-			v2m_oscclk1: osc@1 {
+			v2m_oscclk1: osc {
 				/* CLCD clock */
 				compatible = "arm,vexpress-osc";
 				arm,vexpress-sysreg,func = <1 1>;
@@ -220,7 +220,7 @@
 			 * };
 			 */
 
-			muxfpga@0 {
+			muxfpga {
 				compatible = "arm,vexpress-muxfpga";
 				arm,vexpress-sysreg,func = <7 0>;
 			};
@@ -243,7 +243,7 @@
 			 * };
 			 */
 
-			dvimode@0 {
+			dvimode {
 				compatible = "arm,vexpress-dvimode";
 				arm,vexpress-sysreg,func = <11 0>;
 			};


### PR DESCRIPTION
DTC generates warnings when unit names begin with 0, or
when a node containing a reg or range property doesn't have a unit name
in the node name. This patch fixes those cases.

Change-Id: If24ec68ef3034fb3fcefb96c5625c47a0bbd8474
Signed-off-by: Roberto Vargas <roberto.vargas@arm.com>