### PR TITLE
opteed: pass power level on suspend

### DIFF
--- a/services/spd/opteed/opteed_pm.c
+++ b/services/spd/opteed/opteed_pm.c
@@ -66,6 +66,9 @@ static void opteed_cpu_suspend_handler(u_register_t max_off_pwrlvl)
 	assert(optee_vector_table);
 	assert(get_optee_pstate(optee_ctx->state) == OPTEE_PSTATE_ON);
 
+	write_ctx_reg(get_gpregs_ctx(&optee_ctx->cpu_ctx), CTX_GPREG_X0,
+		      max_off_pwrlvl);
+
 	/* Program the entry point and enter OPTEE */
 	cm_set_elr_el3(SECURE, (uint64_t) &optee_vector_table->cpu_suspend_entry);
 	rc = opteed_synchronous_sp_entry(optee_ctx);


### PR DESCRIPTION
Some platforms might chose to take different actions depending on this
value; this is precisely the case for rcar-gen3.

Signed-off-by: Jorge Ramirez-Ortiz <jramirez@baylibre.com>