### PR TITLE
cci: Use dsb to wait before reading status register

### DIFF
--- a/drivers/arm/cci/cci.c
+++ b/drivers/arm/cci/cci.c
@@ -147,7 +147,7 @@ void cci_enable_snoop_dvm_reqs(unsigned int master_id)
 	 * Wait for the completion of the write to the Snoop Control Register
 	 * before testing the change_pending bit
 	 */
-	dmbish();
+	dsbish();
 
 	/* Wait for the dust to settle down */
 	while (mmio_read_32(cci_base + STATUS_REG) & CHANGE_PENDING_BIT)
@@ -174,7 +174,7 @@ void cci_disable_snoop_dvm_reqs(unsigned int master_id)
 	 * Wait for the completion of the write to the Snoop Control Register
 	 * before testing the change_pending bit
 	 */
-	dmbish();
+	dsbish();
 
 	/* Wait for the dust to settle down */
 	while (mmio_read_32(cci_base + STATUS_REG) & CHANGE_PENDING_BIT)


### PR DESCRIPTION
The CCI500 TRM explicitily requires completion of the write
operation before the read operation, and it is not guaranteed
by dmb but it is dsb.

Change-Id: Ieeaa0d1a4b8fcb87108dea9b6de03d9c8a150829
Signed-off-by: Roberto Vargas <roberto.vargas@arm.com>