### PR TITLE
rpi3: Remove dependencies on Arm platform code

### DIFF
--- a/plat/rpi3/include/plat_macros.S
+++ b/plat/rpi3/include/plat_macros.S
@@ -1,13 +1,10 @@
 /*
- * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#ifndef __PLAT_MACROS_S__
-#define __PLAT_MACROS_S__
-
-#include <arm_macros.S>
-#include <platform_def.h>
+#ifndef PLAT_MACROS_S
+#define PLAT_MACROS_S
 
 	/* ---------------------------------------------
 	 * The below required platform porting macro
@@ -20,4 +17,4 @@
 	.macro plat_crash_print_regs
 	.endm
 
-#endif /* __PLAT_MACROS_S__ */
+#endif /* PLAT_MACROS_S */

--- a/plat/rpi3/platform.mk
+++ b/plat/rpi3/platform.mk
@@ -5,8 +5,6 @@
 #
 
 PLAT_INCLUDES		:=	-Iinclude/common/tbbr			\
-				-Iinclude/plat/arm/common/		\
-				-Iinclude/plat/arm/common/aarch64/	\
 				-Iplat/rpi3/include
 
 PLAT_BL_COMMON_SOURCES	:=	drivers/console/aarch64/console.S	\


### PR DESCRIPTION
The Raspberry Pi 3 port doesn't actually depend on any Arm platform code, so the dependencies can be removed.