### PR TITLE
xlat: Set AP[1] to 1 when it is RES1

### DIFF
--- a/include/lib/xlat_tables/xlat_tables_defs.h
+++ b/include/lib/xlat_tables/xlat_tables_defs.h
@@ -107,10 +107,8 @@
  * Permissions bits, and does not define an AP[0] bit.
  *
  * AP[1] is valid only for a stage 1 translation that supports two VA ranges
- * (i.e. in the ARMv8A.0 architecture, that is the S-EL1&0 regime).
- *
- * AP[1] is RES0 for stage 1 translations that support only one VA range
- * (e.g. EL3).
+ * (i.e. in the ARMv8A.0 architecture, that is the S-EL1&0 regime). It is RES1
+ * when stage 1 translations can only support one VA range.
  */
 #define AP2_SHIFT			U(0x7)
 #define AP2_RO				U(0x1)
@@ -119,6 +117,7 @@
 #define AP1_SHIFT			U(0x6)
 #define AP1_ACCESS_UNPRIVILEGED		U(0x1)
 #define AP1_NO_ACCESS_UNPRIVILEGED	U(0x0)
+#define AP1_RES1			U(0x1)
 
 /*
  * The following definitions must all be passed to the LOWER_ATTRS() macro to
@@ -128,6 +127,7 @@
 #define AP_RW				(AP2_RW << 5)
 #define AP_ACCESS_UNPRIVILEGED		(AP1_ACCESS_UNPRIVILEGED    << 4)
 #define AP_NO_ACCESS_UNPRIVILEGED	(AP1_NO_ACCESS_UNPRIVILEGED << 4)
+#define AP_ONE_VA_RANGE_RES1		(AP1_RES1 << 4)
 #define NS				(U(0x1) << 3)
 #define ATTR_NON_CACHEABLE_INDEX	U(0x2)
 #define ATTR_DEVICE_INDEX		U(0x1)

--- a/lib/xlat_tables_v2/xlat_tables_internal.c
+++ b/lib/xlat_tables_v2/xlat_tables_internal.c
@@ -155,7 +155,7 @@ static uint64_t xlat_desc(const xlat_ctx_t *ctx, uint32_t attr,
 		}
 	} else {
 		assert(ctx->xlat_regime == EL3_REGIME);
-		desc |= LOWER_ATTRS(AP_NO_ACCESS_UNPRIVILEGED);
+		desc |= LOWER_ATTRS(AP_ONE_VA_RANGE_RES1);
 	}
 
 	/*


### PR DESCRIPTION
According to the ARMv8 ARM issue C.a:

    AP[1] is valid only for stage 1 of a translation regime that can
    support two VA ranges. It is RES 1 when stage 1 translations can
    support only one VA range.

This means that, even though this bit is ignored, it should be set to 1 in the EL3 and EL2 translation regimes.

For translation regimes consisting on EL0 and a higher regime this bit selects between control at EL0 or at the higher Exception level. The regimes that support two VA ranges are EL1&0 and EL2&0 (the later one is only available since ARMv8.1).

This fix has to be applied to both versions of the translation tables library.