### PR TITLE
Fix memory leaks in fiptool

### DIFF
--- a/tools/fiptool/fiptool.c
+++ b/tools/fiptool/fiptool.c
@@ -169,7 +169,10 @@ static void free_image_desc(image_desc_t *desc)
 	free(desc->name);
 	free(desc->cmdline_name);
 	free(desc->action_arg);
-	free(desc->image);
+	if (desc->image) {
+		free(desc->image->buffer);
+		free(desc->image);
+	}
 	free(desc);
 }
 


### PR DESCRIPTION
Free desc->image->buffer before freeing desc->image. We make sure that
the desc->image is non-null before attempting this.

Change-Id: I35c5674629a41d7cf1a78b7b41ca4b930d0fb688
Signed-off-by: Jonathan Wright <jonathan.wright@arm.com>