### PR TITLE
Panic in BL1 when TB_FW_CONFIG is invalid

### DIFF
--- a/plat/arm/common/arm_dyn_cfg.c
+++ b/plat/arm/common/arm_dyn_cfg.c
@@ -61,8 +61,8 @@ void arm_load_tb_fw_config(void)
 
 	err = arm_dyn_tb_fw_cfg_init((void *)config_base, &tb_fw_node);
 	if (err < 0) {
-		WARN("Invalid TB_FW_CONFIG loaded\n");
-		return;
+		ERROR("Invalid TB_FW_CONFIG loaded\n");
+		panic();
 	}
 
 	err = arm_dyn_get_disable_auth((void *)config_base, tb_fw_node, &disable_auth);


### PR DESCRIPTION
In Arm platforms, when using dynamic configuration, the necessary
parameters are made available as a DTB. The DTB is loaded by BL1 and,
later on, is parsed by BL1, BL2 or even both, depending on when
information from the DTB is needed.

When the DTB is going to be parsed, it must be validated first, to
ensure that it is properly structured. If an invalid DTB is detected
then:
  - BL1 prints a diagnostic but allows execution to continue,
  - BL2 prints a diagnostic and panics.

Now the behaviour of BL1 is changed so for it also to panic. Thus, the
behaviour of BL1 and BL2 is now similar.

Keep in mind that if BL1 only loads the DTB but it doesn't need to
read/write it, then it doesn't validate it. The validation is done only
when the DTB is actually going to be accessed.

Change-Id: Idcae6092e6dbeab7248dd5e041d6cbb7784fe410
Signed-off-by: John Tsichritzis <john.tsichritzis@arm.com>