### PR TITLE
xlat_v2: add a check on mm_cursor->size to avoid infinite loop

### DIFF
--- a/lib/xlat_tables_v2/xlat_tables_internal.c
+++ b/lib/xlat_tables_v2/xlat_tables_internal.c
@@ -784,8 +784,8 @@ void mmap_add_region_ctx(xlat_ctx_t *ctx, const mmap_region_t *mm)
 	       && mm_cursor->size)
 		++mm_cursor;
 
-	while ((mm_cursor->base_va + mm_cursor->size - 1 == end_va)
-	       && (mm_cursor->size < mm->size))
+	while ((mm_cursor->base_va + mm_cursor->size - 1 == end_va) &&
+	       (mm_cursor->size != 0U) && (mm_cursor->size < mm->size))
 		++mm_cursor;
 
 	/*


### PR DESCRIPTION
The issue can occur if end_va is equal to the max architecture address,
and when mm_cursor point to the last entry of mmap_region_t table: {0}.
The first line of the while will then be true, e.g. on AARCH32, we have:
mm_cursor->base_va (=0) + mm_cursor->size (=0) - 1 == end_va (=0xFFFFFFFF)
And the mm_cursor->size = 0 will be lesser than mm->size

A check on mm_cursor->size != 0 should be done as in the previous while,
to avoid such kind of infinite loop.

fixes arm-software/tf-issues#594

Signed-off-by: Yann Gautier <yann.gautier@st.com>