### PR TITLE
Update runtime_svc.c

### DIFF
--- a/common/runtime_svc.c
+++ b/common/runtime_svc.c
@@ -81,7 +81,7 @@ static int32_t validate_rt_svc_desc(const rt_svc_desc_t *desc)
 #endif /* SMCCC_MAJOR_VERSION */
 
 	/* A runtime service having no init or handle function doesn't make sense */
-	if ((desc->init == NULL) && (desc->handle == NULL))
+	if ((desc->init == NULL) || (desc->handle == NULL))
 		return -EINVAL;
 
 	return 0;


### PR DESCRIPTION
Maybe there should use or "||" operator as the annotation says  in:
arm-trusted-firmware/common/runtime_svc.c line 83.

> /* A runtime service having no init or handle function doesn't make sense */