### PR TITLE
Remove the unused macro NDEBUG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,6 @@ ifneq (${DEBUG}, 0)
         LOG_LEVEL	:=	40
 else
         BUILD_TYPE	:=	release
-        $(eval $(call add_define,NDEBUG))
         # Use LOG_LEVEL_NOTICE by default for release builds
         LOG_LEVEL	:=	20
 endif


### PR DESCRIPTION
The C standards specify that this macro is used to
disable asserts but, in our code, the assert macro
is controlled with ENABLE_ASSERTIONS. Having this macro
here creates confusion about the behaviour of assert.

Change-Id: Iab8689a14dc2b8790729857d56585ce43c0c4f51
Signed-off-by: Roberto Vargas <roberto.vargas@arm.com>