### PR TITLE
Add device-tree-compiler to the list of packages

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -52,7 +52,7 @@ Install the required packages to build TF-A with the following command:
 
 ::
 
-    sudo apt-get install build-essential gcc make git libssl-dev
+    sudo apt-get install device-tree-compiler build-essential gcc make git libssl-dev
 
 TF-A has been tested with `Linaro Release 17.10`_.
 


### PR DESCRIPTION
Updated the user guide with the build dependency - device-tree-compiler

Change-Id: Ia7800dae52f152b2c3a3b41f1078ab7499d2f4b6
Signed-off-by: Sathees Balya <sathees.balya@arm.com>
