### PR TITLE
rockchip: Add plat_is_my_cpu_primary function

### DIFF
--- a/plat/rockchip/common/aarch64/plat_helpers.S
+++ b/plat/rockchip/common/aarch64/plat_helpers.S
@@ -18,7 +18,7 @@
 	.globl	platform_cpu_warmboot
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_report_exception
-	.globl	platform_is_primary_cpu
+	.globl	plat_is_my_cpu_primary
 	.globl	plat_my_core_pos
 	.globl	plat_reset_handler
 	.globl	plat_panic_handler
@@ -73,12 +73,13 @@ cb_panic:
 	b	cb_panic
 endfunc plat_secondary_cold_boot_setup
 
-func platform_is_primary_cpu
+func plat_is_my_cpu_primary
+	mrs	x0, mpidr_el1
 	and	x0, x0, #(MPIDR_CLUSTER_MASK | MPIDR_CPU_MASK)
 	cmp	x0, #PLAT_RK_PRIMARY_CPU
 	cset	x0, eq
 	ret
-endfunc platform_is_primary_cpu
+endfunc plat_is_my_cpu_primary
 
 	/* --------------------------------------------------------------------
 	 * void plat_panic_handler(void)


### PR DESCRIPTION
This function is required for platforms where
COLD_BOOT_SINGLE_CPU=0 however it was missing from rockchip
platforms

Change-Id: I32a85f226a4f22085a27113903f34bdb6f28dbcc
Signed-off-by: Daniel Boulby <daniel.boulby@arm.com>