### PR TITLE
context_mgmt: Fix HANDLE_EA_EL3_FIRST implementation

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -457,8 +457,10 @@ Common build options
    .. __: `platform-interrupt-controller-API.rst`
    .. __: `interrupt-framework-design.rst`
 
--  ``HANDLE_EA_EL3_FIRST``: When defined External Aborts and SError Interrupts
-   will be always trapped in EL3 i.e. in BL31 at runtime.
+-  ``HANDLE_EA_EL3_FIRST``: When set to ``1``, External Aborts and SError
+   Interrupts will be always trapped in EL3 i.e. in BL31 at runtime. When set to
+   ``0`` (default), these exceptions will be trapped in the current exception
+   level (or in EL1 if the current exception level is EL0).
 
 -  ``HW_ASSISTED_COHERENCY``: On most Arm systems to-date, platform-specific
    software operations are required for CPUs to enter and exit coherency.

--- a/lib/el3_runtime/aarch64/context_mgmt.c
+++ b/lib/el3_runtime/aarch64/context_mgmt.c
@@ -105,7 +105,7 @@ void cm_setup_context(cpu_context_t *ctx, const entry_point_info_t *ep)
 	if (EP_GET_ST(ep->h.attr))
 		scr_el3 |= SCR_ST_BIT;
 
-#ifndef HANDLE_EA_EL3_FIRST
+#if !HANDLE_EA_EL3_FIRST
 	/*
 	 * SCR_EL3.EA: Do not route External Abort and SError Interrupt External
 	 *  to EL3 when executing at a lower EL. When executing at EL3, External


### PR DESCRIPTION
This patch fixes a bug in the context management code that causes it to
ignore the HANDLE_EA_EL3_FIRST compile-time option and instead always
configure SCR_EL3 to force all external aborts to trap into EL3. The
code used #ifdef to read compile-time option declared with add_define in
the Makefile... however, those options are always defined, they're just
defined to either 0 or 1, so #if is the correct syntax to check for
them.

This bug has existed since the Nov 2017 commit 76454ab (AArch64:
Introduce External Abort handling), which changed the
HANDLE_EA_EL3_FIRST option to use add_define.

Change-Id: I7189f41d0daee78fa2fcf4066323e663e1e04d3d
Signed-off-by: Julius Werner <jwerner@chromium.org>