### PR TITLE
make_cert: return error when invalid options are used

### DIFF
--- a/tools/cert_create/src/main.c
+++ b/tools/cert_create/src/main.c
@@ -140,8 +140,6 @@ static void print_help(const char *cmd, const struct option *long_opt)
 		i++;
 	}
 	printf("\n");
-
-	exit(0);
 }
 
 static int get_key_alg(const char *key_alg_str)
@@ -334,7 +332,7 @@ int main(int argc, char *argv[])
 			break;
 		case 'h':
 			print_help(argv[0], cmd_opt);
-			break;
+			exit(0);
 		case 'k':
 			save_keys = 1;
 			break;


### PR DESCRIPTION
Print_help was used in different contexts and returning no
error in that function was hiding the error when incorrect
options were used.

Change-Id: Ic3f71748be7ff8440c9d54810b986e9f177f4439
Signed-off-by: Roberto Vargas <roberto.vargas@arm.com>