### PR TITLE
rpi3: Fix TBB implementation

### DIFF
--- a/plat/rpi3/rpi3_io_storage.c
+++ b/plat/rpi3/rpi3_io_storage.c
@@ -14,23 +14,6 @@
 #include <platform_def.h>
 #include <string.h>
 
-/* Semihosting filenames */
-#define BL2_IMAGE_NAME			"bl2.bin"
-#define BL31_IMAGE_NAME			"bl31.bin"
-#define BL32_IMAGE_NAME			"bl32.bin"
-#define BL33_IMAGE_NAME			"bl33.bin"
-
-#if TRUSTED_BOARD_BOOT
-#define BL2_CERT_NAME			"bl2.crt"
-#define TRUSTED_KEY_CERT_NAME		"trusted_key.crt"
-#define BL31_KEY_CERT_NAME		"bl31_key.crt"
-#define BL32_KEY_CERT_NAME		"bl32_key.crt"
-#define BL33_KEY_CERT_NAME		"bl33_key.crt"
-#define BL31_CERT_NAME			"bl31.crt"
-#define BL32_CERT_NAME			"bl32.crt"
-#define BL33_CERT_NAME			"bl33.crt"
-#endif /* TRUSTED_BOARD_BOOT */
-
 /* IO devices */
 static const io_dev_connector_t *fip_dev_con;
 static uintptr_t fip_dev_handle;
@@ -67,36 +50,36 @@ static const io_uuid_spec_t bl33_uuid_spec = {
 };
 
 #if TRUSTED_BOARD_BOOT
-static const io_uuid_spec_t bl2_cert_uuid_spec = {
-	.uuid = UUID_TRUSTED_BOOT_FIRMWARE_BL2_CERT,
+static const io_uuid_spec_t tb_fw_cert_uuid_spec = {
+	.uuid = UUID_TRUSTED_BOOT_FW_CERT,
 };
 
 static const io_uuid_spec_t trusted_key_cert_uuid_spec = {
 	.uuid = UUID_TRUSTED_KEY_CERT,
 };
 
-static const io_uuid_spec_t bl31_key_cert_uuid_spec = {
-	.uuid = UUID_EL3_RUNTIME_FIRMWARE_BL31_KEY_CERT,
+static const io_uuid_spec_t soc_fw_key_cert_uuid_spec = {
+	.uuid = UUID_SOC_FW_KEY_CERT,
 };
 
-static const io_uuid_spec_t bl32_key_cert_uuid_spec = {
-	.uuid = UUID_SECURE_PAYLOAD_BL32_KEY_CERT,
+static const io_uuid_spec_t tos_fw_key_cert_uuid_spec = {
+	.uuid = UUID_TRUSTED_OS_FW_KEY_CERT,
 };
 
-static const io_uuid_spec_t bl33_key_cert_uuid_spec = {
-	.uuid = UUID_NON_TRUSTED_FIRMWARE_BL33_KEY_CERT,
+static const io_uuid_spec_t nt_fw_key_cert_uuid_spec = {
+	.uuid = UUID_NON_TRUSTED_FW_KEY_CERT,
 };
 
-static const io_uuid_spec_t bl31_cert_uuid_spec = {
-	.uuid = UUID_EL3_RUNTIME_FIRMWARE_BL31_CERT,
+static const io_uuid_spec_t soc_fw_cert_uuid_spec = {
+	.uuid = UUID_SOC_FW_CONTENT_CERT,
 };
 
-static const io_uuid_spec_t bl32_cert_uuid_spec = {
-	.uuid = UUID_SECURE_PAYLOAD_BL32_CERT,
+static const io_uuid_spec_t tos_fw_cert_uuid_spec = {
+	.uuid = UUID_TRUSTED_OS_FW_CONTENT_CERT,
 };
 
-static const io_uuid_spec_t bl33_cert_uuid_spec = {
-	.uuid = UUID_NON_TRUSTED_FIRMWARE_BL33_CERT,
+static const io_uuid_spec_t nt_fw_cert_uuid_spec = {
+	.uuid = UUID_NON_TRUSTED_FW_CONTENT_CERT,
 };
 #endif /* TRUSTED_BOARD_BOOT */
 
@@ -152,9 +135,9 @@ static const struct plat_io_policy policies[] = {
 		open_fip
 	},
 #if TRUSTED_BOARD_BOOT
-	[BL2_CERT_ID] = {
+	[TRUSTED_BOOT_FW_CERT_ID] = {
 		&fip_dev_handle,
-		(uintptr_t)&bl2_cert_uuid_spec,
+		(uintptr_t)&tb_fw_cert_uuid_spec,
 		open_fip
 	},
 	[TRUSTED_KEY_CERT_ID] = {
@@ -162,34 +145,34 @@ static const struct plat_io_policy policies[] = {
 		(uintptr_t)&trusted_key_cert_uuid_spec,
 		open_fip
 	},
-	[BL31_KEY_CERT_ID] = {
+	[SOC_FW_KEY_CERT_ID] = {
 		&fip_dev_handle,
-		(uintptr_t)&bl31_key_cert_uuid_spec,
+		(uintptr_t)&soc_fw_key_cert_uuid_spec,
 		open_fip
 	},
-	[BL32_KEY_CERT_ID] = {
+	[TRUSTED_OS_FW_KEY_CERT_ID] = {
 		&fip_dev_handle,
-		(uintptr_t)&bl32_key_cert_uuid_spec,
+		(uintptr_t)&tos_fw_key_cert_uuid_spec,
 		open_fip
 	},
-	[BL33_KEY_CERT_ID] = {
+	[NON_TRUSTED_FW_KEY_CERT_ID] = {
 		&fip_dev_handle,
-		(uintptr_t)&bl33_key_cert_uuid_spec,
+		(uintptr_t)&nt_fw_key_cert_uuid_spec,
 		open_fip
 	},
-	[BL31_CERT_ID] = {
+	[SOC_FW_CONTENT_CERT_ID] = {
 		&fip_dev_handle,
-		(uintptr_t)&bl31_cert_uuid_spec,
+		(uintptr_t)&soc_fw_cert_uuid_spec,
 		open_fip
 	},
-	[BL32_CERT_ID] = {
+	[TRUSTED_OS_FW_CONTENT_CERT_ID] = {
 		&fip_dev_handle,
-		(uintptr_t)&bl32_cert_uuid_spec,
+		(uintptr_t)&tos_fw_cert_uuid_spec,
 		open_fip
 	},
-	[BL33_CERT_ID] = {
+	[NON_TRUSTED_FW_CONTENT_CERT_ID] = {
 		&fip_dev_handle,
-		(uintptr_t)&bl33_cert_uuid_spec,
+		(uintptr_t)&nt_fw_cert_uuid_spec,
 		open_fip
 	},
 #endif /* TRUSTED_BOARD_BOOT */

--- a/plat/rpi3/rpi3_rotpk.S
+++ b/plat/rpi3/rpi3_rotpk.S
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+	.global rpi3_rotpk_hash
+	.global rpi3_rotpk_hash_end
+rpi3_rotpk_hash:
+	/* DER header */
+	.byte 0x30, 0x31, 0x30, 0x0D, 0x06, 0x09, 0x60, 0x86, 0x48
+	.byte 0x01, 0x65, 0x03, 0x04, 0x02, 0x01, 0x05, 0x00, 0x04, 0x20
+	/* SHA256 */
+	.incbin ROTPK_HASH
+rpi3_rotpk_hash_end:

--- a/plat/rpi3/rpi3_tbbr.c
+++ b/plat/rpi3/rpi3_tbbr.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <platform.h>
+
+extern char rpi3_rotpk_hash[], rpi3_rotpk_hash_end[];
+
+int plat_get_rotpk_info(void *cookie, void **key_ptr, unsigned int *key_len,
+			unsigned int *flags)
+{
+	*key_ptr = rpi3_rotpk_hash;
+	*key_len = rpi3_rotpk_hash_end - rpi3_rotpk_hash;
+	*flags = ROTPK_IS_HASH;
+
+	return 0;
+}
+
+int plat_get_nv_ctr(void *cookie, unsigned int *nv_ctr)
+{
+	*nv_ctr = 0;
+
+	return 0;
+}
+
+int plat_set_nv_ctr(void *cookie, unsigned int nv_ctr)
+{
+	return 1;
+}


### PR DESCRIPTION
This commit applies the development TBBR approach used by QEMU.

To build use:
```
 make \
  PLAT=rpi3 RPI3_BL33_IN_AARCH32=1 \
  BL33=../rpi3-arm-tf-bootstrap/aarch32/el2-bootstrap.bin \
  TRUSTED_BOARD_BOOT=1 \
  MBEDTLS_DIR=../mbedtls/ \
  GENERATE_COT=1 \
  all fip
```
Then in the release directory use:
```
  cp bl1.bin bl1.pad.bin
  truncate --size=65536 bl1.pad.bin
  cat bl1.pad.bin fip.bin > armstub8.bin
```
Signed-off-by: Teddy Reed <teddy.reed@gmail.com>