### PR TITLE
SDEI: Fix dispatch bug

### DIFF
--- a/services/std_svc/sdei/sdei_intr_mgmt.c
+++ b/services/std_svc/sdei/sdei_intr_mgmt.c
@@ -505,7 +505,7 @@ int sdei_intr_handler(uint32_t intr_raw, uint32_t flags, void *handle,
 	 * the event handling completed, EOI the corresponding
 	 * interrupt.
 	 */
-	if ((map->ev_num != SDEI_EVENT_0) && is_map_bound(map)) {
+	if ((map->ev_num != SDEI_EVENT_0) && !is_map_bound(map)) {
 		ERROR("Invalid SDEI mapping: ev=%u\n", map->ev_num);
 		panic();
 	}


### PR DESCRIPTION
The Commit cdb6ac94ecb3c4caa784cd4d7580cf6252146196 introduced a bug
because of which the SDEI dispatcher wrongly panic when an SDEI event
dispatched earlier as a result of interrupt. This patch fixes the check
for a bound interrupt.

Change-Id: If55c8f0422ff781731248bbbc9c1b59fa0d3c4b0
Signed-off-by: Jeenu Viswambharan <jeenu.viswambharan@arm.com>