### PR TITLE
Fix the makefile to remove the cert_create executable on 'make realclean'

### DIFF
--- a/tools/cert_create/Makefile
+++ b/tools/cert_create/Makefile
@@ -86,5 +86,5 @@ clean:
 	$(call SHELL_DELETE_ALL, src/build_msg.o ${OBJECTS})
 
 realclean: clean
-	$(call SHELL_DELETE, ${BINARY})
+	$(call SHELL_DELETE,${BINARY})
 


### PR DESCRIPTION
Spurious whitespace existed in the BINARY shell variable which meant
the cert_tool executable was not being removed on 'make realclean'.

Change-Id: Ibfd2fd17889514f6613e33c6df58d53b9232ec14
Signed-off-by: Jonathan Wright <jonathan.wright@arm.com>