### PR TITLE
SPM: Do not trap S-EL0 access to SVE/SIMD/FP regs

### DIFF
--- a/services/std_svc/spm/secure_partition_setup.c
+++ b/services/std_svc/spm/secure_partition_setup.c
@@ -236,12 +236,14 @@ void secure_partition_setup(void)
 			SPM_SHIM_EXCEPTIONS_PTR);
 
 	/*
-	 * FPEN: Forbid the Secure Partition to access FP/SIMD registers.
+	 * FPEN: Allow the Secure Partition to access FP/SIMD registers.
+	 * Note that SPM will not do any saving/restoring of these registers on
+	 * behalf of the SP. This falls under the SP's responsibility.
 	 * TTA: Enable access to trace registers.
 	 * ZEN (v8.2): Trap SVE instructions and access to SVE registers.
 	 */
 	write_ctx_reg(get_sysregs_ctx(ctx), CTX_CPACR_EL1,
-			CPACR_EL1_FPEN(CPACR_EL1_FP_TRAP_ALL));
+			CPACR_EL1_FPEN(CPACR_EL1_FP_TRAP_NONE));
 
 	/*
 	 * Prepare information in buffer shared between EL3 and S-EL0


### PR DESCRIPTION
This allows secure partitions to access these registers. This is
needed in some cases. For example, it has been reported that in order
to implement secure storage services, a secure partition needs to
encrypt/decrypt some authentication variables, which requires FP/SIMD
support.

Note that SPM will not do any saving/restoring of these registers on
behalf of the SP. This falls under the SP's responsibility.

Also note that if the SP gets preempted, it might not get a chance to
save/restore FP/SIMD registers first. This patch does not address this
problem. It only serves as a temporary solution to unblock development
on the secure partition side.
