### PR TITLE
rpi3: Add support for Trusted Board Boot

### DIFF
--- a/docs/plat/rpi3.rst
+++ b/docs/plat/rpi3.rst
@@ -243,6 +243,16 @@ The following build options are supported:
   BL32_EXTRA1=tee-pager_v2.bin  BL32_EXTRA2=tee-pageable_v2.bin``
   to put the binaries into the FIP.
 
+- ``TRUSTED_BOARD_BOOT``: This port supports TBB. Set this option
+  ``TRUSTED_BOARD_BOOT=1`` to enable it. In order to use TBB, you might
+  want to set ``GENERATE_COT=1`` to let the contents of the FIP automatically
+  signed by the build process. The ROT key will be generated and output to
+  ``rot_key.pem`` in the build directory. It is able to set ROT_KEY to
+  your own key in PEM format.
+  Also in order to build, you need to clone mbedtls from
+  `here <https://github.com/ARMmbed/mbedtls>`__.
+  And set MBEDTLS_DIR to mbedtls source directory.
+
 The following is not currently supported:
 
 - AArch32 for TF-A itself.

--- a/docs/plat/rpi3.rst
+++ b/docs/plat/rpi3.rst
@@ -101,7 +101,7 @@ secure platform!
 
     0x00000000 +-----------------+
                |       ROM       | BL1
-    0x00010000 +-----------------+
+    0x00020000 +-----------------+
                |       FIP       |
     0x00200000 +-----------------+
                |                 |
@@ -213,7 +213,7 @@ by ``debug`` if you set the build option ``DEBUG=1``):
 .. code:: shell
 
     cp build/rpi3/release/bl1.bin bl1.pad.bin
-    truncate --size=65536 bl1.pad.bin
+    truncate --size=131072 bl1.pad.bin
     cat bl1.pad.bin build/rpi3/release/fip.bin > armstub8.bin
 
 The resulting file, ``armstub8.bin``, contains BL1 and the FIP in the place they

--- a/plat/rpi3/include/platform_def.h
+++ b/plat/rpi3/include/platform_def.h
@@ -64,11 +64,11 @@
  * there is no Secure RAM in the Raspberry Pi 3.
  */
 #define SEC_ROM_BASE			ULL(0x00000000)
-#define SEC_ROM_SIZE			ULL(0x00010000)
+#define SEC_ROM_SIZE			ULL(0x00020000)
 
 /* FIP placed after ROM to append it to BL1 with very little padding. */
-#define PLAT_RPI3_FIP_BASE		ULL(0x00010000)
-#define PLAT_RPI3_FIP_MAX_SIZE		ULL(0x001F0000)
+#define PLAT_RPI3_FIP_BASE		ULL(0x00020000)
+#define PLAT_RPI3_FIP_MAX_SIZE		ULL(0x001E0000)
 
 /* We have 16M of memory reserved at at 256M */
 #define SEC_SRAM_BASE			ULL(0x10000000)

--- a/plat/rpi3/platform.mk
+++ b/plat/rpi3/platform.mk
@@ -134,3 +134,48 @@ endif
 ifneq ($(BL32_EXTRA2),)
 $(eval $(call TOOL_ADD_IMG,BL32_EXTRA2,--tos-fw-extra2))
 endif
+
+ifneq (${TRUSTED_BOARD_BOOT},0)
+
+    include drivers/auth/mbedtls/mbedtls_crypto.mk
+    include drivers/auth/mbedtls/mbedtls_x509.mk
+
+    USE_TBBR_DEFS	:=	1
+
+    AUTH_SOURCES	:=	drivers/auth/auth_mod.c			\
+				drivers/auth/crypto_mod.c		\
+				drivers/auth/img_parser_mod.c		\
+				drivers/auth/tbbr/tbbr_cot.c
+
+    PLAT_INCLUDES	+=	-Iinclude/bl1/tbbr
+
+    BL1_SOURCES		+=	${AUTH_SOURCES}				\
+				bl1/tbbr/tbbr_img_desc.c		\
+				plat/common/tbbr/plat_tbbr.c		\
+				plat/rpi3/rpi3_trusted_boot.c	     	\
+				plat/rpi3/rpi3_rotpk.S
+
+    BL2_SOURCES		+=	${AUTH_SOURCES}				\
+				plat/common/tbbr/plat_tbbr.c		\
+				plat/rpi3/rpi3_trusted_boot.c	     	\
+				plat/rpi3/rpi3_rotpk.S
+
+    ROT_KEY             = $(BUILD_PLAT)/rot_key.pem
+    ROTPK_HASH          = $(BUILD_PLAT)/rotpk_sha256.bin
+
+    $(eval $(call add_define_val,ROTPK_HASH,'"$(ROTPK_HASH)"'))
+
+    $(BUILD_PLAT)/bl1/rpi3_rotpk.o: $(ROTPK_HASH)
+    $(BUILD_PLAT)/bl2/rpi3_rotpk.o: $(ROTPK_HASH)
+
+    certificates: $(ROT_KEY)
+
+    $(ROT_KEY):
+	@echo "  OPENSSL $@"
+	$(Q)openssl genrsa 2048 > $@ 2>/dev/null
+
+    $(ROTPK_HASH): $(ROT_KEY)
+	@echo "  OPENSSL $@"
+	$(Q)openssl rsa -in $< -pubout -outform DER 2>/dev/null |\
+	openssl dgst -sha256 -binary > $@ 2>/dev/null
+endif

--- a/plat/rpi3/rpi3_io_storage.c
+++ b/plat/rpi3/rpi3_io_storage.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -21,14 +21,14 @@
 #define BL33_IMAGE_NAME			"bl33.bin"
 
 #if TRUSTED_BOARD_BOOT
-#define BL2_CERT_NAME			"bl2.crt"
+#define TRUSTED_BOOT_FW_CERT_NAME	"tb_fw.crt"
 #define TRUSTED_KEY_CERT_NAME		"trusted_key.crt"
-#define BL31_KEY_CERT_NAME		"bl31_key.crt"
-#define BL32_KEY_CERT_NAME		"bl32_key.crt"
-#define BL33_KEY_CERT_NAME		"bl33_key.crt"
-#define BL31_CERT_NAME			"bl31.crt"
-#define BL32_CERT_NAME			"bl32.crt"
-#define BL33_CERT_NAME			"bl33.crt"
+#define SOC_FW_KEY_CERT_NAME		"soc_fw_key.crt"
+#define TOS_FW_KEY_CERT_NAME		"tos_fw_key.crt"
+#define NT_FW_KEY_CERT_NAME		"nt_fw_key.crt"
+#define SOC_FW_CONTENT_CERT_NAME	"soc_fw_content.crt"
+#define TOS_FW_CONTENT_CERT_NAME	"tos_fw_content.crt"
+#define NT_FW_CONTENT_CERT_NAME		"nt_fw_content.crt"
 #endif /* TRUSTED_BOARD_BOOT */
 
 /* IO devices */
@@ -67,36 +67,36 @@ static const io_uuid_spec_t bl33_uuid_spec = {
 };
 
 #if TRUSTED_BOARD_BOOT
-static const io_uuid_spec_t bl2_cert_uuid_spec = {
-	.uuid = UUID_TRUSTED_BOOT_FIRMWARE_BL2_CERT,
+static const io_uuid_spec_t tb_fw_cert_uuid_spec = {
+	.uuid = UUID_TRUSTED_BOOT_FW_CERT,
 };
 
 static const io_uuid_spec_t trusted_key_cert_uuid_spec = {
 	.uuid = UUID_TRUSTED_KEY_CERT,
 };
 
-static const io_uuid_spec_t bl31_key_cert_uuid_spec = {
-	.uuid = UUID_EL3_RUNTIME_FIRMWARE_BL31_KEY_CERT,
+static const io_uuid_spec_t soc_fw_key_cert_uuid_spec = {
+	.uuid = UUID_SOC_FW_KEY_CERT,
 };
 
-static const io_uuid_spec_t bl32_key_cert_uuid_spec = {
-	.uuid = UUID_SECURE_PAYLOAD_BL32_KEY_CERT,
+static const io_uuid_spec_t tos_fw_key_cert_uuid_spec = {
+	.uuid = UUID_TRUSTED_OS_FW_KEY_CERT,
 };
 
-static const io_uuid_spec_t bl33_key_cert_uuid_spec = {
-	.uuid = UUID_NON_TRUSTED_FIRMWARE_BL33_KEY_CERT,
+static const io_uuid_spec_t nt_fw_key_cert_uuid_spec = {
+	.uuid = UUID_NON_TRUSTED_FW_KEY_CERT,
 };
 
-static const io_uuid_spec_t bl31_cert_uuid_spec = {
-	.uuid = UUID_EL3_RUNTIME_FIRMWARE_BL31_CERT,
+static const io_uuid_spec_t soc_fw_cert_uuid_spec = {
+	.uuid = UUID_SOC_FW_CONTENT_CERT,
 };
 
-static const io_uuid_spec_t bl32_cert_uuid_spec = {
-	.uuid = UUID_SECURE_PAYLOAD_BL32_CERT,
+static const io_uuid_spec_t tos_fw_cert_uuid_spec = {
+	.uuid = UUID_TRUSTED_OS_FW_CONTENT_CERT,
 };
 
-static const io_uuid_spec_t bl33_cert_uuid_spec = {
-	.uuid = UUID_NON_TRUSTED_FIRMWARE_BL33_CERT,
+static const io_uuid_spec_t nt_fw_cert_uuid_spec = {
+	.uuid = UUID_NON_TRUSTED_FW_CONTENT_CERT,
 };
 #endif /* TRUSTED_BOARD_BOOT */
 
@@ -152,9 +152,9 @@ static const struct plat_io_policy policies[] = {
 		open_fip
 	},
 #if TRUSTED_BOARD_BOOT
-	[BL2_CERT_ID] = {
+	[TRUSTED_BOOT_FW_CERT_ID] = {
 		&fip_dev_handle,
-		(uintptr_t)&bl2_cert_uuid_spec,
+		(uintptr_t)&tb_fw_cert_uuid_spec,
 		open_fip
 	},
 	[TRUSTED_KEY_CERT_ID] = {
@@ -162,34 +162,34 @@ static const struct plat_io_policy policies[] = {
 		(uintptr_t)&trusted_key_cert_uuid_spec,
 		open_fip
 	},
-	[BL31_KEY_CERT_ID] = {
+	[SOC_FW_KEY_CERT_ID] = {
 		&fip_dev_handle,
-		(uintptr_t)&bl31_key_cert_uuid_spec,
+		(uintptr_t)&soc_fw_key_cert_uuid_spec,
 		open_fip
 	},
-	[BL32_KEY_CERT_ID] = {
+	[TRUSTED_OS_FW_KEY_CERT_ID] = {
 		&fip_dev_handle,
-		(uintptr_t)&bl32_key_cert_uuid_spec,
+		(uintptr_t)&tos_fw_key_cert_uuid_spec,
 		open_fip
 	},
-	[BL33_KEY_CERT_ID] = {
+	[NON_TRUSTED_FW_KEY_CERT_ID] = {
 		&fip_dev_handle,
-		(uintptr_t)&bl33_key_cert_uuid_spec,
+		(uintptr_t)&nt_fw_key_cert_uuid_spec,
 		open_fip
 	},
-	[BL31_CERT_ID] = {
+	[SOC_FW_CONTENT_CERT_ID] = {
 		&fip_dev_handle,
-		(uintptr_t)&bl31_cert_uuid_spec,
+		(uintptr_t)&soc_fw_cert_uuid_spec,
 		open_fip
 	},
-	[BL32_CERT_ID] = {
+	[TRUSTED_OS_FW_CONTENT_CERT_ID] = {
 		&fip_dev_handle,
-		(uintptr_t)&bl32_cert_uuid_spec,
+		(uintptr_t)&tos_fw_cert_uuid_spec,
 		open_fip
 	},
-	[BL33_CERT_ID] = {
+	[NON_TRUSTED_FW_CONTENT_CERT_ID] = {
 		&fip_dev_handle,
-		(uintptr_t)&bl33_cert_uuid_spec,
+		(uintptr_t)&nt_fw_cert_uuid_spec,
 		open_fip
 	},
 #endif /* TRUSTED_BOARD_BOOT */

--- a/plat/rpi3/rpi3_rotpk.S
+++ b/plat/rpi3/rpi3_rotpk.S
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+	.global rpi3_rotpk_hash
+	.global rpi3_rotpk_hash_end
+rpi3_rotpk_hash:
+	/* DER header */
+	.byte 0x30, 0x31, 0x30, 0x0D, 0x06, 0x09, 0x60, 0x86, 0x48
+	.byte 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20
+	/* SHA256 */
+	.incbin ROTPK_HASH
+rpi3_rotpk_hash_end:

--- a/plat/rpi3/rpi3_trusted_boot.c
+++ b/plat/rpi3/rpi3_trusted_boot.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <platform.h>
+
+extern char rpi3_rotpk_hash[], rpi3_rotpk_hash_end[];
+
+int plat_get_rotpk_info(void *cookie, void **key_ptr, unsigned int *key_len,
+			unsigned int *flags)
+{
+	*key_ptr = rpi3_rotpk_hash;
+	*key_len = rpi3_rotpk_hash_end - rpi3_rotpk_hash;
+	*flags = ROTPK_IS_HASH;
+
+	return 0;
+}
+
+int plat_get_nv_ctr(void *cookie, unsigned int *nv_ctr)
+{
+	*nv_ctr = 0;
+
+	return 0;
+}
+
+int plat_set_nv_ctr(void *cookie, unsigned int nv_ctr)
+{
+	return 1;
+}


### PR DESCRIPTION
This patch adds support for TBB to qemu. The ROTPK is generated at build
time and is included into BL1/BL2. The key and content certificates are
read over semihosting.
