### PR TITLE
Fix build for SEPARATE_CODE_AND_RODATA=0

### DIFF
--- a/include/plat/arm/common/arm_def.h
+++ b/include/plat/arm/common/arm_def.h
@@ -241,16 +241,25 @@
 						ARM_EL3_TZC_DRAM1_SIZE,	\
 						MT_MEMORY | MT_RW | MT_SECURE)
 
+/*
+ * If SEPARATE_CODE_AND_RODATA=1 we define a region for each section
+ * otherwise one region is defined containing both.
+ */
 #if SEPARATE_CODE_AND_RODATA
-#define ARM_MAP_BL_CODE			MAP_REGION_FLAT(			\
+#define ARM_MAP_BL_RO			MAP_REGION_FLAT(			\
 						BL_CODE_BASE,			\
 						BL_CODE_END - BL_CODE_BASE,	\
-						MT_CODE | MT_SECURE)
-#define ARM_MAP_BL_RO_DATA		MAP_REGION_FLAT(			\
+						MT_CODE | MT_SECURE),		\
+					MAP_REGION_FLAT(			\
 						BL_RO_DATA_BASE,		\
 						BL_RO_DATA_END			\
 							- BL_RO_DATA_BASE,	\
 						MT_RO_DATA | MT_SECURE)
+#else
+#define ARM_MAP_BL_RO			MAP_REGION_FLAT(			\
+						BL_CODE_BASE,			\
+						BL_CODE_END - BL_CODE_BASE,	\
+						MT_CODE | MT_SECURE)
 #endif
 #if USE_COHERENT_MEM
 #define ARM_MAP_BL_COHERENT_RAM		MAP_REGION_FLAT(			\
@@ -261,14 +270,10 @@
 #endif
 
 /*
- * The number of regions like RO(code), coherent and data required by
+ * The max number of regions like RO(code), coherent and data required by
  * different BL stages which need to be mapped in the MMU.
  */
-#if USE_COHERENT_MEM
 # define ARM_BL_REGIONS			4
-#else
-# define ARM_BL_REGIONS			3
-#endif
 
 #define MAX_MMAP_REGIONS		(PLAT_ARM_MMAP_ENTRIES +	\
 					 ARM_BL_REGIONS)

--- a/plat/arm/common/arm_bl1_setup.c
+++ b/plat/arm/common/arm_bl1_setup.c
@@ -28,15 +28,26 @@
 					bl1_tzram_layout.total_base,	\
 					bl1_tzram_layout.total_size,	\
 					MT_MEMORY | MT_RW | MT_SECURE)
-#define MAP_BL1_CODE		MAP_REGION_FLAT(			\
+/*
+ * If SEPARATE_CODE_AND_RODATA=1 we define a region for each section
+ * otherwise one region is defined containing both
+ */
+#if SEPARATE_CODE_AND_RODATA
+#define MAP_BL1_RO		MAP_REGION_FLAT(			\
 					BL_CODE_BASE,			\
 					BL1_CODE_END - BL_CODE_BASE,	\
-					MT_CODE | MT_SECURE)
-#define MAP_BL1_RO_DATA		MAP_REGION_FLAT(			\
+					MT_CODE | MT_SECURE),		\
+				MAP_REGION_FLAT(			\
 					BL1_RO_DATA_BASE,		\
 					BL1_RO_DATA_END			\
 						- BL_RO_DATA_BASE,	\
 					MT_RO_DATA | MT_SECURE)
+#else
+#define MAP_BL1_RO		MAP_REGION_FLAT(			\
+					BL_CODE_BASE,			\
+					BL1_CODE_END - BL_CODE_BASE,	\
+					MT_CODE | MT_SECURE)
+#endif
 
 /* Data structure which holds the extents of the trusted SRAM for BL1*/
 static meminfo_t bl1_tzram_layout;
@@ -105,8 +116,7 @@ void arm_bl1_plat_arch_setup(void)
 
 	const mmap_region_t bl_regions[] = {
 		MAP_BL1_TOTAL,
-		MAP_BL1_CODE,
-		MAP_BL1_RO_DATA,
+		MAP_BL1_RO,
 		{0}
 	};
 

--- a/plat/arm/common/arm_bl2_el3_setup.c
+++ b/plat/arm/common/arm_bl2_el3_setup.c
@@ -75,8 +75,7 @@ void arm_bl2_el3_plat_arch_setup(void)
 
 	const mmap_region_t bl_regions[] = {
 		MAP_BL2_EL3_TOTAL,
-		ARM_MAP_BL_CODE,
-		ARM_MAP_BL_RO_DATA,
+		ARM_MAP_BL_RO,
 		{0}
 	};
 

--- a/plat/arm/common/arm_bl2_setup.c
+++ b/plat/arm/common/arm_bl2_setup.c
@@ -245,8 +245,7 @@ void arm_bl2_plat_arch_setup(void)
 
 	const mmap_region_t bl_regions[] = {
 		MAP_BL2_TOTAL,
-		ARM_MAP_BL_CODE,
-		ARM_MAP_BL_RO_DATA,
+		ARM_MAP_BL_RO,
 		{0}
 	};
 

--- a/plat/arm/common/arm_bl2u_setup.c
+++ b/plat/arm/common/arm_bl2u_setup.c
@@ -72,8 +72,7 @@ void arm_bl2u_plat_arch_setup(void)
 
 	const mmap_region_t bl_regions[] = {
 		MAP_BL2U_TOTAL,
-		ARM_MAP_BL_CODE,
-		ARM_MAP_BL_RO_DATA,
+		ARM_MAP_BL_RO,
 		{0}
 	};
 

--- a/plat/arm/common/arm_bl31_setup.c
+++ b/plat/arm/common/arm_bl31_setup.c
@@ -287,8 +287,7 @@ void arm_bl31_plat_arch_setup(void)
 
 	const mmap_region_t bl_regions[] = {
 		MAP_BL31_TOTAL,
-		ARM_MAP_BL_CODE,
-		ARM_MAP_BL_RO_DATA,
+		ARM_MAP_BL_RO,
 #if USE_COHERENT_MEM
 		ARM_MAP_BL_COHERENT_RAM,
 #endif

--- a/plat/arm/common/sp_min/arm_sp_min_setup.c
+++ b/plat/arm/common/sp_min/arm_sp_min_setup.c
@@ -203,8 +203,7 @@ void sp_min_plat_arch_setup(void)
 {
 	const mmap_region_t bl_regions[] = {
 		MAP_BL_SP_MIN_TOTAL,
-		ARM_MAP_BL_CODE,
-		ARM_MAP_BL_RO_DATA,
+		ARM_MAP_BL_RO,
 #if USE_COHERENT_MEM
 		ARM_MAP_BL_COHERENT_RAM,
 #endif

--- a/plat/arm/common/tsp/arm_tsp_setup.c
+++ b/plat/arm/common/tsp/arm_tsp_setup.c
@@ -81,8 +81,7 @@ void tsp_plat_arch_setup(void)
 
 	const mmap_region_t bl_regions[] = {
 		MAP_BL_TSP_TOTAL,
-		ARM_MAP_BL_CODE,
-		ARM_MAP_BL_RO_DATA,
+		ARM_MAP_BL_RO,
 		{0}
 	};
 


### PR DESCRIPTION
TF won't build since no memory region is specified
for when SEPARATE_CODE_AND_RODATA=0 it still relies on
the ARM_MAP_BL_RO_DATA region which is never defined for
this case. Create memory region combining code and RO data for
when the build flag SEPARATE_CODE_AND_RODATA=0 to fix this

Change-Id: I6c129eb0833497710cce55e76b8908ce03e0a638
Signed-off-by: Daniel Boulby <daniel.boulby@arm.com>