### PR TITLE
Replace stdio.h functions by TF functions

### DIFF
--- a/common/tf_snprintf.c
+++ b/common/tf_snprintf.c
@@ -8,6 +8,17 @@
 #include <platform.h>
 #include <stdarg.h>
 
+static void string_print(char **s, size_t n, size_t *chars_printed,
+			 const char *str)
+{
+	while (*str) {
+		if (*chars_printed < n)
+			*(*s)++ = *str;
+		(*chars_printed)++;
+		str++;
+	}
+}
+
 static void unsigned_dec_print(char **s, size_t n, size_t *chars_printed,
 			       unsigned int unum)
 {
@@ -32,6 +43,7 @@ static void unsigned_dec_print(char **s, size_t n, size_t *chars_printed,
  * The following type specifiers are supported:
  *
  * %d or %i - signed decimal format
+ * %s - string format
  * %u - unsigned decimal format
  *
  * The function panics on all other formats specifiers.
@@ -45,6 +57,7 @@ int tf_snprintf(char *s, size_t n, const char *fmt, ...)
 	va_list args;
 	int num;
 	unsigned int unum;
+	char *str;
 	size_t chars_printed = 0;
 
 	if (n == 1) {
@@ -78,6 +91,10 @@ int tf_snprintf(char *s, size_t n, const char *fmt, ...)
 				}
 
 				unsigned_dec_print(&s, n, &chars_printed, unum);
+				break;
+			case 's':
+				str = va_arg(args, char *);
+				string_print(&s, n, &chars_printed, str);
 				break;
 			case 'u':
 				unum = va_arg(args, unsigned int);

--- a/drivers/marvell/comphy/phy-comphy-cp110.c
+++ b/drivers/marvell/comphy/phy-comphy-cp110.c
@@ -18,7 +18,7 @@
 
 /* #define DEBUG_COMPHY */
 #ifdef DEBUG_COMPHY
-#define debug(format...) printf(format)
+#define debug(format...) tf_printf(format)
 #else
 #define debug(format, arg...)
 #endif

--- a/drivers/partition/partition.c
+++ b/drivers/partition/partition.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -24,7 +24,7 @@ static void dump_entries(int num)
 
 	VERBOSE("Partition table with %d entries:\n", num);
 	for (i = 0; i < num; i++) {
-		len = snprintf(name, EFI_NAMELEN, "%s", list.list[i].name);
+		len = tf_snprintf(name, EFI_NAMELEN, "%s", list.list[i].name);
 		for (j = 0; j < EFI_NAMELEN - len - 1; j++) {
 			name[len + j] = ' ';
 		}

--- a/drivers/st/clk/stm32mp1_clk.c
+++ b/drivers/st/clk/stm32mp1_clk.c
@@ -1344,7 +1344,7 @@ int stm32mp1_clk_init(void)
 	for (i = (enum stm32mp1_pll_id)0; i < _PLL_NB; i++) {
 		char name[12];
 
-		sprintf(name, "st,pll@%d", i);
+		tf_snprintf(name, sizeof(name), "st,pll@%d", i);
 		plloff[i] = fdt_rcc_subnode_offset(name);
 
 		if (!fdt_check_node(plloff[i])) {

--- a/plat/hisilicon/hikey/hisi_ipc.c
+++ b/plat/hisilicon/hikey/hisi_ipc.c
@@ -1,16 +1,16 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <arch_helpers.h>
+#include <debug.h>
 #include <hisi_ipc.h>
 #include <hisi_sram_map.h>
 #include <mmio.h>
 #include <platform_def.h>
 #include <stdarg.h>
-#include <stdio.h>
 #include <string.h>
 
 static int ipc_init;
@@ -63,7 +63,7 @@ int hisi_cpus_powered_off_besides_curr(unsigned int cpu)
 static void hisi_ipc_send(unsigned int ipc_num)
 {
 	if (!ipc_init) {
-		printf("error ipc base is null!!!\n");
+		tf_printf("error ipc base is null!!!\n");
 		return;
 	}
 

--- a/plat/marvell/a8k/common/mss/mss_bl2_setup.c
+++ b/plat/marvell/a8k/common/mss/mss_bl2_setup.c
@@ -85,7 +85,6 @@ int bl2_plat_handle_scp_bl2(image_info_t *scp_bl2_image_info)
 	int ret;
 
 	INFO("BL2: Initiating SCP_BL2 transfer to SCP\n");
-	printf("BL2: Initiating SCP_BL2 transfer to SCP\n");
 
 	/* initialize time (for delay functionality) */
 	plat_delay_timer_init();

--- a/services/spd/trusty/generic-arm64-smcall.c
+++ b/services/spd/trusty/generic-arm64-smcall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -29,14 +29,14 @@ static void trusty_dputc(char ch, int secure)
 	s->linebuf[s->l++] = ch;
 	if (s->l == sizeof(s->linebuf) || ch == '\n') {
 		if (secure)
-			printf("secure os: ");
+			tf_printf("secure os: ");
 		else
-			printf("non-secure os: ");
+			tf_printf("non-secure os: ");
 		for (i = 0; i < s->l; i++) {
 			putchar(s->linebuf[i]);
 		}
 		if (ch != '\n') {
-			printf(" <...>\n");
+			tf_printf(" <...>\n");
 		}
 		s->l = 0;
 	}


### PR DESCRIPTION
Functions provided by stdio.h such as printf and sprintf are available in the codebase, but they add a lot of code to the final image if they are used:

- AArch64: ~4KB
- AArch32: ~2KB in T32, ~3KB in A32

tf_printf and tf_snprintf are a lot more simple, but it is preferable to use them when possible because they are also used in common code.