### PR TITLE
Build: add cpp build processing for dtb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,8 @@ BL_COMMON_SOURCES	+=	common/bl_common.c			\
 				${COMPILER_RT_SRCS}			\
 				${STDLIB_SRCS}
 
-INCLUDES		+=	-Iinclude/bl1				\
+INCLUDES		+=	-Iinclude				\
+				-Iinclude/bl1				\
 				-Iinclude/bl2				\
 				-Iinclude/bl2u				\
 				-Iinclude/bl31				\

--- a/make_helpers/build_macros.mk
+++ b/make_helpers/build_macros.mk
@@ -372,11 +372,14 @@ endef
 define MAKE_DTB
 
 $(eval DOBJ := $(addprefix $(1)/,$(call SOURCES_TO_DTBS,$(2))))
+$(eval DPRE := $(addprefix $(1)/,$(patsubst %.dts,%.pre.dts,$(notdir $(2)))))
 $(eval DEP := $(patsubst %.dtb,%.d,$(DOBJ)))
 
 $(DOBJ): $(2) $(filter-out %.d,$(MAKEFILE_LIST)) | fdt_dirs
+	@echo "  CPP     $$<"
+	$$(Q)$$(CPP) $$(CPPFLAGS) -x assembler-with-cpp -o $(DPRE) $$<
 	@echo "  DTC     $$<"
-	$$(Q)$$(DTC) $$(DTC_FLAGS) -d $(DEP) -o $$@ $$<
+	$$(Q)$$(DTC) $$(DTC_FLAGS) -i fdts -d $(DEP) -o $$@ $(DPRE)
 
 -include $(DEP)
 


### PR DESCRIPTION
This is an add-on feature that allows processing
device tree with external includes.

fixes arm-software/tf-issues#595

Signed-off-by: Lionel Debieve <lionel.debieve@st.com>
Signed-off-by: Yann Gautier <yann.gautier@st.com>