### PR TITLE
Adjust BL2_AT_EL3 memory layout

### DIFF
--- a/docs/firmware-design.rst
+++ b/docs/firmware-design.rst
@@ -516,8 +516,8 @@ This functionality can be tested with FVP loading the image directly
 in memory and changing the address where the system jumps at reset.
 For example:
 
-	-C cluster0.cpu0.RVBAR=0x4020000
-	--data cluster0.cpu0=bl2.bin@0x4020000
+	-C cluster0.cpu0.RVBAR=0x402e000
+	--data cluster0.cpu0=bl2.bin@0x402e000
 
 With this configuration, FVP is like a platform of the first case,
 where the Boot ROM jumps always to the same address. For simplification,

--- a/include/plat/arm/common/arm_def.h
+++ b/include/plat/arm/common/arm_def.h
@@ -339,9 +339,9 @@
  * BL2 specific defines.
  ******************************************************************************/
 #if BL2_AT_EL3
-/* Put BL2 in the middle of the Trusted SRAM */
+/* Put BL2 towards the middle of the Trusted SRAM */
 #define BL2_BASE			(ARM_TRUSTED_SRAM_BASE + \
-						(PLAT_ARM_TRUSTED_SRAM_SIZE >> 1))
+						(PLAT_ARM_TRUSTED_SRAM_SIZE >> 1) + 0xe000)
 #define BL2_LIMIT			(ARM_BL_RAM_BASE + ARM_BL_RAM_SIZE)
 
 #else
@@ -374,7 +374,15 @@
 #define BL31_BASE			((ARM_BL_RAM_BASE + ARM_BL_RAM_SIZE)\
 						- PLAT_ARM_MAX_BL31_SIZE)
 #define BL31_PROGBITS_LIMIT		BL2_BASE
+/*
+ * For BL2_AT_EL3 make sure the BL31 can grow up until BL2_BASE. This is
+ * because in the BL2_AT_EL3 configuration, BL2 is always resident.
+ */
+#if BL2_AT_EL3
+#define BL31_LIMIT			BL2_BASE
+#else
 #define BL31_LIMIT			(ARM_BL_RAM_BASE + ARM_BL_RAM_SIZE)
+#endif
 #endif
 
 #if defined(AARCH32) || JUNO_AARCH32_EL3_RUNTIME


### PR DESCRIPTION
For the BL2_AT_EL3 configuration, move BL2 higher up to make more
space for BL31.  Adjust the BL31 limit to be up to BL2 base.  This is
because BL2 is always resident for the BL2_AT_EL3 configuration and
thus we cannot overlay it with BL31.

Change-Id: I71e89863ed48f5159e8b619f49c7c73b253397aa
Signed-off-by: Dimitris Papastamos <dimitris.papastamos@arm.com>