### PR TITLE
Always compile debug macros

### DIFF
--- a/include/common/debug.h
+++ b/include/common/debug.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,10 +7,12 @@
 #ifndef __DEBUG_H__
 #define __DEBUG_H__
 
-/* The log output macros print output to the console. These macros produce
+/*
+ * The log output macros print output to the console. These macros produce
  * compiled log output only if the LOG_LEVEL defined in the makefile (or the
  * make command line) is greater or equal than the level required for that
  * type of log output.
+ *
  * The format expected is the same as for printf(). For example:
  * INFO("Info %s.\n", "message")    -> INFO:    Info message.
  * WARN("Warning %s.\n", "message") -> WARNING: Warning message.
@@ -38,34 +40,46 @@
 #define LOG_MARKER_INFO			"\x28"	/* 40 */
 #define LOG_MARKER_VERBOSE		"\x32"	/* 50 */
 
+/*
+ * If the log output is too low then this macro is used in place of tf_log()
+ * below. The intent is to get the compiler to evaluate the function call for
+ * type checking and format specifier correctness but let it optimize it out.
+ */
+#define no_tf_log(fmt, ...)				\
+	do {						\
+		if (0) {				\
+			tf_log(fmt, ##__VA_ARGS__);	\
+		}					\
+	} while (0)
+
 #if LOG_LEVEL >= LOG_LEVEL_NOTICE
 # define NOTICE(...)	tf_log(LOG_MARKER_NOTICE __VA_ARGS__)
 #else
-# define NOTICE(...)
+# define NOTICE(...)	no_tf_log(LOG_MARKER_NOTICE __VA_ARGS__)
 #endif
 
 #if LOG_LEVEL >= LOG_LEVEL_ERROR
 # define ERROR(...)	tf_log(LOG_MARKER_ERROR __VA_ARGS__)
 #else
-# define ERROR(...)
+# define ERROR(...)	no_tf_log(LOG_MARKER_ERROR __VA_ARGS__)
 #endif
 
 #if LOG_LEVEL >= LOG_LEVEL_WARNING
 # define WARN(...)	tf_log(LOG_MARKER_WARNING __VA_ARGS__)
 #else
-# define WARN(...)
+# define WARN(...)	no_tf_log(LOG_MARKER_WARNING __VA_ARGS__)
 #endif
 
 #if LOG_LEVEL >= LOG_LEVEL_INFO
 # define INFO(...)	tf_log(LOG_MARKER_INFO __VA_ARGS__)
 #else
-# define INFO(...)
+# define INFO(...)	no_tf_log(LOG_MARKER_INFO __VA_ARGS__)
 #endif
 
 #if LOG_LEVEL >= LOG_LEVEL_VERBOSE
 # define VERBOSE(...)	tf_log(LOG_MARKER_VERBOSE __VA_ARGS__)
 #else
-# define VERBOSE(...)
+# define VERBOSE(...)	no_tf_log(LOG_MARKER_VERBOSE __VA_ARGS__)
 #endif
 
 void __dead2 do_panic(void);

--- a/plat/nvidia/tegra/common/tegra_bl31_setup.c
+++ b/plat/nvidia/tegra/common/tegra_bl31_setup.c
@@ -116,9 +116,6 @@ void bl31_early_platform_setup(bl31_params_t *from_bl2,
 {
 	plat_params_from_bl2_t *plat_params =
 		(plat_params_from_bl2_t *)plat_params_from_bl2;
-#if LOG_LEVEL >= LOG_LEVEL_INFO
-	int impl = (read_midr() >> MIDR_IMPL_SHIFT) & MIDR_IMPL_MASK;
-#endif
 	image_info_t bl32_img_info = { {0} };
 	uint64_t tzdram_start, tzdram_end, bl32_start, bl32_end;
 
@@ -227,8 +224,9 @@ void bl31_early_platform_setup(bl31_params_t *from_bl2,
 	/* Early platform setup for Tegra SoCs */
 	plat_early_platform_setup();
 
-	INFO("BL3-1: Boot CPU: %s Processor [%lx]\n", (impl == DENVER_IMPL) ?
-		"Denver" : "ARM", read_mpidr());
+	INFO("BL3-1: Boot CPU: %s Processor [%lx]\n",
+	     (((read_midr() >> MIDR_IMPL_SHIFT) & MIDR_IMPL_MASK)
+	      == DENVER_IMPL) ? "Denver" : "ARM", read_mpidr());
 }
 
 #ifdef SPD_trusty

--- a/services/std_svc/sdei/sdei_main.c
+++ b/services/std_svc/sdei/sdei_main.c
@@ -932,43 +932,43 @@ uint64_t sdei_smc_handler(uint32_t smc_fid,
 	case SDEI_VERSION:
 		SDEI_LOG("> VER\n");
 		ret = sdei_version();
-		SDEI_LOG("< VER:%lx\n", ret);
+		SDEI_LOG("< VER:%llx\n", ret);
 		SMC_RET1(handle, ret);
 
 	case SDEI_EVENT_REGISTER:
 		x5 = SMC_GET_GP(handle, CTX_GPREG_X5);
-		SDEI_LOG("> REG(n:%d e:%lx a:%lx f:%x m:%lx)\n", (int) x1,
+		SDEI_LOG("> REG(n:%d e:%llx a:%llx f:%x m:%llx)\n", (int) x1,
 				x2, x3, (int) x4, x5);
 		ret = sdei_event_register(x1, x2, x3, x4, x5);
-		SDEI_LOG("< REG:%ld\n", ret);
+		SDEI_LOG("< REG:%lld\n", ret);
 		SMC_RET1(handle, ret);
 
 	case SDEI_EVENT_ENABLE:
 		SDEI_LOG("> ENABLE(n:%d)\n", (int) x1);
 		ret = sdei_event_enable(x1);
-		SDEI_LOG("< ENABLE:%ld\n", ret);
+		SDEI_LOG("< ENABLE:%lld\n", ret);
 		SMC_RET1(handle, ret);
 
 	case SDEI_EVENT_DISABLE:
 		SDEI_LOG("> DISABLE(n:%d)\n", (int) x1);
 		ret = sdei_event_disable(x1);
-		SDEI_LOG("< DISABLE:%ld\n", ret);
+		SDEI_LOG("< DISABLE:%lld\n", ret);
 		SMC_RET1(handle, ret);
 
 	case SDEI_EVENT_CONTEXT:
 		SDEI_LOG("> CTX(p:%d):%lx\n", (int) x1, read_mpidr_el1());
 		ret = sdei_event_context(handle, x1);
-		SDEI_LOG("< CTX:%ld\n", ret);
+		SDEI_LOG("< CTX:%lld\n", ret);
 		SMC_RET1(handle, ret);
 
 	case SDEI_EVENT_COMPLETE_AND_RESUME:
 		resume = 1;
 
 	case SDEI_EVENT_COMPLETE:
-		SDEI_LOG("> COMPLETE(r:%d sta/ep:%lx):%lx\n", resume, x1,
+		SDEI_LOG("> COMPLETE(r:%d sta/ep:%llx):%lx\n", resume, x1,
 				read_mpidr_el1());
 		ret = sdei_event_complete(resume, x1);
-		SDEI_LOG("< COMPLETE:%lx\n", ret);
+		SDEI_LOG("< COMPLETE:%llx\n", ret);
 
 		/*
 		 * Set error code only if the call failed. If the call
@@ -985,19 +985,19 @@ uint64_t sdei_smc_handler(uint32_t smc_fid,
 	case SDEI_EVENT_STATUS:
 		SDEI_LOG("> STAT(n:%d)\n", (int) x1);
 		ret = sdei_event_status(x1);
-		SDEI_LOG("< STAT:%ld\n", ret);
+		SDEI_LOG("< STAT:%lld\n", ret);
 		SMC_RET1(handle, ret);
 
 	case SDEI_EVENT_GET_INFO:
 		SDEI_LOG("> INFO(n:%d, %d)\n", (int) x1, (int) x2);
 		ret = sdei_event_get_info(x1, x2);
-		SDEI_LOG("< INFO:%ld\n", ret);
+		SDEI_LOG("< INFO:%lld\n", ret);
 		SMC_RET1(handle, ret);
 
 	case SDEI_EVENT_UNREGISTER:
 		SDEI_LOG("> UNREG(n:%d)\n", (int) x1);
 		ret = sdei_event_unregister(x1);
-		SDEI_LOG("< UNREG:%ld\n", ret);
+		SDEI_LOG("< UNREG:%lld\n", ret);
 		SMC_RET1(handle, ret);
 
 	case SDEI_PE_UNMASK:
@@ -1009,49 +1009,49 @@ uint64_t sdei_smc_handler(uint32_t smc_fid,
 	case SDEI_PE_MASK:
 		SDEI_LOG("> MASK:%lx\n", read_mpidr_el1());
 		ret = sdei_pe_mask();
-		SDEI_LOG("< MASK:%ld\n", ret);
+		SDEI_LOG("< MASK:%lld\n", ret);
 		SMC_RET1(handle, ret);
 
 	case SDEI_INTERRUPT_BIND:
 		SDEI_LOG("> BIND(%d)\n", (int) x1);
 		ret = sdei_interrupt_bind(x1);
-		SDEI_LOG("< BIND:%ld\n", ret);
+		SDEI_LOG("< BIND:%lld\n", ret);
 		SMC_RET1(handle, ret);
 
 	case SDEI_INTERRUPT_RELEASE:
 		SDEI_LOG("> REL(%d)\n", (int) x1);
 		ret = sdei_interrupt_release(x1);
-		SDEI_LOG("< REL:%ld\n", ret);
+		SDEI_LOG("< REL:%lld\n", ret);
 		SMC_RET1(handle, ret);
 
 	case SDEI_SHARED_RESET:
 		SDEI_LOG("> S_RESET():%lx\n", read_mpidr_el1());
 		ret = sdei_shared_reset();
-		SDEI_LOG("< S_RESET:%ld\n", ret);
+		SDEI_LOG("< S_RESET:%lld\n", ret);
 		SMC_RET1(handle, ret);
 
 	case SDEI_PRIVATE_RESET:
 		SDEI_LOG("> P_RESET():%lx\n", read_mpidr_el1());
 		ret = sdei_private_reset();
-		SDEI_LOG("< P_RESET:%ld\n", ret);
+		SDEI_LOG("< P_RESET:%lld\n", ret);
 		SMC_RET1(handle, ret);
 
 	case SDEI_EVENT_ROUTING_SET:
-		SDEI_LOG("> ROUTE_SET(n:%d f:%lx aff:%lx)\n", (int) x1, x2, x3);
+		SDEI_LOG("> ROUTE_SET(n:%d f:%llx aff:%llx)\n", (int) x1, x2, x3);
 		ret = sdei_event_routing_set(x1, x2, x3);
-		SDEI_LOG("< ROUTE_SET:%ld\n", ret);
+		SDEI_LOG("< ROUTE_SET:%lld\n", ret);
 		SMC_RET1(handle, ret);
 
 	case SDEI_FEATURES:
-		SDEI_LOG("> FTRS(f:%lx)\n", x1);
+		SDEI_LOG("> FTRS(f:%llx)\n", x1);
 		ret = sdei_features(x1);
-		SDEI_LOG("< FTRS:%lx\n", ret);
+		SDEI_LOG("< FTRS:%llx\n", ret);
 		SMC_RET1(handle, ret);
 
 	case SDEI_EVENT_SIGNAL:
-		SDEI_LOG("> SIGNAL(e:%lx t:%lx)\n", x1, x2);
+		SDEI_LOG("> SIGNAL(e:%llx t:%llx)\n", x1, x2);
 		ret = sdei_signal(x1, x2);
-		SDEI_LOG("< SIGNAL:%ld\n", ret);
+		SDEI_LOG("< SIGNAL:%lld\n", ret);
 		SMC_RET1(handle, ret);
 
 	default:


### PR DESCRIPTION
These patches modify the debug macros (INFO, NOTICE, ...) to get the compiler to evaluate them all the time. They also fix the build issues that this uncovered.
