### PR TITLE
hikey: include TBB in BL1

### DIFF
--- a/plat/hisilicon/hikey/include/hikey_layout.h
+++ b/plat/hisilicon/hikey/include/hikey_layout.h
@@ -31,20 +31,20 @@
  * + loader +
  * ++++++++++  0xF980_1000
  * + BL1_RO +
- * ++++++++++  0xF981_0000
+ * ++++++++++  0xF981_8000
  * + BL1_RW +
  * ++++++++++  0xF989_8000
  */
 #define BL1_RO_BASE			(XG2RAM0_BASE + BL1_XG2RAM0_OFFSET)
-#define BL1_RO_LIMIT			(XG2RAM0_BASE + 0x10000)
-#define BL1_RW_BASE			(BL1_RO_LIMIT)	/* 0xf981_0000 */
-#define BL1_RW_SIZE			(0x00088000)
+#define BL1_RO_LIMIT			(XG2RAM0_BASE + 0x18000)
+#define BL1_RW_BASE			(BL1_RO_LIMIT)	/* 0xf981_8000 */
+#define BL1_RW_SIZE			(0x00080000)
 #define BL1_RW_LIMIT			(0xF9898000)
 
 /*
  * Non-Secure BL1U specific defines.
  */
-#define NS_BL1U_BASE			(0xf9818000)
+#define NS_BL1U_BASE			(0xf9828000)
 #define NS_BL1U_SIZE			(0x00010000)
 #define NS_BL1U_LIMIT			(NS_BL1U_BASE + NS_BL1U_SIZE)
 

--- a/plat/hisilicon/hikey/platform.mk
+++ b/plat/hisilicon/hikey/platform.mk
@@ -134,6 +134,11 @@ AUTH_SOURCES		:=	drivers/auth/auth_mod.c			\
 				drivers/auth/img_parser_mod.c		\
 				drivers/auth/tbbr/tbbr_cot.c
 
+BL1_SOURCES		+=	${AUTH_SOURCES}				\
+				plat/common/tbbr/plat_tbbr.c		\
+				plat/hisilicon/hikey/hikey_tbbr.c	\
+				plat/hisilicon/hikey/hikey_rotpk.S
+
 BL2_SOURCES		+=	${AUTH_SOURCES}				\
 				plat/common/tbbr/plat_tbbr.c		\
 				plat/hisilicon/hikey/hikey_tbbr.c	\
@@ -143,6 +148,7 @@ ROT_KEY		=	$(BUILD_PLAT)/rot_key.pem
 ROTPK_HASH		=	$(BUILD_PLAT)/rotpk_sha256.bin
 
 $(eval $(call add_define_val,ROTPK_HASH,'"$(ROTPK_HASH)"'))
+$(BUILD_PLAT)/bl1/hikey_rotpk.o: $(ROTPK_HASH)
 $(BUILD_PLAT)/bl2/hikey_rotpk.o: $(ROTPK_HASH)
 
 certificates: $(ROT_KEY)
@@ -154,8 +160,6 @@ $(ROTPK_HASH): $(ROT_KEY)
 	@echo "  OPENSSL $@"
 	$(Q)openssl rsa -in $< -pubout -outform DER 2>/dev/null |\
 	openssl dgst -sha256 -binary > $@ 2>/dev/null
-
-override BL1_SOURCES	=
 endif
 
 # Enable workarounds for selected Cortex-A53 errata.


### PR DESCRIPTION
BL1 is used in recovery mode on HiKey. The TBB implementation
on HiKey is in BL2. It means that user need to build ATF BL2
with TBB and ATF BL1 with non-TBB. It's inconvenient.

So include TBB in BL1, too.

Signed-off-by: Teddy Reed <teddy@prosauce.org>
Signed-off-by: Victor Chong <victor.chong@linaro.org>
Signed-off-by: Haojian Zhuang <haojian.zhuang@linaro.org>