### PR TITLE
MISRA rule 21.15 fix

### DIFF
--- a/lib/xlat_tables_v2/xlat_tables_internal.c
+++ b/lib/xlat_tables_v2/xlat_tables_internal.c
@@ -735,7 +735,7 @@ static int mmap_add_region_check(xlat_ctx_t *ctx, const mmap_region_t *mm)
 
 void mmap_add_region_ctx(xlat_ctx_t *ctx, const mmap_region_t *mm)
 {
-	mmap_region_t *mm_cursor = ctx->mmap;
+	mmap_region_t *mm_cursor = ctx->mmap, *mm_destination;
 	const mmap_region_t *mm_end = ctx->mmap + ctx->mmap_num;
 	mmap_region_t *mm_last;
 	unsigned long long end_pa = mm->base_pa + mm->size - 1;
@@ -802,9 +802,10 @@ void mmap_add_region_ctx(xlat_ctx_t *ctx, const mmap_region_t *mm)
 	 * that there is free space.
 	 */
 	assert(mm_last->size == 0U);
-
+	
 	/* Make room for new region by moving other regions up by one place */
-	memmove(mm_cursor + 1, mm_cursor,
+	mm_destination = mm_cursor + 1;
+	memmove(mm_destination, mm_cursor,
 		(uintptr_t)mm_last - (uintptr_t)mm_cursor);
 
 	/*


### PR DESCRIPTION
Rule 21.15: The pointer arguments to the Standard Library functions
memcpy, memmove and memcmp shall be pointers to qualified or unqualified
versions of compatible types.

Basically that means that both pointer arguments must be of the same
type. However, even if the pointers passed as arguments to the above
functions are of the same type, Coverity still thinks it's a violation
if we do pointer arithmetics directly at the function call. Thus the
pointer arithmetic operations were moved outside of the function
argument.

First detected on the following configuration
        make PLAT=fvp LOG_LEVEL=50