### PR TITLE
lib: el3_runtime: initialise actlr_el1 to hardware defaults

### DIFF
--- a/lib/el3_runtime/aarch64/context_mgmt.c
+++ b/lib/el3_runtime/aarch64/context_mgmt.c
@@ -65,7 +65,7 @@ static void cm_init_context_common(cpu_context_t *ctx, const entry_point_info_t 
 	uint32_t scr_el3, pmcr_el0;
 	el3_state_t *state;
 	gp_regs_t *gp_regs;
-	unsigned long sctlr_elx;
+	unsigned long sctlr_elx, actlr_elx;
 
 	assert(ctx);
 
@@ -172,6 +172,16 @@ static void cm_init_context_common(cpu_context_t *ctx, const entry_point_info_t 
 	 * are not part of the stored cpu_context.
 	 */
 	write_ctx_reg(get_sysregs_ctx(ctx), CTX_SCTLR_EL1, sctlr_elx);
+
+	/*
+	 * Base the context ACTLR_EL1 on the current value, as it is
+	 * implementation defined. The context restore process will write
+	 * the value from the context to the actual register and can cause
+	 * problems for processor cores that don't expect certain bits to
+	 * be zero.
+	 */
+	actlr_elx = read_actlr_el1();
+	write_ctx_reg((get_sysregs_ctx(ctx)), (CTX_ACTLR_EL1), (actlr_elx));
 
 	if (security_state == SECURE) {
 		/*


### PR DESCRIPTION
The context management library initialises the CPU context for the
secure/non-secure worlds to zero. This leads to zeros being stored
to the actual registers when we restore the CPU context, during a
world switch. Denver CPUs dont expect zero to be written to the
implementation defined, actlr_el1 register, at any point of time.
Writing a zero to some fields of this register, results in an
UNDEFINED exception.

This patch bases the context actlr_el1 value on the actual hardware
register, to maintain parity with the expected settings

Change-Id: I1c806d7ff12daa7fd1e5c72825494b81454948f2
Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>