### PR TITLE
Set console function pointers to const

### DIFF
--- a/include/drivers/console.h
+++ b/include/drivers/console.h
@@ -39,9 +39,9 @@ typedef struct console {
 	 * fields of the struct to 64 bits in AArch64 and 32 bits in AArch32
 	 */
 	u_register_t flags;
-	int (*putc)(int character, struct console *console);
-	int (*getc)(struct console *console);
-	int (*flush)(struct console *console);
+	int (*const putc)(int character, struct console *console);
+	int (*const getc)(struct console *console);
+	int (*const flush)(struct console *console);
 	/* Additional private driver data may follow here. */
 } console_t;
 #include <console_assertions.h> /* offset macro assertions for console_t */


### PR DESCRIPTION
Set the function pointers in the console struct and the functions
they point to to const since they only need to be defined when
the console is being initialised and should not be changed after

Change-Id: I0574307111e3ab2f13d1a4a74c3fa75532dfa4be
Signed-off-by: Daniel Boulby <daniel.boulby@arm.com>