### PR TITLE
Remove cyclic inclusion of platform_def.h in common_def.h

### DIFF
--- a/include/plat/arm/common/arm_def.h
+++ b/include/plat/arm/common/arm_def.h
@@ -10,7 +10,6 @@
 #include <common_def.h>
 #include <gic_common.h>
 #include <interrupt_props.h>
-#include <platform_def.h>
 #include <tbbr_img_def.h>
 #include <utils_def.h>
 #include <xlat_tables_defs.h>

--- a/include/plat/common/common_def.h
+++ b/include/plat/common/common_def.h
@@ -7,7 +7,6 @@
 #define __COMMON_DEF_H__
 
 #include <bl_common.h>
-#include <platform_def.h>
 
 /******************************************************************************
  * Required platform porting definitions that are expected to be common to

--- a/plat/arm/board/juno/aarch64/juno_helpers.S
+++ b/plat/arm/board/juno/aarch64/juno_helpers.S
@@ -12,6 +12,7 @@
 #include <cortex_a72.h>
 #include <cpu_macros.S>
 #include <css_def.h>
+#include <platform_def.h>
 #include <v2m_def.h>
 #include "../juno_def.h"
 

--- a/plat/arm/css/common/aarch64/css_helpers.S
+++ b/plat/arm/css/common/aarch64/css_helpers.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,6 +7,7 @@
 #include <asm_macros.S>
 #include <cpu_macros.S>
 #include <css_def.h>
+#include <platform_def.h>
 
 	.weak	plat_secondary_cold_boot_setup
 	.weak	plat_get_my_entrypoint

--- a/plat/nvidia/tegra/soc/t186/plat_trampoline.S
+++ b/plat/nvidia/tegra/soc/t186/plat_trampoline.S
@@ -1,13 +1,13 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <arch.h>
 #include <asm_macros.S>
-#include <common_def.h>
 #include <memctrl_v2.h>
+#include <platform_def.h>
 #include <tegra_def.h>
 
 #define TEGRA186_SMMU_CTX_SIZE		0x420


### PR DESCRIPTION
By removing the inclusion of platform_def.h in common_def.h and
arm_def.h, it helps to avoid some of the cyclic inclusion problems in
platforms. This change mostly affects ARM platforms and it can be fixed
by directly including the required header.

Change-Id: I77421cdfc72d9fc906089b3d8571441bba473dca
Signed-off-by: Deepak Pandey <Deepak.Pandey@arm.com>