### PR TITLE
Fix MISRA defects in xlat tables lib and SP805 driver

### DIFF
--- a/drivers/arm/sp805/sp805.c
+++ b/drivers/arm/sp805/sp805.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,17 +10,17 @@
 
 /* Inline register access functions */
 
-static inline void sp805_write_wdog_load(uintptr_t base, unsigned long value)
+static inline void sp805_write_wdog_load(uintptr_t base, uint32_t value)
 {
 	mmio_write_32(base + SP805_WDOG_LOAD_OFF, value);
 }
 
-static inline void sp805_write_wdog_ctrl(uintptr_t base, unsigned long value)
+static inline void sp805_write_wdog_ctrl(uintptr_t base, uint32_t value)
 {
 	mmio_write_32(base + SP805_WDOG_CTR_OFF, value);
 }
 
-static inline void sp805_write_wdog_lock(uintptr_t base, unsigned long value)
+static inline void sp805_write_wdog_lock(uintptr_t base, uint32_t value)
 {
 	mmio_write_32(base + SP805_WDOG_LOCK_OFF, value);
 }
@@ -28,23 +28,23 @@ static inline void sp805_write_wdog_lock(uintptr_t base, unsigned long value)
 
 /* Public API implementation */
 
-void sp805_start(uintptr_t base, unsigned long ticks)
+void sp805_start(uintptr_t base, unsigned int ticks)
 {
 	sp805_write_wdog_load(base, ticks);
 	sp805_write_wdog_ctrl(base, SP805_CTR_RESEN | SP805_CTR_INTEN);
 	/* Lock registers access */
-	sp805_write_wdog_lock(base, 0);
+	sp805_write_wdog_lock(base, 0U);
 }
 
 void sp805_stop(uintptr_t base)
 {
 	sp805_write_wdog_lock(base, WDOG_UNLOCK_KEY);
-	sp805_write_wdog_ctrl(base, 0);
+	sp805_write_wdog_ctrl(base, 0U);
 }
 
-void sp805_refresh(uintptr_t base, unsigned long ticks)
+void sp805_refresh(uintptr_t base, unsigned int ticks)
 {
 	sp805_write_wdog_lock(base, WDOG_UNLOCK_KEY);
 	sp805_write_wdog_load(base, ticks);
-	sp805_write_wdog_lock(base, 0);
+	sp805_write_wdog_lock(base, 0U);
 }

--- a/include/drivers/arm/sp805.h
+++ b/include/drivers/arm/sp805.h
@@ -1,23 +1,25 @@
 /*
- * Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __SP805_H__
-#define __SP805_H__
+#ifndef SP805_H
+#define SP805_H
+
+#include <utils_def.h>
 
 /* SP805 register offset */
-#define SP805_WDOG_LOAD_OFF		0x000
-#define SP805_WDOG_CTR_OFF		0x008
-#define SP805_WDOG_LOCK_OFF		0xc00
+#define SP805_WDOG_LOAD_OFF		UL(0x000)
+#define SP805_WDOG_CTR_OFF		UL(0x008)
+#define SP805_WDOG_LOCK_OFF		UL(0xc00)
 
 /* Magic word to unlock the wd registers */
-#define WDOG_UNLOCK_KEY			0x1ACCE551
+#define WDOG_UNLOCK_KEY			U(0x1ACCE551)
 
 /* Register field definitions */
-#define SP805_CTR_RESEN			(1 << 1)
-#define SP805_CTR_INTEN			(1 << 0)
+#define SP805_CTR_RESEN			(U(1) << 1)
+#define SP805_CTR_INTEN			(U(1) << 0)
 
 #ifndef __ASSEMBLY__
 
@@ -25,10 +27,10 @@
 
 /* Public high level API */
 
-void sp805_start(uintptr_t base, unsigned long ticks);
+void sp805_start(uintptr_t base, unsigned int ticks);
 void sp805_stop(uintptr_t base);
-void sp805_refresh(uintptr_t base, unsigned long ticks);
+void sp805_refresh(uintptr_t base, unsigned int ticks);
 
 #endif /* __ASSEMBLY__ */
 
-#endif /* __SP805_H__ */
+#endif /* SP805_H */

--- a/include/lib/xlat_tables/aarch32/xlat_tables_aarch32.h
+++ b/include/lib/xlat_tables/aarch32/xlat_tables_aarch32.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __XLAT_TABLES_AARCH32_H__
-#define __XLAT_TABLES_AARCH32_H__
+#ifndef XLAT_TABLES_AARCH32_H
+#define XLAT_TABLES_AARCH32_H
 
 #include <arch.h>
 #include <utils_def.h>
@@ -24,7 +24,7 @@
  * The define below specifies the first table level that allows block
  * descriptors.
  */
-#if PAGE_SIZE != (4 * 1024)
+#if PAGE_SIZE != PAGE_SIZE_4KB
 #error "Invalid granule size. AArch32 supports 4KB pages only."
 #endif
 
@@ -43,8 +43,8 @@
  * [1] See the ARMv8-A Architecture Reference Manual (DDI 0487A.j) for more
  * information, Section G4.6.5
  */
-#define MIN_VIRT_ADDR_SPACE_SIZE	(ULL(1) << (32 - TTBCR_TxSZ_MAX))
-#define MAX_VIRT_ADDR_SPACE_SIZE	(ULL(1) << (32 - TTBCR_TxSZ_MIN))
+#define MIN_VIRT_ADDR_SPACE_SIZE	(ULL(1) << (U(32) - TTBCR_TxSZ_MAX))
+#define MAX_VIRT_ADDR_SPACE_SIZE	(ULL(1) << (U(32) - TTBCR_TxSZ_MIN))
 
 /*
  * Here we calculate the initial lookup level from the value of the given
@@ -66,7 +66,8 @@
  * valid. Therefore, the caller is expected to check it is the case using the
  * CHECK_VIRT_ADDR_SPACE_SIZE() macro first.
  */
-#define GET_XLAT_TABLE_LEVEL_BASE(_virt_addr_space_size)			\
-	(((_virt_addr_space_size) > (ULL(1) << L1_XLAT_ADDRESS_SHIFT)) ? 1 : 2)
+#define GET_XLAT_TABLE_LEVEL_BASE(_virt_addr_space_sz)			\
+	(((_virt_addr_space_sz) > (ULL(1) << L1_XLAT_ADDRESS_SHIFT)) ?	\
+	 U(1) : U(2))
 
-#endif /* __XLAT_TABLES_AARCH32_H__ */
+#endif /* XLAT_TABLES_AARCH32_H */

--- a/include/lib/xlat_tables/aarch64/xlat_tables_aarch64.h
+++ b/include/lib/xlat_tables/aarch64/xlat_tables_aarch64.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __XLAT_TABLES_AARCH64_H__
-#define __XLAT_TABLES_AARCH64_H__
+#ifndef XLAT_TABLES_AARCH64_H
+#define XLAT_TABLES_AARCH64_H
 
 #include <arch.h>
 #include <utils_def.h>
@@ -30,9 +30,9 @@ unsigned long long tcr_physical_addr_size_bits(unsigned long long max_addr);
  * The define below specifies the first table level that allows block
  * descriptors.
  */
-#if PAGE_SIZE == (4 * 1024)
+#if PAGE_SIZE == PAGE_SIZE_4KB
 # define MIN_LVL_BLOCK_DESC	U(1)
-#elif PAGE_SIZE == (16 * 1024) || PAGE_SIZE == (64 * 1024)
+#elif (PAGE_SIZE == PAGE_SIZE_16KB) || (PAGE_SIZE == PAGE_SIZE_64KB)
 # define MIN_LVL_BLOCK_DESC	U(2)
 #endif
 
@@ -50,8 +50,8 @@ unsigned long long tcr_physical_addr_size_bits(unsigned long long max_addr);
  * information:
  * Page 1730: 'Input address size', 'For all translation stages'.
  */
-#define MIN_VIRT_ADDR_SPACE_SIZE	(ULL(1) << (64 - TCR_TxSZ_MAX))
-#define MAX_VIRT_ADDR_SPACE_SIZE	(ULL(1) << (64 - TCR_TxSZ_MIN))
+#define MIN_VIRT_ADDR_SPACE_SIZE	(ULL(1) << (U(64) - TCR_TxSZ_MAX))
+#define MAX_VIRT_ADDR_SPACE_SIZE	(ULL(1) << (U(64) - TCR_TxSZ_MIN))
 
 /*
  * Here we calculate the initial lookup level from the value of the given
@@ -74,10 +74,10 @@ unsigned long long tcr_physical_addr_size_bits(unsigned long long max_addr);
  * valid. Therefore, the caller is expected to check it is the case using the
  * CHECK_VIRT_ADDR_SPACE_SIZE() macro first.
  */
-#define GET_XLAT_TABLE_LEVEL_BASE(_virt_addr_space_size)				\
-	(((_virt_addr_space_size) > (ULL(1) << L0_XLAT_ADDRESS_SHIFT))		\
-	? 0									\
-	 : (((_virt_addr_space_size) > (ULL(1) << L1_XLAT_ADDRESS_SHIFT))	\
-	 ? 1 : 2))
+#define GET_XLAT_TABLE_LEVEL_BASE(_virt_addr_space_sz)		\
+	(((_virt_addr_space_sz) > (ULL(1) << L0_XLAT_ADDRESS_SHIFT))	\
+	? 0U								\
+	 : (((_virt_addr_space_sz) > (ULL(1) << L1_XLAT_ADDRESS_SHIFT))	\
+	 ? 1U : 2U))
 
-#endif /* __XLAT_TABLES_AARCH64_H__ */
+#endif /* XLAT_TABLES_AARCH64_H */

--- a/include/lib/xlat_tables/xlat_mmu_helpers.h
+++ b/include/lib/xlat_tables/xlat_mmu_helpers.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __XLAT_MMU_HELPERS_H__
-#define __XLAT_MMU_HELPERS_H__
+#ifndef XLAT_MMU_HELPERS_H
+#define XLAT_MMU_HELPERS_H
 
 /*
  * The following flags are passed to enable_mmu_xxx() to override the default
@@ -52,6 +52,7 @@
 
 #ifndef __ASSEMBLY__
 
+#include <stdint.h>
 #include <sys/types.h>
 
 /*
@@ -82,4 +83,4 @@ size_t xlat_arch_get_max_supported_granule_size(void);
 
 #endif /* __ASSEMBLY__ */
 
-#endif /* __XLAT_MMU_HELPERS_H__ */
+#endif /* XLAT_MMU_HELPERS_H */

--- a/include/lib/xlat_tables/xlat_tables.h
+++ b/include/lib/xlat_tables/xlat_tables.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2014-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __XLAT_TABLES_H__
-#define __XLAT_TABLES_H__
+#ifndef XLAT_TABLES_H
+#define XLAT_TABLES_H
 
 #include <xlat_tables_defs.h>
 
@@ -92,4 +92,4 @@ void mmap_add_region(unsigned long long base_pa, uintptr_t base_va,
 void mmap_add(const mmap_region_t *mm);
 
 #endif /*__ASSEMBLY__*/
-#endif /* __XLAT_TABLES_H__ */
+#endif /* XLAT_TABLES_H */

--- a/include/lib/xlat_tables/xlat_tables_arch.h
+++ b/include/lib/xlat_tables/xlat_tables_arch.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __XLAT_TABLES_ARCH_H__
-#define __XLAT_TABLES_ARCH_H__
+#ifndef XLAT_TABLES_ARCH_H
+#define XLAT_TABLES_ARCH_H
 
 #ifdef AARCH32
 #include "aarch32/xlat_tables_aarch32.h"
@@ -21,8 +21,8 @@
  * limits. Not that these limits are different for AArch32 and AArch64.
  */
 #define CHECK_VIRT_ADDR_SPACE_SIZE(size)			\
-	(((unsigned long long)(size) >= MIN_VIRT_ADDR_SPACE_SIZE) &&		\
-	((unsigned long long)(size) <= MAX_VIRT_ADDR_SPACE_SIZE) &&		\
+	(((unsigned long long)(size) >= MIN_VIRT_ADDR_SPACE_SIZE) &&	\
+	((unsigned long long)(size) <= MAX_VIRT_ADDR_SPACE_SIZE) &&	\
 	IS_POWER_OF_TWO(size))
 
 /*
@@ -40,4 +40,4 @@
 	((addr_space_size) >>						\
 		XLAT_ADDR_SHIFT(GET_XLAT_TABLE_LEVEL_BASE(addr_space_size)))
 
-#endif /* __XLAT_TABLES_ARCH_H__ */
+#endif /* XLAT_TABLES_ARCH_H */

--- a/include/lib/xlat_tables/xlat_tables_defs.h
+++ b/include/lib/xlat_tables/xlat_tables_defs.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __XLAT_TABLES_DEFS_H__
-#define __XLAT_TABLES_DEFS_H__
+#ifndef XLAT_TABLES_DEFS_H
+#define XLAT_TABLES_DEFS_H
 
 #include <arch.h>
 #include <utils_def.h>
@@ -23,6 +23,10 @@
 #define ONE_GB_INDEX(x)		((x) >> ONE_GB_SHIFT)
 #define TWO_MB_INDEX(x)		((x) >> TWO_MB_SHIFT)
 #define FOUR_KB_INDEX(x)	((x) >> FOUR_KB_SHIFT)
+
+#define PAGE_SIZE_4KB		U(4096)
+#define PAGE_SIZE_16KB		U(16384)
+#define PAGE_SIZE_64KB		U(65536)
 
 #define INVALID_DESC		U(0x0)
 /*
@@ -66,8 +70,8 @@
  */
 #define PAGE_SIZE_SHIFT		FOUR_KB_SHIFT
 #define PAGE_SIZE		(U(1) << PAGE_SIZE_SHIFT)
-#define PAGE_SIZE_MASK		(PAGE_SIZE - 1)
-#define IS_PAGE_ALIGNED(addr)	(((addr) & PAGE_SIZE_MASK) == 0)
+#define PAGE_SIZE_MASK		(PAGE_SIZE - U(1))
+#define IS_PAGE_ALIGNED(addr)	(((addr) & PAGE_SIZE_MASK) == U(0))
 
 #define XLAT_ENTRY_SIZE_SHIFT	U(3) /* Each MMU table entry is 8 bytes (1 << 3) */
 #define XLAT_ENTRY_SIZE		(U(1) << XLAT_ENTRY_SIZE_SHIFT)
@@ -80,7 +84,7 @@
 /* Values for number of entries in each MMU translation table */
 #define XLAT_TABLE_ENTRIES_SHIFT (XLAT_TABLE_SIZE_SHIFT - XLAT_ENTRY_SIZE_SHIFT)
 #define XLAT_TABLE_ENTRIES	(U(1) << XLAT_TABLE_ENTRIES_SHIFT)
-#define XLAT_TABLE_ENTRIES_MASK	(XLAT_TABLE_ENTRIES - 1)
+#define XLAT_TABLE_ENTRIES_MASK	(XLAT_TABLE_ENTRIES - U(1))
 
 /* Values to convert a memory address to an index into a translation table */
 #define L3_XLAT_ADDRESS_SHIFT	PAGE_SIZE_SHIFT
@@ -90,9 +94,9 @@
 #define XLAT_ADDR_SHIFT(level)	(PAGE_SIZE_SHIFT + \
 		  ((XLAT_TABLE_LEVEL_MAX - (level)) * XLAT_TABLE_ENTRIES_SHIFT))
 
-#define XLAT_BLOCK_SIZE(level)	((u_register_t)1 << XLAT_ADDR_SHIFT(level))
+#define XLAT_BLOCK_SIZE(level)	(UL(1) << XLAT_ADDR_SHIFT(level))
 /* Mask to get the bits used to index inside a block of a certain level */
-#define XLAT_BLOCK_MASK(level)	(XLAT_BLOCK_SIZE(level) - 1)
+#define XLAT_BLOCK_MASK(level)	(XLAT_BLOCK_SIZE(level) - UL(1))
 /* Mask to get the address bits common to a block of a certain table level*/
 #define XLAT_ADDR_MASK(level)	(~XLAT_BLOCK_MASK(level))
 /*
@@ -111,13 +115,13 @@
  * when stage 1 translations can only support one VA range.
  */
 #define AP2_SHIFT			U(0x7)
-#define AP2_RO				U(0x1)
-#define AP2_RW				U(0x0)
+#define AP2_RO				ULL(0x1)
+#define AP2_RW				ULL(0x0)
 
 #define AP1_SHIFT			U(0x6)
-#define AP1_ACCESS_UNPRIVILEGED		U(0x1)
-#define AP1_NO_ACCESS_UNPRIVILEGED	U(0x0)
-#define AP1_RES1			U(0x1)
+#define AP1_ACCESS_UNPRIVILEGED		ULL(0x1)
+#define AP1_NO_ACCESS_UNPRIVILEGED	ULL(0x0)
+#define AP1_RES1			ULL(0x1)
 
 /*
  * The following definitions must all be passed to the LOWER_ATTRS() macro to
@@ -129,9 +133,9 @@
 #define AP_NO_ACCESS_UNPRIVILEGED	(AP1_NO_ACCESS_UNPRIVILEGED << 4)
 #define AP_ONE_VA_RANGE_RES1		(AP1_RES1 << 4)
 #define NS				(U(0x1) << 3)
-#define ATTR_NON_CACHEABLE_INDEX	U(0x2)
-#define ATTR_DEVICE_INDEX		U(0x1)
-#define ATTR_IWBWA_OWBWA_NTR_INDEX	U(0x0)
+#define ATTR_NON_CACHEABLE_INDEX	ULL(0x2)
+#define ATTR_DEVICE_INDEX		ULL(0x1)
+#define ATTR_IWBWA_OWBWA_NTR_INDEX	ULL(0x0)
 #define LOWER_ATTRS(x)			(((x) & U(0xfff)) << 2)
 
 /* Normal Memory, Outer Write-Through non-transient, Inner Non-cacheable */

--- a/include/lib/xlat_tables/xlat_tables_v2.h
+++ b/include/lib/xlat_tables/xlat_tables_v2.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __XLAT_TABLES_V2_H__
-#define __XLAT_TABLES_V2_H__
+#ifndef XLAT_TABLES_V2_H
+#define XLAT_TABLES_V2_H
 
 #include <xlat_tables_defs.h>
 #include <xlat_tables_v2_helpers.h>
@@ -27,7 +27,7 @@
 
 /* Helper macro to define an mmap_region_t. */
 #define MAP_REGION(_pa, _va, _sz, _attr)	\
-	_MAP_REGION_FULL_SPEC(_pa, _va, _sz, _attr, REGION_DEFAULT_GRANULARITY)
+	MAP_REGION_FULL_SPEC(_pa, _va, _sz, _attr, REGION_DEFAULT_GRANULARITY)
 
 /* Helper macro to define an mmap_region_t with an identity mapping. */
 #define MAP_REGION_FLAT(_adr, _sz, _attr)			\
@@ -44,7 +44,7 @@
  * equivalent to the MAP_REGION() macro.
  */
 #define MAP_REGION2(_pa, _va, _sz, _attr, _gr)			\
-	_MAP_REGION_FULL_SPEC(_pa, _va, _sz, _attr, _gr)
+	MAP_REGION_FULL_SPEC(_pa, _va, _sz, _attr, _gr)
 
 /*
  * Shifts and masks to access fields of an mmap attribute
@@ -163,7 +163,7 @@ typedef struct xlat_ctx xlat_ctx_t;
  */
 #define REGISTER_XLAT_CONTEXT(_ctx_name, _mmap_count, _xlat_tables_count, \
 			_virt_addr_space_size, _phy_addr_space_size)	\
-	_REGISTER_XLAT_CONTEXT_FULL_SPEC(_ctx_name, (_mmap_count),	\
+	REGISTER_XLAT_CONTEXT_FULL_SPEC(_ctx_name, (_mmap_count),	\
 					 (_xlat_tables_count),		\
 					 (_virt_addr_space_size),	\
 					 (_phy_addr_space_size),	\
@@ -183,7 +183,7 @@ typedef struct xlat_ctx xlat_ctx_t;
 #define REGISTER_XLAT_CONTEXT2(_ctx_name, _mmap_count, _xlat_tables_count, \
 			_virt_addr_space_size, _phy_addr_space_size,	\
 			_xlat_regime, _section_name)			\
-	_REGISTER_XLAT_CONTEXT_FULL_SPEC(_ctx_name, (_mmap_count),	\
+	REGISTER_XLAT_CONTEXT_FULL_SPEC(_ctx_name, (_mmap_count),	\
 					 (_xlat_tables_count),		\
 					 (_virt_addr_space_size),	\
 					 (_phy_addr_space_size),	\
@@ -296,7 +296,7 @@ int mmap_remove_dynamic_region_ctx(xlat_ctx_t *ctx,
  * translation tables are not modified by any other code while this function is
  * executing.
  */
-int change_mem_attributes(xlat_ctx_t *ctx, uintptr_t base_va, size_t size,
+int change_mem_attributes(const xlat_ctx_t *ctx, uintptr_t base_va, size_t size,
 			  uint32_t attr);
 
 /*
@@ -318,4 +318,4 @@ int get_mem_attributes(const xlat_ctx_t *ctx, uintptr_t base_va,
 		       uint32_t *attributes);
 
 #endif /*__ASSEMBLY__*/
-#endif /* __XLAT_TABLES_V2_H__ */
+#endif /* XLAT_TABLES_V2_H */

--- a/include/lib/xlat_tables/xlat_tables_v2_helpers.h
+++ b/include/lib/xlat_tables/xlat_tables_v2_helpers.h
@@ -9,10 +9,10 @@
  * used outside of this library code.
  */
 
-#ifndef __XLAT_TABLES_V2_HELPERS_H__
-#define __XLAT_TABLES_V2_HELPERS_H__
+#ifndef XLAT_TABLES_V2_HELPERS_H
+#define XLAT_TABLES_V2_HELPERS_H
 
-#ifndef __XLAT_TABLES_V2_H__
+#ifndef XLAT_TABLES_V2_H
 #error "Do not include this header file directly. Include xlat_tables_v2.h instead."
 #endif
 
@@ -32,7 +32,7 @@ struct mmap_region;
  * the fields of the structure but its parameter list is not guaranteed to
  * remain stable as we add members to mmap_region_t.
  */
-#define _MAP_REGION_FULL_SPEC(_pa, _va, _sz, _attr, _gr)	\
+#define MAP_REGION_FULL_SPEC(_pa, _va, _sz, _attr, _gr)		\
 	{							\
 		.base_pa = (_pa),				\
 		.base_va = (_va),				\
@@ -58,7 +58,7 @@ struct xlat_ctx {
 	 * null entry.
 	 */
 	struct mmap_region *mmap;
-	unsigned int mmap_num;
+	int mmap_num;
 
 	/*
 	 * Array of finer-grain translation tables.
@@ -66,7 +66,7 @@ struct xlat_ctx {
 	 * contain both level-2 and level-3 entries.
 	 */
 	uint64_t (*tables)[XLAT_TABLE_ENTRIES];
-	unsigned int tables_num;
+	int tables_num;
 	/*
 	 * Keep track of how many regions are mapped in each table. The base
 	 * table can't be unmapped so it isn't needed to keep track of it.
@@ -75,7 +75,7 @@ struct xlat_ctx {
 	int *tables_mapped_regions;
 #endif /* PLAT_XLAT_TABLES_DYNAMIC */
 
-	unsigned int next_table;
+	int next_table;
 
 	/*
 	 * Base translation table. It doesn't need to have the same amount of
@@ -96,7 +96,7 @@ struct xlat_ctx {
 	unsigned int base_level;
 
 	/* Set to 1 when the translation tables are initialized. */
-	unsigned int initialized;
+	int initialized;
 
 	/*
 	 * Translation regime managed by this xlat_ctx_t. It should be one of
@@ -106,60 +106,60 @@ struct xlat_ctx {
 };
 
 #if PLAT_XLAT_TABLES_DYNAMIC
-#define _ALLOC_DYNMAP_STRUCT(_ctx_name, _xlat_tables_count)		\
+#define XLAT_ALLOC_DYNMAP_STRUCT(_ctx_name, _xlat_tables_count)		\
 	static int _ctx_name##_mapped_regions[_xlat_tables_count];
 
-#define _REGISTER_DYNMAP_STRUCT(_ctx_name)				\
+#define XLAT_REGISTER_DYNMAP_STRUCT(_ctx_name)				\
 	.tables_mapped_regions = _ctx_name##_mapped_regions,
 #else
-#define _ALLOC_DYNMAP_STRUCT(_ctx_name, _xlat_tables_count)		\
+#define XLAT_ALLOC_DYNMAP_STRUCT(_ctx_name, _xlat_tables_count)		\
 	/* do nothing */
 
-#define _REGISTER_DYNMAP_STRUCT(_ctx_name)				\
+#define XLAT_REGISTER_DYNMAP_STRUCT(_ctx_name)				\
 	/* do nothing */
 #endif /* PLAT_XLAT_TABLES_DYNAMIC */
 
-#define _REGISTER_XLAT_CONTEXT_FULL_SPEC(_ctx_name, _mmap_count, _xlat_tables_count,	\
-			_virt_addr_space_size, _phy_addr_space_size,		\
-			_xlat_regime, _section_name)				\
-	CASSERT(CHECK_VIRT_ADDR_SPACE_SIZE(_virt_addr_space_size),		\
-		assert_invalid_virtual_addr_space_size_for_##_ctx_name);	\
-										\
-	CASSERT(CHECK_PHY_ADDR_SPACE_SIZE(_phy_addr_space_size),		\
-		assert_invalid_physical_addr_space_sizefor_##_ctx_name);	\
-										\
-	static mmap_region_t _ctx_name##_mmap[_mmap_count + 1];			\
-										\
-	static uint64_t _ctx_name##_xlat_tables[_xlat_tables_count]		\
-		[XLAT_TABLE_ENTRIES]						\
-		__aligned(XLAT_TABLE_SIZE) __section(_section_name);		\
-										\
-	static uint64_t _ctx_name##_base_xlat_table				\
-		[GET_NUM_BASE_LEVEL_ENTRIES(_virt_addr_space_size)]		\
-		__aligned(GET_NUM_BASE_LEVEL_ENTRIES(_virt_addr_space_size)	\
-			* sizeof(uint64_t));					\
-										\
-	_ALLOC_DYNMAP_STRUCT(_ctx_name, _xlat_tables_count)			\
-										\
-	static xlat_ctx_t _ctx_name##_xlat_ctx = {				\
-		.va_max_address = (_virt_addr_space_size) - 1,			\
-		.pa_max_address = (_phy_addr_space_size) - 1,			\
-		.mmap = _ctx_name##_mmap,					\
-		.mmap_num = (_mmap_count),					\
-		.base_level = GET_XLAT_TABLE_LEVEL_BASE(_virt_addr_space_size),	\
-		.base_table = _ctx_name##_base_xlat_table,			\
-		.base_table_entries =						\
-			GET_NUM_BASE_LEVEL_ENTRIES(_virt_addr_space_size),	\
-		.tables = _ctx_name##_xlat_tables,				\
-		.tables_num = _xlat_tables_count,				\
-		 _REGISTER_DYNMAP_STRUCT(_ctx_name)				\
-		.xlat_regime = (_xlat_regime),					\
-		.max_pa = 0,							\
-		.max_va = 0,							\
-		.next_table = 0,						\
-		.initialized = 0,						\
+#define REGISTER_XLAT_CONTEXT_FULL_SPEC(_ctx_name, _mmap_count,		\
+			_xlat_tables_count, _virt_addr_space_size,	\
+			_phy_addr_space_size, _xlat_regime, _section_name)\
+	CASSERT(CHECK_VIRT_ADDR_SPACE_SIZE(_virt_addr_space_size),	\
+		assert_invalid_virtual_addr_space_size_for_##_ctx_name);\
+									\
+	CASSERT(CHECK_PHY_ADDR_SPACE_SIZE(_phy_addr_space_size),	\
+		assert_invalid_physical_addr_space_sizefor_##_ctx_name);\
+									\
+	static mmap_region_t _ctx_name##_mmap[_mmap_count + 1];		\
+									\
+	static uint64_t _ctx_name##_xlat_tables[_xlat_tables_count]	\
+		[XLAT_TABLE_ENTRIES]					\
+		__aligned(XLAT_TABLE_SIZE) __section(_section_name);	\
+									\
+	static uint64_t _ctx_name##_base_xlat_table			\
+		[GET_NUM_BASE_LEVEL_ENTRIES(_virt_addr_space_size)]	\
+		__aligned(GET_NUM_BASE_LEVEL_ENTRIES(_virt_addr_space_size)\
+			* sizeof(uint64_t));				\
+									\
+	XLAT_ALLOC_DYNMAP_STRUCT(_ctx_name, _xlat_tables_count)		\
+									\
+	static xlat_ctx_t _ctx_name##_xlat_ctx = {			\
+		.va_max_address = (_virt_addr_space_size) - 1UL,	\
+		.pa_max_address = (_phy_addr_space_size) - 1ULL,	\
+		.mmap = _ctx_name##_mmap,				\
+		.mmap_num = (_mmap_count),				\
+		.base_level = GET_XLAT_TABLE_LEVEL_BASE(_virt_addr_space_size),\
+		.base_table = _ctx_name##_base_xlat_table,		\
+		.base_table_entries =					\
+			GET_NUM_BASE_LEVEL_ENTRIES(_virt_addr_space_size),\
+		.tables = _ctx_name##_xlat_tables,			\
+		.tables_num = _xlat_tables_count,			\
+		 XLAT_REGISTER_DYNMAP_STRUCT(_ctx_name)			\
+		.xlat_regime = (_xlat_regime),				\
+		.max_pa = 0U,						\
+		.max_va = 0U,						\
+		.next_table = 0,					\
+		.initialized = 0,					\
 	}
 
 #endif /*__ASSEMBLY__*/
 
-#endif /* __XLAT_TABLES_V2_HELPERS_H__ */
+#endif /* XLAT_TABLES_V2_HELPERS_H */

--- a/lib/xlat_tables/aarch32/xlat_tables.c
+++ b/lib/xlat_tables/aarch32/xlat_tables.c
@@ -13,7 +13,7 @@
 #include <xlat_tables.h>
 #include "../xlat_tables_private.h"
 
-#if ARM_ARCH_MAJOR == 7 && !defined(ARMV7_SUPPORTS_LARGE_PAGE_ADDRESSING)
+#if (ARM_ARCH_MAJOR == 7) && !defined(ARMV7_SUPPORTS_LARGE_PAGE_ADDRESSING)
 #error ARMv7 target does not support LPAE MMU descriptors
 #endif
 
@@ -34,16 +34,16 @@ static unsigned long long get_max_supported_pa(void)
 }
 #endif /* ENABLE_ASSERTIONS */
 
-int xlat_arch_current_el(void)
+unsigned int xlat_arch_current_el(void)
 {
 	/*
 	 * If EL3 is in AArch32 mode, all secure PL1 modes (Monitor, System,
 	 * SVC, Abort, UND, IRQ and FIQ modes) execute at EL3.
 	 */
-	return 3;
+	return 3U;
 }
 
-uint64_t xlat_arch_get_xn_desc(int el __unused)
+uint64_t xlat_arch_get_xn_desc(unsigned int el __unused)
 {
 	return UPPER_ATTRS(XN);
 }
@@ -53,12 +53,12 @@ void init_xlat_tables(void)
 	unsigned long long max_pa;
 	uintptr_t max_va;
 	print_mmap();
-	init_xlation_table(0, base_xlation_table, XLAT_TABLE_LEVEL_BASE,
+	init_xlation_table(0U, base_xlation_table, XLAT_TABLE_LEVEL_BASE,
 						&max_va, &max_pa);
 
-	assert(max_va <= PLAT_VIRT_ADDR_SPACE_SIZE - 1);
-	assert(max_pa <= PLAT_PHY_ADDR_SPACE_SIZE - 1);
-	assert((PLAT_PHY_ADDR_SPACE_SIZE - 1) <= get_max_supported_pa());
+	assert(max_va <= (PLAT_VIRT_ADDR_SPACE_SIZE - 1U));
+	assert(max_pa <= (PLAT_PHY_ADDR_SPACE_SIZE - 1U));
+	assert((PLAT_PHY_ADDR_SPACE_SIZE - 1U) <= get_max_supported_pa());
 }
 
 /*******************************************************************************
@@ -71,7 +71,7 @@ void enable_mmu_secure(unsigned int flags)
 	uint64_t ttbr0;
 
 	assert(IS_IN_SECURE());
-	assert((read_sctlr() & SCTLR_M_BIT) == 0);
+	assert((read_sctlr() & SCTLR_M_BIT) == 0U);
 
 	/* Set attributes in the right indices of the MAIR */
 	mair0 = MAIR0_ATTR_SET(ATTR_DEVICE, ATTR_DEVICE_INDEX);
@@ -87,18 +87,18 @@ void enable_mmu_secure(unsigned int flags)
 	/*
 	 * Set TTBCR bits as well. Set TTBR0 table properties. Disable TTBR1.
 	 */
-	if (flags & XLAT_TABLE_NC) {
+	int t0sz = 32 - __builtin_ctzll(PLAT_VIRT_ADDR_SPACE_SIZE);
+
+	if ((flags & XLAT_TABLE_NC) != 0U) {
 		/* Inner & outer non-cacheable non-shareable. */
 		ttbcr = TTBCR_EAE_BIT |
 			TTBCR_SH0_NON_SHAREABLE | TTBCR_RGN0_OUTER_NC |
-			TTBCR_RGN0_INNER_NC |
-			(32 - __builtin_ctzll(PLAT_VIRT_ADDR_SPACE_SIZE));
+			TTBCR_RGN0_INNER_NC | (uint32_t) t0sz;
 	} else {
 		/* Inner & outer WBWA & shareable. */
 		ttbcr = TTBCR_EAE_BIT |
 			TTBCR_SH0_INNER_SHAREABLE | TTBCR_RGN0_OUTER_WBA |
-			TTBCR_RGN0_INNER_WBA |
-			(32 - __builtin_ctzll(PLAT_VIRT_ADDR_SPACE_SIZE));
+			TTBCR_RGN0_INNER_WBA | (uint32_t) t0sz;
 	}
 	ttbcr |= TTBCR_EPD1_BIT;
 	write_ttbcr(ttbcr);
@@ -106,7 +106,7 @@ void enable_mmu_secure(unsigned int flags)
 	/* Set TTBR0 bits as well */
 	ttbr0 = (uintptr_t) base_xlation_table;
 	write64_ttbr0(ttbr0);
-	write64_ttbr1(0);
+	write64_ttbr1(0U);
 
 	/*
 	 * Ensure all translation table writes have drained
@@ -120,7 +120,7 @@ void enable_mmu_secure(unsigned int flags)
 	sctlr = read_sctlr();
 	sctlr |= SCTLR_WXN_BIT | SCTLR_M_BIT;
 
-	if (flags & DISABLE_DCACHE)
+	if ((flags & DISABLE_DCACHE) != 0U)
 		sctlr &= ~SCTLR_C_BIT;
 	else
 		sctlr |= SCTLR_C_BIT;

--- a/lib/xlat_tables/aarch64/xlat_tables.c
+++ b/lib/xlat_tables/aarch64/xlat_tables.c
@@ -31,26 +31,26 @@ static unsigned long long calc_physical_addr_size_bits(
 					unsigned long long max_addr)
 {
 	/* Physical address can't exceed 48 bits */
-	assert((max_addr & ADDR_MASK_48_TO_63) == 0);
+	assert((max_addr & ADDR_MASK_48_TO_63) == 0U);
 
 	/* 48 bits address */
-	if (max_addr & ADDR_MASK_44_TO_47)
+	if ((max_addr & ADDR_MASK_44_TO_47) != 0U)
 		return TCR_PS_BITS_256TB;
 
 	/* 44 bits address */
-	if (max_addr & ADDR_MASK_42_TO_43)
+	if ((max_addr & ADDR_MASK_42_TO_43) != 0U)
 		return TCR_PS_BITS_16TB;
 
 	/* 42 bits address */
-	if (max_addr & ADDR_MASK_40_TO_41)
+	if ((max_addr & ADDR_MASK_40_TO_41) != 0U)
 		return TCR_PS_BITS_4TB;
 
 	/* 40 bits address */
-	if (max_addr & ADDR_MASK_36_TO_39)
+	if ((max_addr & ADDR_MASK_36_TO_39) != 0U)
 		return TCR_PS_BITS_1TB;
 
 	/* 36 bits address */
-	if (max_addr & ADDR_MASK_32_TO_35)
+	if ((max_addr & ADDR_MASK_32_TO_35) != 0U)
 		return TCR_PS_BITS_64GB;
 
 	return TCR_PS_BITS_4GB;
@@ -78,21 +78,21 @@ static unsigned long long get_max_supported_pa(void)
 }
 #endif /* ENABLE_ASSERTIONS */
 
-int xlat_arch_current_el(void)
+unsigned int xlat_arch_current_el(void)
 {
-	int el = GET_EL(read_CurrentEl());
+	unsigned int el = (unsigned int)GET_EL(read_CurrentEl());
 
-	assert(el > 0);
+	assert(el > 0U);
 
 	return el;
 }
 
-uint64_t xlat_arch_get_xn_desc(int el)
+uint64_t xlat_arch_get_xn_desc(unsigned int el)
 {
-	if (el == 3) {
+	if (el == 3U) {
 		return UPPER_ATTRS(XN);
 	} else {
-		assert(el == 1);
+		assert(el == 1U);
 		return UPPER_ATTRS(PXN);
 	}
 }
@@ -102,12 +102,12 @@ void init_xlat_tables(void)
 	unsigned long long max_pa;
 	uintptr_t max_va;
 	print_mmap();
-	init_xlation_table(0, base_xlation_table, XLAT_TABLE_LEVEL_BASE,
+	init_xlation_table(0U, base_xlation_table, XLAT_TABLE_LEVEL_BASE,
 			   &max_va, &max_pa);
 
-	assert(max_va <= PLAT_VIRT_ADDR_SPACE_SIZE - 1);
-	assert(max_pa <= PLAT_PHY_ADDR_SPACE_SIZE - 1);
-	assert((PLAT_PHY_ADDR_SPACE_SIZE - 1) <= get_max_supported_pa());
+	assert(max_va <= (PLAT_VIRT_ADDR_SPACE_SIZE - 1U));
+	assert(max_pa <= (PLAT_PHY_ADDR_SPACE_SIZE - 1U));
+	assert((PLAT_PHY_ADDR_SPACE_SIZE - 1U) <= get_max_supported_pa());
 
 	tcr_ps_bits = calc_physical_addr_size_bits(max_pa);
 }
@@ -129,7 +129,7 @@ void init_xlat_tables(void)
 		uint32_t sctlr;						\
 									\
 		assert(IS_IN_EL(_el));					\
-		assert((read_sctlr_el##_el() & SCTLR_M_BIT) == 0);	\
+		assert((read_sctlr_el##_el() & SCTLR_M_BIT) == 0U);	\
 									\
 		/* Set attributes in the right indices of the MAIR */	\
 		mair = MAIR_ATTR_SET(ATTR_DEVICE, ATTR_DEVICE_INDEX);	\
@@ -144,16 +144,18 @@ void init_xlat_tables(void)
 									\
 		/* Set TCR bits as well. */				\
 		/* Set T0SZ to (64 - width of virtual address space) */	\
-		if (flags & XLAT_TABLE_NC) {				\
+		int t0sz = 64 - __builtin_ctzll(PLAT_VIRT_ADDR_SPACE_SIZE);\
+									\
+		if ((flags & XLAT_TABLE_NC) != 0U) {			\
 			/* Inner & outer non-cacheable non-shareable. */\
 			tcr = TCR_SH_NON_SHAREABLE |			\
 				TCR_RGN_OUTER_NC | TCR_RGN_INNER_NC |	\
-				(64 - __builtin_ctzll(PLAT_VIRT_ADDR_SPACE_SIZE));\
+				(uint64_t) t0sz;			\
 		} else {						\
 			/* Inner & outer WBWA & shareable. */		\
 			tcr = TCR_SH_INNER_SHAREABLE |			\
 				TCR_RGN_OUTER_WBA | TCR_RGN_INNER_WBA |	\
-				(64 - __builtin_ctzll(PLAT_VIRT_ADDR_SPACE_SIZE));\
+				(uint64_t) t0sz;			\
 		}							\
 		tcr |= _tcr_extra;					\
 		write_tcr_el##_el(tcr);					\
@@ -172,7 +174,7 @@ void init_xlat_tables(void)
 		sctlr = read_sctlr_el##_el();				\
 		sctlr |= SCTLR_WXN_BIT | SCTLR_M_BIT;			\
 									\
-		if (flags & DISABLE_DCACHE)				\
+		if ((flags & DISABLE_DCACHE) != 0U)			\
 			sctlr &= ~SCTLR_C_BIT;				\
 		else							\
 			sctlr |= SCTLR_C_BIT;				\

--- a/lib/xlat_tables/xlat_tables_common.c
+++ b/lib/xlat_tables/xlat_tables_common.c
@@ -32,6 +32,7 @@
 #endif
 
 #define UNSET_DESC	~0ULL
+#define MT_UNKNOWN	~0U
 
 static uint64_t xlat_tables[MAX_XLAT_TABLES][XLAT_TABLE_ENTRIES]
 			__aligned(XLAT_TABLE_SIZE) __section("xlat_table");
@@ -55,7 +56,7 @@ void print_mmap(void)
 #if LOG_LEVEL >= LOG_LEVEL_VERBOSE
 	debug_print("mmap:\n");
 	mmap_region_t *mm = mmap;
-	while (mm->size) {
+	while (mm->size != 0U) {
 		debug_print(" VA:%p  PA:0x%llx  size:0x%zx  attr:0x%x\n",
 				(void *)mm->base_va, mm->base_pa,
 				mm->size, mm->attr);
@@ -69,46 +70,47 @@ void mmap_add_region(unsigned long long base_pa, uintptr_t base_va,
 		     size_t size, unsigned int attr)
 {
 	mmap_region_t *mm = mmap;
-	mmap_region_t *mm_last = mm + ARRAY_SIZE(mmap) - 1;
-	unsigned long long end_pa = base_pa + size - 1;
-	uintptr_t end_va = base_va + size - 1;
+	const mmap_region_t *mm_last = mm + ARRAY_SIZE(mmap) - 1U;
+	unsigned long long end_pa = base_pa + size - 1U;
+	uintptr_t end_va = base_va + size - 1U;
 
 	assert(IS_PAGE_ALIGNED(base_pa));
 	assert(IS_PAGE_ALIGNED(base_va));
 	assert(IS_PAGE_ALIGNED(size));
 
-	if (!size)
+	if (size == 0U)
 		return;
 
 	assert(base_pa < end_pa); /* Check for overflows */
 	assert(base_va < end_va);
 
 	assert((base_va + (uintptr_t)size - (uintptr_t)1) <=
-					(PLAT_VIRT_ADDR_SPACE_SIZE - 1));
+					(PLAT_VIRT_ADDR_SPACE_SIZE - 1U));
 	assert((base_pa + (unsigned long long)size - 1ULL) <=
-					(PLAT_PHY_ADDR_SPACE_SIZE - 1));
+					(PLAT_PHY_ADDR_SPACE_SIZE - 1U));
 
 #if ENABLE_ASSERTIONS
 
 	/* Check for PAs and VAs overlaps with all other regions */
 	for (mm = mmap; mm->size; ++mm) {
 
-		uintptr_t mm_end_va = mm->base_va + mm->size - 1;
+		uintptr_t mm_end_va = mm->base_va + mm->size - 1U;
 
 		/*
 		 * Check if one of the regions is completely inside the other
 		 * one.
 		 */
 		int fully_overlapped_va =
-			((base_va >= mm->base_va) && (end_va <= mm_end_va)) ||
-			((mm->base_va >= base_va) && (mm_end_va <= end_va));
+			(((base_va >= mm->base_va) && (end_va <= mm_end_va)) ||
+			((mm->base_va >= base_va) && (mm_end_va <= end_va)))
+			? 1 : 0;
 
 		/*
 		 * Full VA overlaps are only allowed if both regions are
 		 * identity mapped (zero offset) or have the same VA to PA
 		 * offset. Also, make sure that it's not the exact same area.
 		 */
-		if (fully_overlapped_va) {
+		if (fully_overlapped_va == 1) {
 			assert((mm->base_va - mm->base_pa) ==
 			       (base_va - base_pa));
 			assert((base_va != mm->base_va) || (size != mm->size));
@@ -122,12 +124,12 @@ void mmap_add_region(unsigned long long base_pa, uintptr_t base_va,
 			unsigned long long mm_end_pa =
 						     mm->base_pa + mm->size - 1;
 
-			int separated_pa =
-				(end_pa < mm->base_pa) || (base_pa > mm_end_pa);
-			int separated_va =
-				(end_va < mm->base_va) || (base_va > mm_end_va);
+			int separated_pa = ((end_pa < mm->base_pa) ||
+				(base_pa > mm_end_pa)) ? 1 : 0;
+			int separated_va = ((end_va < mm->base_va) ||
+				(base_va > mm_end_va)) ? 1 : 0;
 
-			assert(separated_va && separated_pa);
+			assert((separated_va == 1) && (separated_pa == 1));
 		}
 	}
 
@@ -136,7 +138,7 @@ void mmap_add_region(unsigned long long base_pa, uintptr_t base_va,
 #endif /* ENABLE_ASSERTIONS */
 
 	/* Find correct place in mmap to insert new region */
-	while (mm->base_va < base_va && mm->size)
+	while ((mm->base_va < base_va) && (mm->size != 0U))
 		++mm;
 
 	/*
@@ -154,10 +156,10 @@ void mmap_add_region(unsigned long long base_pa, uintptr_t base_va,
 		++mm;
 
 	/* Make room for new region by moving other regions up by one place */
-	memmove(mm + 1, mm, (uintptr_t)mm_last - (uintptr_t)mm);
+	(void)memmove(mm + 1, mm, (uintptr_t)mm_last - (uintptr_t)mm);
 
 	/* Check we haven't lost the empty sentinal from the end of the array */
-	assert(mm_last->size == 0);
+	assert(mm_last->size == 0U);
 
 	mm->base_pa = base_pa;
 	mm->base_va = base_va;
@@ -172,9 +174,12 @@ void mmap_add_region(unsigned long long base_pa, uintptr_t base_va,
 
 void mmap_add(const mmap_region_t *mm)
 {
-	while (mm->size) {
-		mmap_add_region(mm->base_pa, mm->base_va, mm->size, mm->attr);
-		++mm;
+	const mmap_region_t *mm_cursor = mm;
+
+	while (mm_cursor->size != 0U) {
+		mmap_add_region(mm_cursor->base_pa, mm_cursor->base_va,
+				mm_cursor->size, mm_cursor->attr);
+		mm_cursor++;
 	}
 }
 
@@ -185,7 +190,7 @@ static uint64_t mmap_desc(unsigned int attr, unsigned long long addr_pa,
 	int mem_type;
 
 	/* Make sure that the granularity is fine enough to map this address. */
-	assert((addr_pa & XLAT_BLOCK_MASK(level)) == 0);
+	assert((addr_pa & XLAT_BLOCK_MASK(level)) == 0U);
 
 	desc = addr_pa;
 	/*
@@ -193,8 +198,8 @@ static uint64_t mmap_desc(unsigned int attr, unsigned long long addr_pa,
 	 * rest.
 	 */
 	desc |= (level == XLAT_TABLE_LEVEL_MAX) ? PAGE_DESC : BLOCK_DESC;
-	desc |= (attr & MT_NS) ? LOWER_ATTRS(NS) : 0;
-	desc |= (attr & MT_RW) ? LOWER_ATTRS(AP_RW) : LOWER_ATTRS(AP_RO);
+	desc |= ((attr & MT_NS) != 0U) ? LOWER_ATTRS(NS) : 0U;
+	desc |= ((attr & MT_RW) != 0U) ? LOWER_ATTRS(AP_RW) : LOWER_ATTRS(AP_RO);
 	/*
 	 * Always set the access flag, as this library assumes access flag
 	 * faults aren't managed.
@@ -239,7 +244,7 @@ static uint64_t mmap_desc(unsigned int attr, unsigned long long addr_pa,
 		 * For read-only memory, rely on the MT_EXECUTE/MT_EXECUTE_NEVER
 		 * attribute to figure out the value of the XN bit.
 		 */
-		if ((attr & MT_RW) || (attr & MT_EXECUTE_NEVER)) {
+		if (((attr & MT_RW) != 0U) || ((attr & MT_EXECUTE_NEVER) != 0U)) {
 			desc |= execute_never_mask;
 		}
 
@@ -253,9 +258,9 @@ static uint64_t mmap_desc(unsigned int attr, unsigned long long addr_pa,
 
 	debug_print((mem_type == MT_MEMORY) ? "MEM" :
 		((mem_type == MT_NON_CACHEABLE) ? "NC" : "DEV"));
-	debug_print(attr & MT_RW ? "-RW" : "-RO");
-	debug_print(attr & MT_NS ? "-NS" : "-S");
-	debug_print(attr & MT_EXECUTE_NEVER ? "-XN" : "-EXEC");
+	debug_print(((attr & MT_RW) != 0U) ? "-RW" : "-RO");
+	debug_print(((attr & MT_NS) != 0U) ? "-NS" : "-S");
+	debug_print(((attr & MT_EXECUTE_NEVER) != 0U) ? "-XN" : "-EXEC");
 	return desc;
 }
 
@@ -265,14 +270,14 @@ static uint64_t mmap_desc(unsigned int attr, unsigned long long addr_pa,
  *
  * On success, this function returns 0.
  * If there are partial overlaps (meaning that a smaller size is needed) or if
- * the region can't be found in the given area, it returns -1. In this case the
- * value pointed by attr should be ignored by the caller.
+ * the region can't be found in the given area, it returns MT_UNKNOWN. In this
+ * case the value pointed by attr should be ignored by the caller.
  */
-static int mmap_region_attr(mmap_region_t *mm, uintptr_t base_va,
-			    size_t size, unsigned int *attr)
+static unsigned int mmap_region_attr(const mmap_region_t *mm, uintptr_t base_va,
+				     size_t size, unsigned int *attr)
 {
 	/* Don't assume that the area is contained in the first region */
-	int ret = -1;
+	unsigned int ret = MT_UNKNOWN;
 
 	/*
 	 * Get attributes from last (innermost) region that contains the
@@ -289,26 +294,26 @@ static int mmap_region_attr(mmap_region_t *mm, uintptr_t base_va,
 	 * in region 2. The loop shouldn't stop at region 2 as inner regions
 	 * have priority over outer regions, it should stop at region 5.
 	 */
-	for (;; ++mm) {
+	for ( ; ; ++mm) {
 
-		if (!mm->size)
+		if (mm->size == 0U)
 			return ret; /* Reached end of list */
 
-		if (mm->base_va > base_va + size - 1)
+		if (mm->base_va > (base_va + size - 1U))
 			return ret; /* Next region is after area so end */
 
-		if (mm->base_va + mm->size - 1 < base_va)
+		if ((mm->base_va + mm->size - 1U) < base_va)
 			continue; /* Next region has already been overtaken */
 
-		if (!ret && mm->attr == *attr)
+		if ((ret == 0U) && (mm->attr == *attr))
 			continue; /* Region doesn't override attribs so skip */
 
-		if (mm->base_va > base_va ||
-			mm->base_va + mm->size - 1 < base_va + size - 1)
-			return -1; /* Region doesn't fully cover our area */
+		if ((mm->base_va > base_va) ||
+			((mm->base_va + mm->size - 1U) < (base_va + size - 1U)))
+			return MT_UNKNOWN; /* Region doesn't fully cover area */
 
 		*attr = mm->attr;
-		ret = 0;
+		ret = 0U;
 	}
 	return ret;
 }
@@ -318,7 +323,8 @@ static mmap_region_t *init_xlation_table_inner(mmap_region_t *mm,
 					uint64_t *table,
 					unsigned int level)
 {
-	assert(level >= XLAT_TABLE_LEVEL_MIN && level <= XLAT_TABLE_LEVEL_MAX);
+	assert((level >= XLAT_TABLE_LEVEL_MIN) &&
+	       (level <= XLAT_TABLE_LEVEL_MAX));
 
 	unsigned int level_size_shift =
 		       L0_XLAT_ADDRESS_SHIFT - level * XLAT_TABLE_ENTRIES_SHIFT;
@@ -331,10 +337,10 @@ static mmap_region_t *init_xlation_table_inner(mmap_region_t *mm,
 	do  {
 		uint64_t desc = UNSET_DESC;
 
-		if (!mm->size) {
+		if (mm->size == 0U) {
 			/* Done mapping regions; finish zeroing the table */
 			desc = INVALID_DESC;
-		} else if (mm->base_va + mm->size - 1 < base_va) {
+		} else if ((mm->base_va + mm->size - 1U) < base_va) {
 			/* This area is after the region so get next region */
 			++mm;
 			continue;
@@ -343,7 +349,7 @@ static mmap_region_t *init_xlation_table_inner(mmap_region_t *mm,
 		debug_print("%s VA:%p size:0x%llx ", get_level_spacer(level),
 			(void *)base_va, (unsigned long long)level_size);
 
-		if (mm->base_va > base_va + level_size - 1) {
+		if (mm->base_va > (base_va + level_size - 1U)) {
 			/* Next region is after this area. Nothing to map yet */
 			desc = INVALID_DESC;
 		/* Make sure that the current level allows block descriptors */
@@ -354,9 +360,10 @@ static mmap_region_t *init_xlation_table_inner(mmap_region_t *mm,
 			 * it will return the innermost region's attributes.
 			 */
 			unsigned int attr;
-			int r = mmap_region_attr(mm, base_va, level_size, &attr);
+			unsigned int r = mmap_region_attr(mm, base_va,
+							  level_size, &attr);
 
-			if (!r) {
+			if (r == 0U) {
 				desc = mmap_desc(attr,
 					base_va - mm->base_va + mm->base_pa,
 					level);
@@ -365,13 +372,15 @@ static mmap_region_t *init_xlation_table_inner(mmap_region_t *mm,
 
 		if (desc == UNSET_DESC) {
 			/* Area not covered by a region so need finer table */
-			uint64_t *new_table = xlat_tables[next_xlat++];
+			uint64_t *new_table = xlat_tables[next_xlat];
+
+			next_xlat++;
 			assert(next_xlat <= MAX_XLAT_TABLES);
 			desc = TABLE_DESC | (uintptr_t)new_table;
 
 			/* Recurse to fill in new table */
 			mm = init_xlation_table_inner(mm, base_va,
-						new_table, level+1);
+						new_table, level + 1U);
 		}
 
 		debug_print("\n");
@@ -379,7 +388,7 @@ static mmap_region_t *init_xlation_table_inner(mmap_region_t *mm,
 		*table++ = desc;
 		base_va += level_size;
 	} while ((base_va & level_index_mask) &&
-		 (base_va - 1 < PLAT_VIRT_ADDR_SPACE_SIZE - 1));
+		 ((base_va - 1U) < (PLAT_VIRT_ADDR_SPACE_SIZE - 1U)));
 
 	return mm;
 }
@@ -388,15 +397,15 @@ void init_xlation_table(uintptr_t base_va, uint64_t *table,
 			unsigned int level, uintptr_t *max_va,
 			unsigned long long *max_pa)
 {
-	int el = xlat_arch_current_el();
+	unsigned int el = xlat_arch_current_el();
 
 	execute_never_mask = xlat_arch_get_xn_desc(el);
 
-	if (el == 3) {
+	if (el == 3U) {
 		ap1_mask = LOWER_ATTRS(AP_ONE_VA_RANGE_RES1);
 	} else {
-		assert(el == 1);
-		ap1_mask = 0;
+		assert(el == 1U);
+		ap1_mask = 0ULL;
 	}
 
 	init_xlation_table_inner(mmap, base_va, table, level);

--- a/lib/xlat_tables/xlat_tables_private.h
+++ b/lib/xlat_tables/xlat_tables_private.h
@@ -1,11 +1,11 @@
 /*
- * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __XLAT_TABLES_PRIVATE_H__
-#define __XLAT_TABLES_PRIVATE_H__
+#ifndef XLAT_TABLES_PRIVATE_H
+#define XLAT_TABLES_PRIVATE_H
 
 #include <cassert.h>
 #include <platform_def.h>
@@ -44,17 +44,17 @@ CASSERT(CHECK_PHY_ADDR_SPACE_SIZE(PLAT_PHY_ADDR_SPACE_SIZE),
 void print_mmap(void);
 
 /* Returns the current Exception Level. The returned EL must be 1 or higher. */
-int xlat_arch_current_el(void);
+unsigned int xlat_arch_current_el(void);
 
 /*
  * Returns the bit mask that has to be ORed to the rest of a translation table
  * descriptor so that execution of code is prohibited at the given Exception
  * Level.
  */
-uint64_t xlat_arch_get_xn_desc(int el);
+uint64_t xlat_arch_get_xn_desc(unsigned int el);
 
 void init_xlation_table(uintptr_t base_va, uint64_t *table,
 			unsigned int level, uintptr_t *max_va,
 			unsigned long long *max_pa);
 
-#endif /* __XLAT_TABLES_PRIVATE_H__ */
+#endif /* XLAT_TABLES_PRIVATE_H */

--- a/lib/xlat_tables_v2/xlat_tables_context.c
+++ b/lib/xlat_tables_v2/xlat_tables_context.c
@@ -78,12 +78,12 @@ void init_xlat_tables(void)
 {
 	assert(tf_xlat_ctx.xlat_regime == EL_REGIME_INVALID);
 
-	int current_el = xlat_arch_current_el();
+	unsigned int current_el = xlat_arch_current_el();
 
-	if (current_el == 1) {
+	if (current_el == 1U) {
 		tf_xlat_ctx.xlat_regime = EL1_EL0_REGIME;
 	} else {
-		assert(current_el == 3);
+		assert(current_el == 3U);
 		tf_xlat_ctx.xlat_regime = EL3_REGIME;
 	}
 

--- a/lib/xlat_tables_v2/xlat_tables_private.h
+++ b/lib/xlat_tables_v2/xlat_tables_private.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __XLAT_TABLES_PRIVATE_H__
-#define __XLAT_TABLES_PRIVATE_H__
+#ifndef XLAT_TABLES_PRIVATE_H
+#define XLAT_TABLES_PRIVATE_H
 
 #include <platform_def.h>
 #include <xlat_tables_defs.h>
@@ -35,6 +35,8 @@
 
 #endif /* PLAT_XLAT_TABLES_DYNAMIC */
 
+extern uint64_t mmu_cfg_params[MMU_CFG_PARAM_MAX];
+
 /*
  * Return the execute-never mask that will prevent instruction fetch at the
  * given translation regime.
@@ -61,7 +63,7 @@ void xlat_arch_tlbi_va(uintptr_t va, int xlat_regime);
 void xlat_arch_tlbi_va_sync(void);
 
 /* Print VA, PA, size and attributes of all regions in the mmap array. */
-void xlat_mmap_print(mmap_region_t *const mmap);
+void xlat_mmap_print(const mmap_region_t *mmap);
 
 /*
  * Print the current state of the translation tables by reading them from
@@ -73,14 +75,14 @@ void xlat_tables_print(xlat_ctx_t *ctx);
  * Returns a block/page table descriptor for the given level and attributes.
  */
 uint64_t xlat_desc(const xlat_ctx_t *ctx, uint32_t attr,
-		   unsigned long long addr_pa, int level);
+		   unsigned long long addr_pa, unsigned int level);
 
 /*
  * Architecture-specific initialization code.
  */
 
 /* Returns the current Exception Level. The returned EL must be 1 or higher. */
-int xlat_arch_current_el(void);
+unsigned int xlat_arch_current_el(void);
 
 /*
  * Return the maximum physical address supported by the hardware.
@@ -94,4 +96,4 @@ unsigned long long xlat_arch_get_max_supported_pa(void);
  */
 int is_mmu_enabled_ctx(const xlat_ctx_t *ctx);
 
-#endif /* __XLAT_TABLES_PRIVATE_H__ */
+#endif /* XLAT_TABLES_PRIVATE_H */

--- a/plat/rpi3/include/platform_def.h
+++ b/plat/rpi3/include/platform_def.h
@@ -217,8 +217,8 @@
  */
 #define ADDR_SPACE_SIZE			(ULL(1) << 32)
 
-#define MAX_MMAP_REGIONS		U(8)
-#define MAX_XLAT_TABLES			U(4)
+#define MAX_MMAP_REGIONS		8
+#define MAX_XLAT_TABLES			4
 
 #define MAX_IO_DEVICES			U(3)
 #define MAX_IO_HANDLES			U(4)


### PR DESCRIPTION
Note that this PR doesn't fix all problems in the xlat tables lib, this is an initial cleanup that fixes a big number of them. It will be needed to do a more fine-grained cleanup when other parts of the code are cleaned of MISRA defects.