### PR TITLE
DSU erratum 936184 workaround

### DIFF
--- a/bl1/bl1.mk
+++ b/bl1/bl1.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -17,7 +17,8 @@ BL1_SOURCES		+=	bl1/bl1_main.c				\
 				${MBEDTLS_SOURCES}
 
 ifeq (${ARCH},aarch64)
-BL1_SOURCES		+=	lib/el3_runtime/aarch64/context.S
+BL1_SOURCES		+=	lib/cpus/aarch64/dsu_helpers.S		\
+				lib/el3_runtime/aarch64/context.S
 endif
 
 ifeq (${TRUSTED_BOARD_BOOT},1)

--- a/bl2/bl2.mk
+++ b/bl2/bl2.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -29,5 +29,10 @@ BL2_SOURCES		+=	bl2/${ARCH}/bl2_el3_entrypoint.S	\
 				bl2/${ARCH}/bl2_el3_exceptions.S	\
 				lib/cpus/${ARCH}/cpu_helpers.S		\
 				lib/cpus/errata_report.c
+
+ifeq (${ARCH},aarch64)
+BL2_SOURCES		+=	lib/cpus/aarch64/dsu_helpers.S
+endif
+
 BL2_LINKERFILE		:=	bl2/bl2_el3.ld.S
 endif

--- a/bl31/bl31.mk
+++ b/bl31/bl31.mk
@@ -24,6 +24,7 @@ BL31_SOURCES		+=	bl31/bl31_main.c				\
 				bl31/bl31_context_mgmt.c			\
 				common/runtime_svc.c				\
 				lib/aarch64/setjmp.S				\
+				lib/cpus/aarch64/dsu_helpers.S			\
 				plat/common/aarch64/platform_mp_stack.S		\
 				services/arm_arch_svc/arm_arch_svc_setup.c	\
 				services/std_svc/std_svc_setup.c		\

--- a/docs/cpu-specific-build-macros.rst
+++ b/docs/cpu-specific-build-macros.rst
@@ -68,10 +68,10 @@ In the current implementation, a platform which has more than 1 variant
 with different revisions of a processor has no runtime mechanism available
 for it to specify which errata workarounds should be enabled or not.
 
-The value of the build flags are 0 by default, that is, disabled. Any other
-value will enable it.
+The value of the build flags is 0 by default, that is, disabled. A value of 1
+will enable it.
 
-For Cortex-A53, following errata build flags are defined :
+For Cortex-A53, the following errata build flags are defined :
 
 -  ``ERRATA_A53_826319``: This applies errata 826319 workaround to Cortex-A53
    CPU. This needs to be enabled only for revision <= r0p2 of the CPU.
@@ -97,7 +97,7 @@ For Cortex-A53, following errata build flags are defined :
    Earlier revisions of the CPU have other errata which require the same
    workaround in software, so they should be covered anyway.
 
-For Cortex-A57, following errata build flags are defined :
+For Cortex-A57, the following errata build flags are defined :
 
 -  ``ERRATA_A57_806969``: This applies errata 806969 workaround to Cortex-A57
    CPU. This needs to be enabled only for revision r0p0 of the CPU.
@@ -127,10 +127,32 @@ For Cortex-A57, following errata build flags are defined :
    CPU. This needs to be enabled only for revision <= r1p3 of the CPU.
 
 
-For Cortex-A72, following errata build flags are defined :
+For Cortex-A72, the following errata build flags are defined :
 
 -  ``ERRATA_A72_859971``: This applies errata 859971 workaround to Cortex-A72
    CPU. This needs to be enabled only for revision <= r0p3 of the CPU.
+
+DSU Errata Workarounds
+----------------------
+
+Similar to CPU errata, TF-A also implements workarounds for DSU (DynamIQ
+Shared Unit) errata. The DSU errata details can be found in the respective Arm
+documentation:
+
+- `Arm DSU Software Developers Errata Notice`_.
+
+Each erratum is identified by an ``ID``, as defined in the DSU errata notice
+document. Thus, the build flags which enable/disable the errata workarounds
+have the format ``ERRATA_DSU_<ID>``. The implementation and application logic
+of DSU errata workarounds are similar to `CPU errata workarounds`_.
+
+For DSU errata, the following build flags are defined:
+
+-  ``ERRATA_DSU_936184``: This applies errata 936184 workaround for the
+   affected DSU configurations. This errata applies only for those DSUs that
+   contain the ACP interface **and** the DSU revision is older than r2p0 (on
+   r2p0 it is fixed). However, please note that this workaround results in
+   increased DSU power consumption on idle.
 
 CPU Specific optimizations
 --------------------------
@@ -171,3 +193,4 @@ architecture that can be enabled by the platform as desired.
 .. _Cortex-A72 MPCore Software Developers Errata Notice: http://infocenter.arm.com/help/topic/com.arm.doc.epm012079/index.html
 .. _Firmware Design guide: firmware-design.rst
 .. _Cortex-A57 Software Optimization Guide: http://infocenter.arm.com/help/topic/com.arm.doc.uan0015b/Cortex_A57_Software_Optimization_Guide_external.pdf
+.. _Arm DSU Software Developers Errata Notice: http://infocenter.arm.com/help/topic/com.arm.doc.epm138168/index.html

--- a/include/lib/cpus/aarch64/dsu_def.h
+++ b/include/lib/cpus/aarch64/dsu_def.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef DSU_DEF_H
+#define DSU_DEF_H
+
+#include <utils_def.h>
+
+/********************************************************************
+ * DSU control registers definitions				    *
+ ********************************************************************/
+#define CLUSTERCFR_EL1		S3_0_C15_C3_0
+#define CLUSTERIDR_EL1		S3_0_C15_C3_1
+#define CLUSTERACTLR_EL1	S3_0_C15_C3_3
+
+/********************************************************************
+ * DSU control registers bit fields				    *
+ ********************************************************************/
+#define CLUSTERIDR_REV_SHIFT	U(0)
+#define CLUSTERIDR_REV_BITS	U(4)
+#define CLUSTERIDR_VAR_SHIFT	U(4)
+#define CLUSTERIDR_VAR_BITS	U(4)
+#define CLUSTERCFR_ACP_SHIFT	U(11)
+
+/********************************************************************
+ * Masks applied for DSU errata workarounds			    *
+ ********************************************************************/
+#define DSU_ERRATA_936184_MASK	(ULL(0x3) << 15)
+
+#endif /* DSU_DEF_H */

--- a/lib/cpus/aarch64/cortex_a55.S
+++ b/lib/cpus/aarch64/cortex_a55.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,6 +10,14 @@
 #include <cortex_a55.h>
 #include <cpu_macros.S>
 #include <plat_macros.S>
+
+func cortex_a55_reset_func
+	mov	x19, x30
+#if ERRATA_DSU_936184
+	bl	errata_dsu_936184_wa
+#endif
+	ret	x19
+endfunc cortex_a55_reset_func
 
 	/* ---------------------------------------------
 	 * HW will do the cache maintenance while powering down
@@ -26,6 +34,26 @@ func cortex_a55_core_pwr_dwn
 	isb
 	ret
 endfunc cortex_a55_core_pwr_dwn
+
+#if REPORT_ERRATA
+/*
+ * Errata printing function for Cortex A55. Must follow AAPCS & can use stack.
+ */
+func cortex_a55_errata_report
+	stp	x8, x30, [sp, #-16]!
+	bl	cpu_get_rev_var
+	mov	x8, x0
+
+	/*
+	 * Report all errata. The revision variant information is at x8, where
+	 * "report_errata" is expecting it and it doesn't corrupt it.
+	 */
+	report_errata ERRATA_DSU_936184, cortex_a55, dsu_936184
+
+	ldp	x8, x30, [sp], #16
+	ret
+endfunc cortex_a55_errata_report
+#endif
 
 	/* ---------------------------------------------
 	 * This function provides cortex_a55 specific
@@ -47,5 +75,5 @@ func cortex_a55_cpu_reg_dump
 endfunc cortex_a55_cpu_reg_dump
 
 declare_cpu_ops cortex_a55, CORTEX_A55_MIDR, \
-	CPU_NO_RESET_FUNC, \
+	cortex_a55_reset_func, \
 	cortex_a55_core_pwr_dwn

--- a/lib/cpus/aarch64/cortex_a75.S
+++ b/lib/cpus/aarch64/cortex_a75.S
@@ -11,6 +11,7 @@
 #include <cpu_macros.S>
 
 func cortex_a75_reset_func
+	mov	x19, x30
 #if IMAGE_BL31 && WORKAROUND_CVE_2017_5715
 	cpu_check_csv2	x0, 1f
 	adr	x0, wa_cve_2017_5715_bpiall_vbar
@@ -24,6 +25,10 @@ func cortex_a75_reset_func
 	orr	x0, x0, #CORTEX_A75_CPUACTLR_EL1_DISABLE_LOAD_PASS_STORE
 	msr	CORTEX_A75_CPUACTLR_EL1, x0
 	isb
+#endif
+
+#if ERRATA_DSU_936184
+	bl	errata_dsu_936184_wa
 #endif
 
 #if ENABLE_AMU
@@ -49,7 +54,7 @@ func cortex_a75_reset_func
 	msr	CPUAMCNTENSET_EL0, x0
 	isb
 #endif
-	ret
+	ret	x19
 endfunc cortex_a75_reset_func
 
 func check_errata_cve_2017_5715
@@ -106,6 +111,7 @@ func cortex_a75_errata_report
 	 */
 	report_errata WORKAROUND_CVE_2017_5715, cortex_a75, cve_2017_5715
 	report_errata WORKAROUND_CVE_2018_3639, cortex_a75, cve_2018_3639
+	report_errata ERRATA_DSU_936184, cortex_a75, dsu_936184
 
 	ldp	x8, x30, [sp], #16
 	ret

--- a/lib/cpus/aarch64/cortex_a76.S
+++ b/lib/cpus/aarch64/cortex_a76.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -207,6 +207,7 @@ func cortex_a76_disable_wa_cve_2018_3639
 endfunc cortex_a76_disable_wa_cve_2018_3639
 
 func cortex_a76_reset_func
+	mov	x19, x30
 #if WORKAROUND_CVE_2018_3639
 	mrs	x0, CORTEX_A76_CPUACTLR2_EL1
 	orr	x0, x0, #CORTEX_A76_CPUACTLR2_EL1_DISABLE_LOAD_PASS_STORE
@@ -224,7 +225,11 @@ func cortex_a76_reset_func
 	msr	vbar_el3, x0
 	isb
 #endif
-	ret
+
+#if ERRATA_DSU_936184
+	bl	errata_dsu_936184_wa
+#endif
+	ret	x19
 endfunc cortex_a76_reset_func
 
 	/* ---------------------------------------------
@@ -258,6 +263,7 @@ func cortex_a76_errata_report
 	 * checking functions of each errata.
 	 */
 	report_errata WORKAROUND_CVE_2018_3639, cortex_a76, cve_2018_3639
+	report_errata ERRATA_DSU_936184, cortex_a76, dsu_936184
 
 	ldp	x8, x30, [sp], #16
 	ret

--- a/lib/cpus/aarch64/dsu_helpers.S
+++ b/lib/cpus/aarch64/dsu_helpers.S
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <asm_macros.S>
+#include <dsu_def.h>
+#include <errata_report.h>
+
+/*
+ * DSU erratum 936184
+ * Check the DSU variant, revision and configuration to determine if the
+ * erratum applies. This erratum was fixed in r2p0.
+ *
+ * This function is called from both assembly and C environment. So it
+ * follows AAPCS.
+ *
+ * Clobbers: x0-x3
+ */
+	.globl	check_errata_dsu_936184
+	.globl	errata_dsu_936184_wa
+
+func check_errata_dsu_936184
+	mov	x2, #ERRATA_NOT_APPLIES
+	mov	x3, #ERRATA_APPLIES
+
+	/* Erratum applies only if ACP interface is present in DSU */
+	mov	x0, x2
+	mrs	x1, CLUSTERCFR_EL1
+	ubfx	x1, x1, #CLUSTERCFR_ACP_SHIFT, #1
+	cbz	x1, 1f
+
+	/* If ACP is present, check if DSU is older than r2p0 */
+	mrs	x1, CLUSTERIDR_EL1
+
+	/* DSU variant and revision bitfields in CLUSTERIDR are adjacent */
+	ubfx	x0, x1, #CLUSTERIDR_REV_SHIFT,\
+			#(CLUSTERIDR_REV_BITS + CLUSTERIDR_VAR_BITS)
+	mov	x1, #(0x2 << CLUSTERIDR_REV_BITS)
+	cmp	x0, x1
+	csel	x0, x2, x3, hs
+1:
+	ret
+endfunc check_errata_dsu_936184
+
+func errata_dsu_936184_wa
+	mov	x20, x30
+	bl	check_errata_dsu_936184
+	cbz	x0, 1f
+
+	/* If erratum applies, we set a mask to a DSU control register */
+	mrs	x0, CLUSTERACTLR_EL1
+	ldr	x1, =DSU_ERRATA_936184_MASK
+	orr	x0, x0, x1
+	msr	CLUSTERACTLR_EL1, x0
+	isb
+1:
+	ret	x20
+endfunc errata_dsu_936184_wa

--- a/lib/cpus/cpu-ops.mk
+++ b/lib/cpus/cpu-ops.mk
@@ -123,6 +123,11 @@ ERRATA_A72_859971	?=0
 # only to r0p0 and r1p0 of the Ares cpu.
 ERRATA_ARES_1043202	?=1
 
+# Flag to apply DSU erratum 936184. This erratum applies to DSUs containing
+# the ACP interface and revision < r2p0. Applying the workaround results in
+# higher DSU power consumption on idle.
+ERRATA_DSU_936184	?=0
+
 # Process ERRATA_A53_826319 flag
 $(eval $(call assert_boolean,ERRATA_A53_826319))
 $(eval $(call add_define,ERRATA_A53_826319))
@@ -186,6 +191,10 @@ $(eval $(call add_define,ERRATA_A72_859971))
 # Process ERRATA_ARES_1043202 flag
 $(eval $(call assert_boolean,ERRATA_ARES_1043202))
 $(eval $(call add_define,ERRATA_ARES_1043202))
+
+# Process ERRATA_DSU_936184 flag
+$(eval $(call assert_boolean,ERRATA_DSU_936184))
+$(eval $(call add_define,ERRATA_DSU_936184))
 
 # Errata build flags
 ifneq (${ERRATA_A53_843419},0)


### PR DESCRIPTION
If the system is in near idle conditions, this erratum could cause a
deadlock or data corruption. This patch applies the workaround that
prevents this.

This DSU erratum affects only the DSUs that contain the ACP interface
and it was fixed in r2p0. The workaround is applied only to the DSUs
that are actually affected.

Link to respective Arm documentation:
http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.epm138168/index.html

Change-Id: I033213b3077685130fc1e3f4f79c4d15d7483ec9
Signed-off-by: John Tsichritzis <john.tsichritzis@arm.com>