### PR TITLE
hikey: Add experimental TBB support

### DIFF
--- a/plat/hisilicon/hikey/hikey_io_storage.c
+++ b/plat/hisilicon/hikey/hikey_io_storage.c
@@ -89,6 +89,44 @@ static const io_uuid_spec_t scp_bl2_uuid_spec = {
 	.uuid = UUID_SCP_FIRMWARE_SCP_BL2,
 };
 
+#if TRUSTED_BOARD_BOOT
+static const io_uuid_spec_t trusted_key_cert_uuid_spec = {
+	.uuid = UUID_TRUSTED_KEY_CERT,
+};
+
+static const io_uuid_spec_t scp_fw_key_cert_uuid_spec = {
+	.uuid = UUID_SCP_FW_KEY_CERT,
+};
+
+static const io_uuid_spec_t soc_fw_key_cert_uuid_spec = {
+	.uuid = UUID_SOC_FW_KEY_CERT,
+};
+
+static const io_uuid_spec_t tos_fw_key_cert_uuid_spec = {
+	.uuid = UUID_TRUSTED_OS_FW_KEY_CERT,
+};
+
+static const io_uuid_spec_t nt_fw_key_cert_uuid_spec = {
+	.uuid = UUID_NON_TRUSTED_FW_KEY_CERT,
+};
+
+static const io_uuid_spec_t scp_fw_cert_uuid_spec = {
+	.uuid = UUID_SCP_FW_CONTENT_CERT,
+};
+
+static const io_uuid_spec_t soc_fw_cert_uuid_spec = {
+	.uuid = UUID_SOC_FW_CONTENT_CERT,
+};
+
+static const io_uuid_spec_t tos_fw_cert_uuid_spec = {
+	.uuid = UUID_TRUSTED_OS_FW_CONTENT_CERT,
+};
+
+static const io_uuid_spec_t nt_fw_cert_uuid_spec = {
+	.uuid = UUID_NON_TRUSTED_FW_CONTENT_CERT,
+};
+#endif /* TRUSTED_BOARD_BOOT */
+
 static const struct plat_io_policy policies[] = {
 	[FIP_IMAGE_ID] = {
 		&emmc_dev_handle,
@@ -124,7 +162,54 @@ static const struct plat_io_policy policies[] = {
 		&fip_dev_handle,
 		(uintptr_t)&bl33_uuid_spec,
 		check_fip
-	}
+	},
+#if TRUSTED_BOARD_BOOT
+	[TRUSTED_KEY_CERT_ID] = {
+		&fip_dev_handle,
+		(uintptr_t)&trusted_key_cert_uuid_spec,
+		check_fip
+	},
+	[SCP_FW_KEY_CERT_ID] = {
+		&fip_dev_handle,
+		(uintptr_t)&scp_fw_key_cert_uuid_spec,
+		check_fip
+	},
+	[SOC_FW_KEY_CERT_ID] = {
+		&fip_dev_handle,
+		(uintptr_t)&soc_fw_key_cert_uuid_spec,
+		check_fip
+	},
+	[TRUSTED_OS_FW_KEY_CERT_ID] = {
+		&fip_dev_handle,
+		(uintptr_t)&tos_fw_key_cert_uuid_spec,
+		check_fip
+	},
+	[NON_TRUSTED_FW_KEY_CERT_ID] = {
+		&fip_dev_handle,
+		(uintptr_t)&nt_fw_key_cert_uuid_spec,
+		check_fip
+	},
+	[SCP_FW_CONTENT_CERT_ID] = {
+		&fip_dev_handle,
+		(uintptr_t)&scp_fw_cert_uuid_spec,
+		check_fip
+	},
+	[SOC_FW_CONTENT_CERT_ID] = {
+		&fip_dev_handle,
+		(uintptr_t)&soc_fw_cert_uuid_spec,
+		check_fip
+	},
+	[TRUSTED_OS_FW_CONTENT_CERT_ID] = {
+		&fip_dev_handle,
+		(uintptr_t)&tos_fw_cert_uuid_spec,
+		check_fip
+	},
+	[NON_TRUSTED_FW_CONTENT_CERT_ID] = {
+		&fip_dev_handle,
+		(uintptr_t)&nt_fw_cert_uuid_spec,
+		check_fip
+	},
+#endif /* TRUSTED_BOARD_BOOT */
 };
 
 static int check_emmc(const uintptr_t spec)

--- a/plat/hisilicon/hikey/hikey_rotpk.S
+++ b/plat/hisilicon/hikey/hikey_rotpk.S
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+	.global hikey_rotpk_hash
+	.global hikey_rotpk_hash_end
+	.section .rodata.hikey_rotpk_hash, "a"
+hikey_rotpk_hash:
+	/* DER header */
+	.byte 0x30, 0x31, 0x30, 0x0D, 0x06, 0x09, 0x60, 0x86, 0x48
+	.byte 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20
+	/* SHA256 */
+	.incbin ROTPK_HASH
+hikey_rotpk_hash_end:

--- a/plat/hisilicon/hikey/hikey_tbbr.c
+++ b/plat/hisilicon/hikey/hikey_tbbr.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <platform.h>
+
+extern char hikey_rotpk_hash[], hikey_rotpk_hash_end[];
+
+int plat_get_rotpk_info(void *cookie, void **key_ptr, unsigned int *key_len,
+			unsigned int *flags)
+{
+	*key_ptr = hikey_rotpk_hash;
+	*key_len = hikey_rotpk_hash_end - hikey_rotpk_hash;
+	*flags = ROTPK_IS_HASH;
+
+	return 0;
+}
+
+int plat_get_nv_ctr(void *cookie, unsigned int *nv_ctr)
+{
+	*nv_ctr = 0;
+
+	return 0;
+}
+
+int plat_set_nv_ctr(void *cookie, unsigned int nv_ctr)
+{
+	return 1;
+}

--- a/plat/hisilicon/hikey/include/hikey_layout.h
+++ b/plat/hisilicon/hikey/include/hikey_layout.h
@@ -58,10 +58,10 @@
  * + loader +
  * ++++++++++ 0xF980_1000
  * +  BL2   +
- * ++++++++++ 0xF981_8000
+ * ++++++++++ 0xF983_0000
  */
 #define BL2_BASE			(BL1_RO_BASE)		/* 0xf980_1000 */
-#define BL2_LIMIT			(0xF9818000)		/* 0xf981_8000 */
+#define BL2_LIMIT			(0xF9830000)		/* 0xf983_0000 */
 
 /*
  * SCP_BL2 specific defines.

--- a/plat/hisilicon/hikey/include/platform_def.h
+++ b/plat/hisilicon/hikey/include/platform_def.h
@@ -21,7 +21,7 @@
  */
 
 /* Size of cacheable stacks */
-#define PLATFORM_STACK_SIZE		0x800
+#define PLATFORM_STACK_SIZE		0x1000
 
 #define FIRMWARE_WELCOME_STR		"Booting Trusted Firmware\n"
 

--- a/plat/hisilicon/hikey/platform.mk
+++ b/plat/hisilicon/hikey/platform.mk
@@ -122,6 +122,42 @@ BL31_SOURCES		+=	plat/hisilicon/hikey/hisi_sip_svc.c			\
 				lib/pmf/pmf_smc.c
 endif
 
+ifneq (${TRUSTED_BOARD_BOOT},0)
+
+include drivers/auth/mbedtls/mbedtls_crypto.mk
+include drivers/auth/mbedtls/mbedtls_x509.mk
+
+USE_TBBR_DEFS		:=	1
+
+AUTH_SOURCES		:=	drivers/auth/auth_mod.c			\
+				drivers/auth/crypto_mod.c		\
+				drivers/auth/img_parser_mod.c		\
+				drivers/auth/tbbr/tbbr_cot.c
+
+BL2_SOURCES		+=	${AUTH_SOURCES}				\
+				plat/common/tbbr/plat_tbbr.c		\
+				plat/hisilicon/hikey/hikey_tbbr.c	\
+				plat/hisilicon/hikey/hikey_rotpk.S
+
+ROT_KEY		=	$(BUILD_PLAT)/rot_key.pem
+ROTPK_HASH		=	$(BUILD_PLAT)/rotpk_sha256.bin
+
+$(eval $(call add_define_val,ROTPK_HASH,'"$(ROTPK_HASH)"'))
+$(BUILD_PLAT)/bl2/hikey_rotpk.o: $(ROTPK_HASH)
+
+certificates: $(ROT_KEY)
+$(ROT_KEY): | $(BUILD_PLAT)
+	@echo "  OPENSSL $@"
+	$(Q)openssl genrsa 2048 > $@ 2>/dev/null
+
+$(ROTPK_HASH): $(ROT_KEY)
+	@echo "  OPENSSL $@"
+	$(Q)openssl rsa -in $< -pubout -outform DER 2>/dev/null |\
+	openssl dgst -sha256 -binary > $@ 2>/dev/null
+
+override BL1_SOURCES	=
+endif
+
 # Enable workarounds for selected Cortex-A53 errata.
 ERRATA_A53_836870		:=	1
 ERRATA_A53_843419		:=	1


### PR DESCRIPTION
This patch adds experimental support for TRUSTED_BOARD_BOOT to the
Hikey. This is adapted from the RPi3 and QEMU implementations.

Since the Hikey starts from BL2 the TRUSTED_BOARD_BOOT ROT begins there
too. When TRUSTED_BOARD_BOOT is defined, the BL1 build is skipped.

See the following example:

    make \
     PLAT=hikey \
     BL33=u-boot.bin \
     SCP_BL2=mcuimage.bin \
     TRUSTED_BOARD_BOOT=1 \
     MBEDTLS_DIR=../../mbedtls \
     GENERATE_COT=1 \
     all fip



--

This is a RFC because this does not work and I am having trouble debugging.

After building the `bl2.bin` and creating a `l-loader.bin` and flashing, the debug output is:
```
NOTICE:  BL2: v1.5(debug):v1.5-373-g3be75e7
NOTICE:  BL2: Built : 23:41:25, Jun 23 2018
INFO:    Using crypto library 'mbed TLS'
INFO:    BL2: Doing platform setup
INFO:    ddr3 rank1 init pass
INFO:    succeed to set ddrc 150mhz
INFO:    ddr3 rank1 init pass
INFO:    succeed to set ddrc 266mhz
INFO:    ddr3 rank1 init pass
INFO:    succeed to set ddrc 400mhz
INFO:    ddr3 rank1 init pass
INFO:    succeed to set ddrc 533mhz
INFO:    ddr3 rank1 init pass
INFO:    succeed to set ddrc 800mhz
INFO:    Samsung DDR
INFO:    ddr test value:0xa5a55a5a
INFO:    BL2: TrustZone: protecting 16777216 bytes of memory at 0x3f000000
INFO:    BL2: TrustZone: protecting 4194304 bytes of memory at 0x3e800000
INFO:    [BDID] [fff91c18] midr: 0x410fd033
INFO:    init_acpu_dvfs: pmic version 17
INFO:    init_acpu_dvfs: ACPU_CHIP_MAX_FREQ=0x186a00.
INFO:    acpu_dvfs_volt_init: success!
INFO:    acpu_dvfs_set_freq: support freq num is 5
INFO:    acpu_dvfs_set_freq: start prof is 0x4
INFO:    acpu_dvfs_set_freq: magic is 0x5a5ac5c5
INFO:    acpu_dvfs_set_freq: voltage:
INFO:      - 0: 0x49
INFO:      - 1: 0x49
INFO:      - 2: 0x50
INFO:      - 3: 0x60
INFO:      - 4: 0x78
NOTICE:  acpu_dvfs_set_freq: set acpu freq success!
INFO:    BL2: Loading image id 2
INFO:    Loading image id=7 at address 0x1000000
INFO:    Image id=7 loaded: 0x1000000 - 0x100060e

Platform exception reporting:
ESR_EL3: 000000008600000e
ELR_EL3: 0000000000000000
```
The exception seems to come from `mbedtls_pk_verify_ext`, perhaps in the bignum implementation. This seems like a red-herring, I'm sure I'm doing something basic incorrectly. I think this because if I add simple trace statements I can land on a different/related exception:
```
Platform exception reporting:
ESR_EL3: 000000008600000f
ELR_EL3: 00000000f98165d0
```

I will continue to experiment and debug. If there are any Hikey or TBB experts around, do you mind doing a quick review? Is there something silly I am overlooking?