### PR TITLE
Remove rt_svc_descs pointer from global scope

### DIFF
--- a/common/runtime_svc.c
+++ b/common/runtime_svc.c
@@ -20,7 +20,6 @@
  * 'rt_svc_descs' array which contains the SMC handler.
  ******************************************************************************/
 uint8_t rt_svc_descs_indices[MAX_RT_SVCS];
-static rt_svc_desc_t *rt_svc_descs;
 
 #define RT_SVC_DECS_NUM		((RT_SVC_DESCS_END - RT_SVC_DESCS_START)\
 					/ sizeof(rt_svc_desc_t))
@@ -98,6 +97,7 @@ void runtime_svc_init(void)
 {
 	int rc = 0;
 	unsigned int index, start_idx, end_idx;
+	rt_svc_desc_t *rt_svc_descs;
 
 	/* Assert the number of descriptors detected are less than maximum indices */
 	assert((RT_SVC_DESCS_END >= RT_SVC_DESCS_START) &&


### PR DESCRIPTION
A pointer to rt_svc_desc_t is defined both in the function
handle_runtime_svc() and globally. Since the value of the
pointer RT_SVC_DESCS_START is defined by the linker and
never changes make this definition local in both
handle_runtime_svc() and runtime_svc_init() to reduce the
number of loads

Change-Id: Iea42c778d8599a26c87700009163b5a8d7d60be2
Signed-off-by: Daniel Boulby <daniel.boulby@arm.com>