### PR TITLE
checkpatch: Ignore SPDX_LICENSE_TAG

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -36,6 +36,10 @@
 # This is not Linux so don't expect a Linux tree!
 --no-tree
 
+# The Linux kernel expects the SPDX license tag in the first line of each file.
+# We don't follow this in the Trusted Firmware.
+--ignore SPDX_LICENSE_TAG
+
 # This clarifes the lines indications in the report.
 #
 # E.g.:


### PR DESCRIPTION
The Linux kernel expects the SPDX license tag in the first line of each source code file in a comment.

In the context of the Linux kernel repository this makes sense because they have many different license headers across their codebase. Moving the tag to the first line of the source code files makes it easier for analyzers to see the license of each file.

In the Trusted Firmware, we control all headers and make sure that they follow the same pattern, so this is not needed.

Fixes: https://github.com/ARM-software/tf-issues/issues/581