### PR TITLE
cci: Wait before reading status register

### DIFF
--- a/drivers/arm/cci/cci.c
+++ b/drivers/arm/cci/cci.c
@@ -5,6 +5,7 @@
  */
 
 #include <arch.h>
+#include <arch_helpers.h>
 #include <assert.h>
 #include <cci.h>
 #include <debug.h>
@@ -142,6 +143,12 @@ void cci_enable_snoop_dvm_reqs(unsigned int master_id)
 		      SLAVE_IFACE_OFFSET(slave_if_id) + SNOOP_CTRL_REG,
 		      DVM_EN_BIT | SNOOP_EN_BIT);
 
+	/*
+	 * Wait for the completion of the write to the Snoop Control Register
+	 * before testing the change_pending bit
+	 */
+	dmbish();
+
 	/* Wait for the dust to settle down */
 	while (mmio_read_32(cci_base + STATUS_REG) & CHANGE_PENDING_BIT)
 		;
@@ -162,6 +169,12 @@ void cci_disable_snoop_dvm_reqs(unsigned int master_id)
 	mmio_write_32(cci_base +
 		      SLAVE_IFACE_OFFSET(slave_if_id) + SNOOP_CTRL_REG,
 		      ~(DVM_EN_BIT | SNOOP_EN_BIT));
+
+	/*
+	 * Wait for the completion of the write to the Snoop Control Register
+	 * before testing the change_pending bit
+	 */
+	dmbish();
 
 	/* Wait for the dust to settle down */
 	while (mmio_read_32(cci_base + STATUS_REG) & CHANGE_PENDING_BIT)


### PR DESCRIPTION
The functions cci_enable_snoop_dvm_reqs and cci_disable_snoop_dvm_reqs write
in the SNOOP_CTRL_REGISTER of the slave interface and it polls the status
register to be sure that the operation is finished before leaving the
functions. If the write in SNOOP_CTRL_REGISTER is reordered after the first
read in the status register then these functions can finish before
enabling/disabling snoops and DVM messages.

The CCI500 TRM specifies:

	Wait for the completion of the write to the Snoop Control Register
	before testing the change_pending bit.

Change-Id: Idc7685963f412be1c16bcd3c6e3cca826e2fdf38
Signed-off-by: Roberto Vargas <roberto.vargas@arm.com>