### PR TITLE
xlat: psci: Use bool instead of int

### DIFF
--- a/include/lib/xlat_tables/xlat_mmu_helpers.h
+++ b/include/lib/xlat_tables/xlat_mmu_helpers.h
@@ -52,6 +52,7 @@
 
 #ifndef __ASSEMBLY__
 
+#include <stdbool.h>
 #include <stdint.h>
 #include <sys/types.h>
 
@@ -78,7 +79,7 @@ void enable_mmu_direct_el1(unsigned int flags);
 void enable_mmu_direct_el3(unsigned int flags);
 #endif /* AARCH32 */
 
-int xlat_arch_is_granule_size_supported(size_t size);
+bool xlat_arch_is_granule_size_supported(size_t size);
 size_t xlat_arch_get_max_supported_granule_size(void);
 
 #endif /* __ASSEMBLY__ */

--- a/include/lib/xlat_tables/xlat_tables_v2_helpers.h
+++ b/include/lib/xlat_tables/xlat_tables_v2_helpers.h
@@ -20,6 +20,7 @@
 
 #include <cassert.h>
 #include <platform_def.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <xlat_tables_arch.h>
 #include <xlat_tables_defs.h>
@@ -95,8 +96,8 @@ struct xlat_ctx {
 	/* Level of the base translation table. */
 	unsigned int base_level;
 
-	/* Set to 1 when the translation tables are initialized. */
-	int initialized;
+	/* Set to true when the translation tables are initialized. */
+	bool initialized;
 
 	/*
 	 * Translation regime managed by this xlat_ctx_t. It should be one of
@@ -157,7 +158,7 @@ struct xlat_ctx {
 		.max_pa = 0U,						\
 		.max_va = 0U,						\
 		.next_table = 0,					\
-		.initialized = 0,					\
+		.initialized = false,					\
 	}
 
 #endif /*__ASSEMBLY__*/

--- a/lib/psci/psci_main.c
+++ b/lib/psci/psci_main.c
@@ -82,7 +82,7 @@ int psci_cpu_suspend(unsigned int power_state,
 	}
 
 	/* Fast path for CPU standby.*/
-	if (is_cpu_standby_req(is_power_down_state, target_pwrlvl) != 0) {
+	if (is_cpu_standby_req(is_power_down_state, target_pwrlvl)) {
 		if  (psci_plat_pm_ops->cpu_standby == NULL)
 			return PSCI_E_INVALID_PARAMS;
 

--- a/lib/psci/psci_private.h
+++ b/lib/psci/psci_private.h
@@ -14,6 +14,7 @@
 #include <cpu_data.h>
 #include <psci.h>
 #include <spinlock.h>
+#include <stdbool.h>
 
 /*
  * The PSCI capability which are provided by the generic code but does not
@@ -93,10 +94,10 @@ static inline plat_local_state_t psci_get_cpu_local_state_by_idx(int idx)
 }
 
 /* Helper function to identify a CPU standby request in PSCI Suspend call */
-static inline int is_cpu_standby_req(unsigned int is_power_down_state,
-				     unsigned int retn_lvl)
+static inline bool is_cpu_standby_req(unsigned int is_power_down_state,
+				      unsigned int retn_lvl)
 {
-	return ((is_power_down_state == 0U) && (retn_lvl == 0U)) ? 1 : 0;
+	return (is_power_down_state == 0U) && (retn_lvl == 0U);
 }
 
 /*******************************************************************************

--- a/lib/xlat_tables/xlat_tables_common.c
+++ b/lib/xlat_tables/xlat_tables_common.c
@@ -11,6 +11,7 @@
 #include <common_def.h>
 #include <debug.h>
 #include <platform_def.h>
+#include <stdbool.h>
 #include <string.h>
 #include <types.h>
 #include <utils.h>
@@ -100,17 +101,16 @@ void mmap_add_region(unsigned long long base_pa, uintptr_t base_va,
 		 * Check if one of the regions is completely inside the other
 		 * one.
 		 */
-		int fully_overlapped_va =
-			(((base_va >= mm->base_va) && (end_va <= mm_end_va)) ||
-			((mm->base_va >= base_va) && (mm_end_va <= end_va)))
-			? 1 : 0;
+		bool fully_overlapped_va =
+			((base_va >= mm->base_va) && (end_va <= mm_end_va)) ||
+			((mm->base_va >= base_va) && (mm_end_va <= end_va));
 
 		/*
 		 * Full VA overlaps are only allowed if both regions are
 		 * identity mapped (zero offset) or have the same VA to PA
 		 * offset. Also, make sure that it's not the exact same area.
 		 */
-		if (fully_overlapped_va == 1) {
+		if (fully_overlapped_va) {
 			assert((mm->base_va - mm->base_pa) ==
 			       (base_va - base_pa));
 			assert((base_va != mm->base_va) || (size != mm->size));
@@ -124,12 +124,12 @@ void mmap_add_region(unsigned long long base_pa, uintptr_t base_va,
 			unsigned long long mm_end_pa =
 						     mm->base_pa + mm->size - 1;
 
-			int separated_pa = ((end_pa < mm->base_pa) ||
-				(base_pa > mm_end_pa)) ? 1 : 0;
-			int separated_va = ((end_va < mm->base_va) ||
-				(base_va > mm_end_va)) ? 1 : 0;
+			bool separated_pa = (end_pa < mm->base_pa) ||
+				(base_pa > mm_end_pa);
+			bool separated_va = (end_va < mm->base_va) ||
+				(base_va > mm_end_va);
 
-			assert((separated_va == 1) && (separated_pa == 1));
+			assert(separated_va && separated_pa);
 		}
 	}
 

--- a/lib/xlat_tables_v2/aarch32/xlat_tables_arch.c
+++ b/lib/xlat_tables_v2/aarch32/xlat_tables_arch.c
@@ -9,7 +9,7 @@
 #include <assert.h>
 #include <cassert.h>
 #include <platform_def.h>
-#include <utils.h>
+#include <stdbool.h>
 #include <utils_def.h>
 #include <xlat_tables_v2.h>
 #include "../xlat_tables_private.h"
@@ -19,15 +19,15 @@
 #endif
 
 /*
- * Returns 1 if the provided granule size is supported, 0 otherwise.
+ * Returns true if the provided granule size is supported, false otherwise.
  */
-int xlat_arch_is_granule_size_supported(size_t size)
+bool xlat_arch_is_granule_size_supported(size_t size)
 {
 	/*
 	 * The library uses the long descriptor translation table format, which
 	 * supports 4 KiB pages only.
 	 */
-	return (size == PAGE_SIZE_4KB) ? 1 : 0;
+	return size == PAGE_SIZE_4KB;
 }
 
 size_t xlat_arch_get_max_supported_granule_size(void)
@@ -43,7 +43,7 @@ unsigned long long xlat_arch_get_max_supported_pa(void)
 }
 #endif /* ENABLE_ASSERTIONS*/
 
-int is_mmu_enabled_ctx(const xlat_ctx_t *ctx __unused)
+bool is_mmu_enabled_ctx(const xlat_ctx_t *ctx __unused)
 {
 	return (read_sctlr() & SCTLR_M_BIT) != 0;
 }

--- a/lib/xlat_tables_v2/aarch64/xlat_tables_arch.c
+++ b/lib/xlat_tables_v2/aarch64/xlat_tables_arch.c
@@ -8,30 +8,31 @@
 #include <arch_helpers.h>
 #include <assert.h>
 #include <cassert.h>
+#include <stdbool.h>
 #include <sys/types.h>
 #include <utils_def.h>
 #include <xlat_tables_v2.h>
 #include "../xlat_tables_private.h"
 
 /*
- * Returns 1 if the provided granule size is supported, 0 otherwise.
+ * Returns true if the provided granule size is supported, false otherwise.
  */
-int xlat_arch_is_granule_size_supported(size_t size)
+bool xlat_arch_is_granule_size_supported(size_t size)
 {
 	u_register_t id_aa64mmfr0_el1 = read_id_aa64mmfr0_el1();
 
 	if (size == PAGE_SIZE_4KB) {
-		return (((id_aa64mmfr0_el1 >> ID_AA64MMFR0_EL1_TGRAN4_SHIFT) &
+		return ((id_aa64mmfr0_el1 >> ID_AA64MMFR0_EL1_TGRAN4_SHIFT) &
 			 ID_AA64MMFR0_EL1_TGRAN4_MASK) ==
-			 ID_AA64MMFR0_EL1_TGRAN4_SUPPORTED) ? 1 : 0;
+			 ID_AA64MMFR0_EL1_TGRAN4_SUPPORTED;
 	} else if (size == PAGE_SIZE_16KB) {
-		return (((id_aa64mmfr0_el1 >> ID_AA64MMFR0_EL1_TGRAN16_SHIFT) &
+		return ((id_aa64mmfr0_el1 >> ID_AA64MMFR0_EL1_TGRAN16_SHIFT) &
 			 ID_AA64MMFR0_EL1_TGRAN16_MASK) ==
-			 ID_AA64MMFR0_EL1_TGRAN16_SUPPORTED) ? 1 : 0;
+			 ID_AA64MMFR0_EL1_TGRAN16_SUPPORTED;
 	} else if (size == PAGE_SIZE_64KB) {
-		return (((id_aa64mmfr0_el1 >> ID_AA64MMFR0_EL1_TGRAN64_SHIFT) &
+		return ((id_aa64mmfr0_el1 >> ID_AA64MMFR0_EL1_TGRAN64_SHIFT) &
 			 ID_AA64MMFR0_EL1_TGRAN64_MASK) ==
-			 ID_AA64MMFR0_EL1_TGRAN64_SUPPORTED) ? 1 : 0;
+			 ID_AA64MMFR0_EL1_TGRAN64_SUPPORTED;
 	} else {
 		return 0;
 	}
@@ -39,12 +40,12 @@ int xlat_arch_is_granule_size_supported(size_t size)
 
 size_t xlat_arch_get_max_supported_granule_size(void)
 {
-	if (xlat_arch_is_granule_size_supported(PAGE_SIZE_64KB) != 0) {
+	if (xlat_arch_is_granule_size_supported(PAGE_SIZE_64KB)) {
 		return PAGE_SIZE_64KB;
-	} else if (xlat_arch_is_granule_size_supported(PAGE_SIZE_16KB) != 0) {
+	} else if (xlat_arch_is_granule_size_supported(PAGE_SIZE_16KB)) {
 		return PAGE_SIZE_16KB;
 	} else {
-		assert(xlat_arch_is_granule_size_supported(PAGE_SIZE_4KB) != 0);
+		assert(xlat_arch_is_granule_size_supported(PAGE_SIZE_4KB));
 		return PAGE_SIZE_4KB;
 	}
 }
@@ -99,15 +100,15 @@ unsigned long long xlat_arch_get_max_supported_pa(void)
 }
 #endif /* ENABLE_ASSERTIONS*/
 
-int is_mmu_enabled_ctx(const xlat_ctx_t *ctx)
+bool is_mmu_enabled_ctx(const xlat_ctx_t *ctx)
 {
 	if (ctx->xlat_regime == EL1_EL0_REGIME) {
 		assert(xlat_arch_current_el() >= 1U);
-		return ((read_sctlr_el1() & SCTLR_M_BIT) != 0U) ? 1 : 0;
+		return (read_sctlr_el1() & SCTLR_M_BIT) != 0U;
 	} else {
 		assert(ctx->xlat_regime == EL3_REGIME);
 		assert(xlat_arch_current_el() >= 3U);
-		return ((read_sctlr_el3() & SCTLR_M_BIT) != 0U) ? 1 : 0;
+		return (read_sctlr_el3() & SCTLR_M_BIT) != 0U;
 	}
 }
 

--- a/lib/xlat_tables_v2/xlat_tables_private.h
+++ b/lib/xlat_tables_v2/xlat_tables_private.h
@@ -8,6 +8,7 @@
 #define XLAT_TABLES_PRIVATE_H
 
 #include <platform_def.h>
+#include <stdbool.h>
 #include <xlat_tables_defs.h>
 
 #if PLAT_XLAT_TABLES_DYNAMIC
@@ -91,9 +92,9 @@ unsigned int xlat_arch_current_el(void);
 unsigned long long xlat_arch_get_max_supported_pa(void);
 
 /*
- * Return 1 if the MMU of the translation regime managed by the given xlat_ctx_t
- * is enabled, 0 otherwise.
+ * Returns true if the MMU of the translation regime managed by the given
+ * xlat_ctx_t is enabled, false otherwise.
  */
-int is_mmu_enabled_ctx(const xlat_ctx_t *ctx);
+bool is_mmu_enabled_ctx(const xlat_ctx_t *ctx);
 
 #endif /* XLAT_TABLES_PRIVATE_H */

--- a/lib/xlat_tables_v2/xlat_tables_utils.c
+++ b/lib/xlat_tables_v2/xlat_tables_utils.c
@@ -9,6 +9,7 @@
 #include <debug.h>
 #include <errno.h>
 #include <platform_def.h>
+#include <stdbool.h>
 #include <types.h>
 #include <utils_def.h>
 #include <xlat_tables_defs.h>
@@ -307,7 +308,7 @@ static uint64_t *find_xlat_table_entry(uintptr_t virtual_addr,
 	 * This shouldn't be reached, the translation table walk should end at
 	 * most at level XLAT_TABLE_LEVEL_MAX and return from inside the loop.
 	 */
-	assert(0);
+	assert(false);
 
 	return NULL;
 }
@@ -326,7 +327,7 @@ static int get_mem_attributes_internal(const xlat_ctx_t *ctx, uintptr_t base_va,
 	 * Sanity-check arguments.
 	 */
 	assert(ctx != NULL);
-	assert(ctx->initialized != 0);
+	assert(ctx->initialized);
 	assert((ctx->xlat_regime == EL1_EL0_REGIME) ||
 	       (ctx->xlat_regime == EL3_REGIME));
 
@@ -422,7 +423,7 @@ int change_mem_attributes(const xlat_ctx_t *ctx,
 	/* Note: This implementation isn't optimized. */
 
 	assert(ctx != NULL);
-	assert(ctx->initialized != 0);
+	assert(ctx->initialized);
 
 	unsigned long long virt_addr_space_size =
 		(unsigned long long)ctx->va_max_address + 1U;


### PR DESCRIPTION
This is done to comply with MISRA rules about essential types.