### PR TITLE
SPM: Refactor entry and exit of the SP

### DIFF
--- a/services/std_svc/spm/spm_private.h
+++ b/services/std_svc/spm/spm_private.h
@@ -35,7 +35,7 @@
 #include <stdint.h>
 #include <xlat_tables_v2.h>
 
-typedef enum secure_partition_state {
+typedef enum sp_state {
 	SP_STATE_RESET = 0,
 	SP_STATE_IDLE,
 	SP_STATE_BUSY


### PR DESCRIPTION
Only use synchronous calls to enter the Secure Partition in order to simplify the SMC handling code.