### PR TITLE
BL2_AT_EL3: do not try to disable MMU twice on AARCH32

### DIFF
--- a/bl2/bl2_main.c
+++ b/bl2/bl2_main.c
@@ -46,6 +46,7 @@ void bl2_main(void)
 	/* Load the subsequent bootloader images. */
 	next_bl_ep_info = bl2_load_images();
 
+#if !BL2_AT_EL3
 #ifdef AARCH32
 	/*
 	 * For AArch32 state BL1 and BL2 share the MMU setup.
@@ -55,8 +56,6 @@ void bl2_main(void)
 	disable_mmu_icache_secure();
 #endif /* AARCH32 */
 
-
-#if !BL2_AT_EL3
 	console_flush();
 
 	/*


### PR DESCRIPTION
If BL2_AT_EL3 is enabled, bl2_run_next_image is called at the end of BL2.
This function calls disable_mmu_icache_secure.
It is then useless to call it in bl2_main in that case.

fixes arm-software/tf-issues#582

Signed-off-by: Yann Gautier <yann.gautier@st.com>