### PR TITLE
drivers: ti: uart: Add TI specific 16550 initialization

### DIFF
--- a/drivers/ti/uart/aarch64/16550_console.S
+++ b/drivers/ti/uart/aarch64/16550_console.S
@@ -66,6 +66,10 @@ func console_16550_core_init
 	/* no interrupt */
 	mov	w3, #0
 	str	w3, [x0, #UARTIER]
+#ifdef TI_16550_MDR_QUIRK
+	/* UART must be enabled on some platforms via the MDR register */
+	str	w3, [x0, #UARTMDR1]
+#endif /* TI_16550_MDR_QUIRK */
 	/* enable fifo, DMA */
 	mov	w3, #(UARTFCR_FIFOEN | UARTFCR_DMAEN)
 	str	w3, [x0, #UARTFCR]

--- a/include/drivers/ti/uart/uart_16550.h
+++ b/include/drivers/ti/uart/uart_16550.h
@@ -23,6 +23,8 @@
 #define UARTMSR			0x18
 #define UARTSPR			0x1c
 #define UARTCSR			0x20
+/* Some instances have MDR1 defined as well */
+#define UARTMDR1		0x20
 #define UARTRXFIFOCFG		0x24
 #define UARTMIE			0x28
 #define UARTVNDR		0x2c


### PR DESCRIPTION
On TI platforms the UART is disabled by default and must be explicitly
enabled using the MDR1 register.

NOTE: The original definition of
http://www.ti.com/lit/ds/symlink/pc16550d.pdf has no MDR register, but
many TI SoCs implementing 16550 do have a quirky MDR register
implemented. So, this should be enabled with TI_16550_MDR_QUIRK

NOTE: In such implementation, the CSR register does not exist.