### PR TITLE
zynqmp: pm: Add API to get number of clocks

### DIFF
--- a/plat/xilinx/zynqmp/pm_service/pm_api_clock.c
+++ b/plat/xilinx/zynqmp/pm_service/pm_api_clock.c
@@ -2307,6 +2307,21 @@ static unsigned int pm_clock_type(unsigned int clock_id)
 }
 
 /**
+ * pm_api_clock_get_num_clocks() - PM call to request number of clocks
+ * @nclocks	Number of clocks
+ *
+ * This function is used by master to get number of clocks.
+ *
+ * @return	Returns success.
+ */
+enum pm_ret_status pm_api_clock_get_num_clocks(unsigned int *nclocks)
+{
+	*nclocks = CLK_MAX;
+
+	return PM_RET_SUCCESS;
+}
+
+/**
  * pm_api_clock_get_name() - PM call to request a clock's name
  * @clock_id	Clock ID
  * @name	Name of clock (max 16 bytes)

--- a/plat/xilinx/zynqmp/pm_service/pm_api_clock.h
+++ b/plat/xilinx/zynqmp/pm_service/pm_api_clock.h
@@ -276,6 +276,7 @@ enum {
 
 
 enum pm_ret_status pm_api_clock_get_name(unsigned int clock_id, char *name);
+enum pm_ret_status pm_api_clock_get_num_clocks(unsigned int *nclocks);
 enum pm_ret_status pm_api_clock_get_topology(unsigned int clock_id,
 					     unsigned int index,
 					     uint32_t *topology);

--- a/plat/xilinx/zynqmp/pm_service/pm_api_sys.c
+++ b/plat/xilinx/zynqmp/pm_service/pm_api_sys.c
@@ -713,6 +713,19 @@ enum pm_ret_status pm_ioctl(enum pm_node_id nid,
 }
 
 /**
+ * pm_clock_get_num_clocks - PM call to request number of clocks
+ * @nclockss: Number of clocks
+ *
+ * This function is used by master to get number of clocks.
+ *
+ * Return: Returns status, either success or error+reason.
+ */
+static enum pm_ret_status pm_clock_get_num_clocks(uint32_t *nclocks)
+{
+	return pm_api_clock_get_num_clocks(nclocks);
+}
+
+/**
  * pm_clock_get_name() - PM call to request a clock's name
  * @clock_id	Clock ID
  * @name	Name of clock (max 16 bytes)
@@ -1116,6 +1129,10 @@ enum pm_ret_status pm_query_data(enum pm_query_id qid,
 	case PM_QID_PINCTRL_GET_PIN_GROUPS:
 		ret = pm_pinctrl_get_pin_groups(arg1, arg2,
 						(uint16_t *)&data[1]);
+		data[0] = (unsigned int)ret;
+		break;
+	case PM_QID_CLOCK_GET_NUM_CLOCKS:
+		ret = pm_clock_get_num_clocks(&data[1]);
 		data[0] = (unsigned int)ret;
 		break;
 	default:

--- a/plat/xilinx/zynqmp/pm_service/pm_api_sys.h
+++ b/plat/xilinx/zynqmp/pm_service/pm_api_sys.h
@@ -23,6 +23,7 @@ enum pm_query_id {
 	PM_QID_PINCTRL_GET_FUNCTION_NAME,
 	PM_QID_PINCTRL_GET_FUNCTION_GROUPS,
 	PM_QID_PINCTRL_GET_PIN_GROUPS,
+	PM_QID_CLOCK_GET_NUM_CLOCKS,
 };
 
 /**********************************************************


### PR DESCRIPTION
Add new query data parameter to get actual number of
clocks so Linux can get actual clock numbers in advance
and allocate memory accordingly.

Signed-off-by: Rajan Vaja <rajan.vaja@xilinx.com>