### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/porting-guide.rst
+++ b/docs/porting-guide.rst
@@ -1661,6 +1661,7 @@ Function : bl2\_plat\_preload\_setup [optional]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
+
     Argument : void
     Return   : void
 
@@ -1674,6 +1675,7 @@ Function : plat\_try\_next\_boot\_source() [optional]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
+
     Argument : void
     Return   : int
 
@@ -1704,6 +1706,7 @@ Function : bl2\_el3\_early\_platform\_setup() [mandatory]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
+
 	Argument : u_register_t, u_register_t, u_register_t, u_register_t
 	Return   : void
 
@@ -1726,6 +1729,7 @@ Function : bl2\_el3\_plat\_arch\_setup() [mandatory]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
+
 	Argument : void
 	Return   : void
 
@@ -1741,6 +1745,7 @@ Function : bl2\_el3\_plat\_prepare\_exit() [optional]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
+
 	Argument : void
 	Return   : void
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -243,10 +243,10 @@ Common build options
 -  ``BL2U``: This is an optional build option which specifies the path to
    BL2U image. In this case, the BL2U in TF-A will not be built.
 
-- ``BL2_AT_EL3``: This is an optional build option that enables the use of
+-  ``BL2_AT_EL3``: This is an optional build option that enables the use of
    BL2 at EL3 execution level.
 
-- ``BL2_IN_XIP_MEM``: In some use-cases BL2 will be stored in eXecute In Place
+-  ``BL2_IN_XIP_MEM``: In some use-cases BL2 will be stored in eXecute In Place
    (XIP) memory, like BL1. In these use-cases, it is necessary to initialize
    the RW sections in RAM, while leaving the RO sections in place. This option
    enable this use-case. For now, this option is only supported when BL2_AT_EL3
@@ -264,10 +264,10 @@ Common build options
    BL32 image for the ``fip`` target. In this case, the BL32 in TF-A will not
    be built.
 
-- ``BL32_EXTRA1``: This is an optional build option which specifies the path to
+-  ``BL32_EXTRA1``: This is an optional build option which specifies the path to
    Trusted OS Extra1 image for the  ``fip`` target.
 
-- ``BL32_EXTRA2``: This is an optional build option which specifies the path to
+-  ``BL32_EXTRA2``: This is an optional build option which specifies the path to
    Trusted OS Extra2 image for the ``fip`` target.
 
 -  ``BL32_KEY``: This option is used when ``GENERATE_COT=1``. It specifies the
@@ -323,10 +323,10 @@ Common build options
 -  ``DEBUG``: Chooses between a debug and release build. It can take either 0
    (release) or 1 (debug) as values. 0 is the default.
 
--  ``DYN_DISABLE_AUTH``: Enables the capability to disable Trusted Board Boot
-   authentication. This option is only meant to be enabled for development
-   platforms. Both TRUSTED_BOARD_BOOT and the LOAD_IMAGE_V2 flags need to be
-   set if this flag has to be enabled. 0 is the default.
+-  ``DYN_DISABLE_AUTH``: Provides the capability to dynamically disable Trusted
+   Board Boot authentication at runtime. This option is meant to be enabled only
+   for development platforms. Both TRUSTED_BOARD_BOOT and LOAD_IMAGE_V2 flags
+   must be set if this flag has to be enabled. 0 is the default.
 
 -  ``EL3_PAYLOAD_BASE``: This option enables booting an EL3 payload instead of
    the normal boot flow. It must specify the entry point address of the EL3
@@ -743,8 +743,8 @@ Arm development platform specific build options
 
    -  ``tsram`` : Trusted SRAM (default option when TBB is not enabled)
    -  ``tdram`` : Trusted DRAM (if available)
-   -  ``dram``  : Secure region in DRAM (default option when TBB is enabled,
-                  configured by the TrustZone controller)
+   -  ``dram`` : Secure region in DRAM (default option when TBB is enabled,
+      configured by the TrustZone controller)
 
 -  ``ARM_XLAT_TABLES_LIB_V1``: boolean option to compile TF-A with version 1
    of the translation tables library instead of version 2. It is set to 0 by
@@ -919,8 +919,7 @@ To check the entire source tree, you must first download copies of
 ``checkpatch.pl``, ``spelling.txt`` and ``const_structs.checkpatch`` available
 in the `Linux master tree`_ scripts directory, then set the ``CHECKPATCH``
 environment variable to point to ``checkpatch.pl`` (with the other 2 files in
-the same directory) and build the target 
-checkcodebase:
+the same directory) and build the target checkcodebase:
 
 ::
 


### PR DESCRIPTION
In the porting guide, there are blue boxes that describe the argument
types and the return type of each function. A small typo caused some of
these boxes not being properly rendered.

In the user guide, small typos were fixed that caused random text being
unintentionally rendered as bold.  Also, a slight rewording was done in
the section describing the DYN_DISABLE_AUTH flag.

Change-Id: I57303ca609436a82162fa9b42c06b0d5a63da6df
Signed-off-by: John Tsichritzis <john.tsichritzis@arm.com>