### PR TITLE
synquacer: Enable optional OP-TEE support

### DIFF
--- a/plat/socionext/synquacer/platform.mk
+++ b/plat/socionext/synquacer/platform.mk
@@ -18,6 +18,10 @@ ERRATA_A53_855873		:= 1
 # Libraries
 include lib/xlat_tables_v2/xlat_tables.mk
 
+ifeq (${SPD},opteed)
+TF_CFLAGS_aarch64	+=	-DBL32_BASE=0xfc000000
+endif
+
 PLAT_PATH		:=	plat/socionext/synquacer
 PLAT_INCLUDES		:=	-I$(PLAT_PATH)/include		\
 				-I$(PLAT_PATH)/drivers/scpi	\


### PR DESCRIPTION
OP-TEE loading is optional on Developerbox controlled via SCP
firmware. To check if OP-TEE is loaded or not, we use DRAM1 region
info passed by SCP firmware.

Signed-off-by: Sumit Garg <sumit.garg@linaro.org>
Reviewed-by: Daniel Thompson <daniel.thompson@linaro.org>