### PR TITLE
allwinner: Add BL32 (corresponds to Trusted OS) support

### DIFF
--- a/docs/plat/allwinner.rst
+++ b/docs/plat/allwinner.rst
@@ -27,3 +27,13 @@ To build:
     make CROSS_COMPILE=aarch64-linux-gnu- PLAT=sun50i_a64 DEBUG=1 bl31
 
 .. _U-Boot documentation: http://git.denx.de/?p=u-boot.git;f=board/sunxi/README.sunxi64;hb=HEAD
+
+Trusted OS dispatcher
+=====================
+
+One can boot Trusted OS(OP-TEE OS, bl32 image) along side bl31 image on Allwinner A64.
+
+In order to include the 'opteed' dispatcher in the image, pass 'SPD=opteed' on the command line
+while compiling the bl31 image and make sure the loader (SPL) loads the Trusted OS binary to
+the beginning of DRAM (0x40000000).
+

--- a/plat/allwinner/common/include/platform_def.h
+++ b/plat/allwinner/common/include/platform_def.h
@@ -42,4 +42,10 @@
 #define PLATFORM_MMAP_REGIONS		4
 #define PLATFORM_STACK_SIZE		(0x1000 / PLATFORM_CORE_COUNT)
 
+#ifndef SPD_none
+#ifndef BL32_BASE
+#define BL32_BASE			SUNXI_DRAM_BASE
+#endif
+#endif
+
 #endif /* __PLATFORM_DEF_H__ */


### PR DESCRIPTION
This pull request is an attempt to run Trusted OS (OP-TEE OS being one of them) along
side BL31 image.

This is the second version of PR  #1431, @Andre-ARM can you please have a look.

Trusted OS image can be fetched from below link:
https://github.com/Amit-Radur/Images.git

Signed-off-by: Amit Singh Tomar <amittomer25@gmail.com>