### PR TITLE
cortex-a55: disable Dcache in power-down handler

### DIFF
--- a/lib/cpus/aarch64/cortex_a55.S
+++ b/lib/cpus/aarch64/cortex_a55.S
@@ -12,10 +12,26 @@
 #include <plat_macros.S>
 
 	/* ---------------------------------------------
+	 * Disable L1 data cache and unified L2/L3 cache
+	 * ---------------------------------------------
+	 */
+func cortex_a55_disable_dcache
+	mrs	x1, sctlr_el3
+	bic	x1, x1, #SCTLR_C_BIT
+	msr	sctlr_el3, x1
+	isb
+	ret
+endfunc cortex_a55_disable_dcache
+	/* ---------------------------------------------
 	 * HW will do the cache maintenance while powering down
 	 * ---------------------------------------------
 	 */
 func cortex_a55_core_pwr_dwn
+#if !HW_ASSISTED_COHERENCY
+	mov x18, x30
+	bl  cortex_a55_disable_dcache
+	mov	x30, x18
+#endif
 	/* ---------------------------------------------
 	 * Enable CPU power down bit in power control register
 	 * ---------------------------------------------


### PR DESCRIPTION
If HW_ASSISTED_COHERENCY is not used, cache maintenance must be
performed in the power-up and power-down sequence.
In the power-down path, the used stack is cleaned and invalidated in
function "psci_do_pwrdown_cache_maintenance". If that function is called
with Dcache enabled, the L1D/L2/L3 cache will be reallocated after
function return due to the follow-up stack operation.

This patch turns off Dcache to avoid that.

Signed-off-by: Aijun Sun <aijun.sun@spreadtrum.com>