### PR TITLE
SPM: Allow entering the SP without needing a SMC

### DIFF
--- a/include/services/spm_svc.h
+++ b/include/services/spm_svc.h
@@ -74,6 +74,9 @@ uint64_t spm_smc_handler(uint32_t smc_fid,
 			 void *handle,
 			 uint64_t flags);
 
+/* Helper to enter a Secure Partition */
+uint64_t spm_sp_call(uint32_t smc_fid, uint64_t x1, uint64_t x2, uint64_t x3);
+
 #endif /* __ASSEMBLY__ */
 
 #endif /* __SPM_SVC_H__ */


### PR DESCRIPTION
It may be needed to enter the Secure Partition through other means than an MM_COMMUNICATE SMC. This patch enables this behaviour by extracting the necessary code from mm_communicate() and allowing other parts of the code to use it.