### PR TITLE
Correct ordering of log levels in documentation

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -486,8 +486,8 @@ Common build options
    ::
 
        0  (LOG_LEVEL_NONE)
-       10 (LOG_LEVEL_NOTICE)
-       20 (LOG_LEVEL_ERROR)
+       10 (LOG_LEVEL_ERROR)
+       20 (LOG_LEVEL_NOTICE)
        30 (LOG_LEVEL_WARNING)
        40 (LOG_LEVEL_INFO)
        50 (LOG_LEVEL_VERBOSE)


### PR DESCRIPTION
Changed the ordering of the log levels in the documentation to
mate the code

Change-Id: Ief1930b73d833fdf675b039c98046591c0c264c1
Signed-off-by: Daniel Boulby <daniel.boulby@arm.com>