### PR TITLE
invalid DCache of stack before we use it

### DIFF
--- a/bl31/aarch64/bl31_entrypoint.S
+++ b/bl31/aarch64/bl31_entrypoint.S
@@ -155,6 +155,39 @@ func bl31_warm_entrypoint
 		_exception_vectors=runtime_exceptions
 
 	/*
+	 * On the warm boot path, when we use HW_ASSISTED_COHERENCY options
+	 * We have to invalid DCache of stack before we use it
+	 * Becasue, when last core power down, the stack content maybe still
+	 *  valid in uncore level DCache(such as L3 DCache)
+	 * At some situation, we may meet memory corruption if we don't invalid it
+	 * Say:
+	 * -> the core prepare power down
+	 * -> WFI
+	 * -> HW flush cache to uncore level(e.g. L3)
+	 * -> power down
+	 * -> (...idle...)
+	 * -> wake up
+	 * -> run to here set the stack <-
+	 * -> later use, write stack (e.g. call function, bl)
+	 * -> {Placeholder A}
+	 * -> return, read stack {Placeholder B}
+	 * Sometimes, if the stack memory stay in uncore level DCache till
+	 * at {Placeholder A} (NOTES: We write the stack memory already).
+	 * So, at this time, We have two copy of stack content
+	 * - First, uncore level DCache copy, its corruption data
+	 * - Second, the main memory copy, its flesh
+	 * Meanwhile, if the uncore level DCache needs replacement
+	 *  and, unfortunately, the stack corruption data just flush out
+	 * OOPS, when we get to pop from stack and return function
+	 * exception will be meet at {Placeholder B}
+	 *
+	 * and, before we enable DCache, we must make sure invalid the stack
+	 */
+#if HW_ASSISTED_COHERENCY || WARMBOOT_ENABLE_DCACHE_EARLY
+	bl	plat_inv_my_stack
+#endif
+
+	/*
 	 * We're about to enable MMU and participate in PSCI state coordination.
 	 *
 	 * The PSCI implementation invokes platform routines that enable CPUs to

--- a/plat/common/aarch32/platform_mp_stack.S
+++ b/plat/common/aarch32/platform_mp_stack.S
@@ -10,6 +10,7 @@
 
 	.weak	plat_get_my_stack
 	.weak	plat_set_my_stack
+	.weak	plat_inv_my_stack
 
 	/* -----------------------------------------------------
 	 * uintptr_t plat_get_my_stack (u_register_t mpidr)
@@ -37,6 +38,21 @@ func plat_set_my_stack
 	mov	sp, r0
 	bx	r4
 endfunc plat_set_my_stack
+
+	/* -----------------------------------------------------
+	 * void plat_inv_my_stack ()
+	 *
+	 * For the current CPU, this function invalid the stack
+	 * pointer to a stack allocated in normal memory.
+	 * -----------------------------------------------------
+	 */
+func plat_inv_my_stack
+	mov	r4, lr
+	get_my_mp_stack platform_normal_stacks, PLATFORM_STACK_SIZE
+	sub	r0, r0, r1
+	bl	inv_dcache_range
+	bx	r4
+endfunc plat_inv_my_stack
 
 	/* -----------------------------------------------------
 	 * Per-cpu stacks in normal memory. Each cpu gets a

--- a/plat/common/aarch64/platform_mp_stack.S
+++ b/plat/common/aarch64/platform_mp_stack.S
@@ -13,11 +13,13 @@
 #if ENABLE_PLAT_COMPAT
 	.globl	plat_get_my_stack
 	.globl	plat_set_my_stack
+	.weak	plat_inv_my_stack
 	.weak	platform_get_stack
 	.weak	platform_set_stack
 #else
 	.weak	plat_get_my_stack
 	.weak	plat_set_my_stack
+	.weak	plat_inv_my_stack
 	.globl	platform_get_stack
 	.globl	platform_set_stack
 #endif /* __ENABLE_PLAT_COMPAT__ */
@@ -56,6 +58,22 @@ func plat_set_my_stack
 	mrs	x0, mpidr_el1
 	b	platform_set_stack
 endfunc plat_set_my_stack
+
+	/* -----------------------------------------------------
+	 * void plat_inv_my_stack ()
+	 *
+	 * For the current CPU, this function invalid the stack
+	 * pointer to a stack allocated in normal memory.
+	 * -----------------------------------------------------
+	 */
+func plat_inv_my_stack
+	mov x9, x30 // lr
+	mrs x0, mpidr_el1
+	bl  platform_get_stack
+	sub x0, x0, x1
+	bl  inv_dcache_range
+	ret x9
+endfunc plat_inv_my_stack
 
 	/* -----------------------------------------------------
 	 * unsigned long platform_get_stack (unsigned long mpidr)
@@ -160,6 +178,21 @@ func plat_set_my_stack
 	mov	sp, x0
 	ret	x9
 endfunc plat_set_my_stack
+
+	/* -----------------------------------------------------
+	 * void plat_inv_my_stack ()
+	 *
+	 * For the current CPU, this function invalid the stack
+	 * pointer to a stack allocated in normal memory.
+	 * -----------------------------------------------------
+	 */
+func plat_inv_my_stack
+	mov	x9, x30 // lr
+	bl 	plat_get_my_stack
+	sub	x0, x0, x1
+	bl	inv_dcache_range
+	ret	x9
+endfunc plat_inv_my_stack
 
 #endif /*__ENABLE_PLAT_COMPAT__*/
 


### PR DESCRIPTION
On the warm boot path, when we use HW_ASSISTED_COHERENCY options
We have to invalid DCache of stack before we use it
and, before we enable DCache, we must make sure invalid the stack

Signed-off-by: Ken Kuang <ken.kuang@unisoc.com>