### PR TITLE
Set FVP DYN_DISABLE_AUTH authentication default to 0

### DIFF
--- a/plat/arm/board/fvp/fdts/fvp_tb_fw_config.dts
+++ b/plat/arm/board/fvp/fdts/fvp_tb_fw_config.dts
@@ -13,7 +13,7 @@
 		hw_config_addr = <0x0 0x82000000>;
 		hw_config_max_size = <0x01000000>;
 		/* Disable authentication for development */
-		disable_auth = <0x1>;
+		disable_auth = <0x0>;
 		/*
 		 * Load SoC and TOS firmware configs at the base of
 		 * non shared SRAM. The runtime checks ensure we don't


### PR DESCRIPTION
Set the ability to dynamically disable Trusted Boot Board
authentication to be off by default

Change-Id: Ibd2aa179179f7d9b0e7731c6e450f200a8c67529
Signed-off-by: Daniel Boulby <daniel.boulby@arm.com>