### PR TITLE
tools/cert_create: fix makefile to build build_msg.o by HOSTCC

### DIFF
--- a/tools/cert_create/Makefile
+++ b/tools/cert_create/Makefile
@@ -75,7 +75,7 @@ ${BINARY}: ${OBJECTS} Makefile
 	@echo "  LD      $@"
 	@echo 'const char build_msg[] = "Built : "__TIME__", "__DATE__; \
                 const char platform_msg[] = "${PLAT_MSG}";' | \
-                ${CC} -c ${CFLAGS} -xc - -o src/build_msg.o
+                ${HOSTCC} -c ${CFLAGS} -xc - -o src/build_msg.o
 	${Q}${HOSTCC} src/build_msg.o ${OBJECTS} ${LIB_DIR} ${LIB} -o $@
 
 %.o: %.c


### PR DESCRIPTION
Previously build_msg.o is built by CC. It causes FTBFS when CC
is not equal to HOSTCC.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>