### PR TITLE
xlat: Have all values of PARange for 8.x architectures

### DIFF
--- a/lib/xlat_tables/aarch64/xlat_tables.c
+++ b/lib/xlat_tables/aarch64/xlat_tables.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -57,13 +57,13 @@ static unsigned long long calc_physical_addr_size_bits(
 }
 
 #if ENABLE_ASSERTIONS
-/* Physical Address ranges supported in the AArch64 Memory Model */
+/*
+ * Physical Address ranges supported in the AArch64 Memory Model. Value 0b110 is
+ * supported in ARMv8.2 onwards.
+ */
 static const unsigned int pa_range_bits_arr[] = {
 	PARANGE_0000, PARANGE_0001, PARANGE_0010, PARANGE_0011, PARANGE_0100,
-	PARANGE_0101,
-#if ARM_ARCH_AT_LEAST(8, 2)
-	PARANGE_0110,
-#endif
+	PARANGE_0101, PARANGE_0110
 };
 
 static unsigned long long get_max_supported_pa(void)

--- a/lib/xlat_tables_v2/aarch64/xlat_tables_arch.c
+++ b/lib/xlat_tables_v2/aarch64/xlat_tables_arch.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -45,13 +45,13 @@ unsigned long long tcr_physical_addr_size_bits(unsigned long long max_addr)
 }
 
 #if ENABLE_ASSERTIONS
-/* Physical Address ranges supported in the AArch64 Memory Model */
+/*
+ * Physical Address ranges supported in the AArch64 Memory Model. Value 0b110 is
+ * supported in ARMv8.2 onwards.
+ */
 static const unsigned int pa_range_bits_arr[] = {
 	PARANGE_0000, PARANGE_0001, PARANGE_0010, PARANGE_0011, PARANGE_0100,
-	PARANGE_0101,
-#if ARM_ARCH_AT_LEAST(8, 2)
-	PARANGE_0110,
-#endif
+	PARANGE_0101, PARANGE_0110
 };
 
 unsigned long long xlat_arch_get_max_supported_pa(void)


### PR DESCRIPTION
In AArch64, the field ID_AA64MMFR0_EL1.PARange has a different set of allowed values depending on the architecture version.

Previously, we only compiled the Trusted Firmware with the values that were allowed by the architecture. However, given that this field is read-only, it is easier to compile the code with all values regardless of the target architecture.