### PR TITLE
Arm platforms: Fix type mismatch for arm_pm_idle_states

### DIFF
--- a/include/plat/arm/common/plat_arm.h
+++ b/include/plat/arm/common/plat_arm.h
@@ -292,5 +292,6 @@ void plat_arm_sp_min_early_platform_setup(u_register_t arg0, u_register_t arg1,
 /* global variables */
 extern plat_psci_ops_t plat_arm_psci_pm_ops;
 extern const mmap_region_t plat_arm_mmap[];
+extern const unsigned int arm_pm_idle_states[];
 
 #endif /* __PLAT_ARM_H__ */

--- a/plat/arm/common/arm_pm.c
+++ b/plat/arm/common/arm_pm.c
@@ -18,10 +18,6 @@
 #pragma weak plat_arm_psci_override_pm_ops
 #pragma weak plat_arm_program_trusted_mailbox
 
-#if ARM_RECOM_STATE_ID_ENC
-extern unsigned int arm_pm_idle_states[];
-#endif /* __ARM_RECOM_STATE_ID_ENC__ */
-
 #if !ARM_RECOM_STATE_ID_ENC
 /*******************************************************************************
  * ARM standard platform handler called to check the validity of the power state


### PR DESCRIPTION
This also gets rid of MISRA violations for Rule 8.3 and 8.4.

Change-Id: I45bba011b16f90953dd4b260fcd58381f978eedc
Signed-off-by: Jeenu Viswambharan <jeenu.viswambharan@arm.com>