### PR TITLE
Prevent two weak definitions of the same function

### DIFF
--- a/plat/arm/board/juno/juno_bl2_setup.c
+++ b/plat/arm/board/juno/juno_bl2_setup.c
@@ -16,7 +16,7 @@
  * boot flow as the core comes up in aarch64 and to enter the BL32 image a warm
  * reset in aarch32 state is required.
  ******************************************************************************/
-int bl2_plat_handle_post_image_load(unsigned int image_id)
+int arm_bl2_plat_handle_post_image_load(unsigned int image_id)
 {
 	int err = arm_bl2_handle_post_image_load(image_id);
 

--- a/plat/arm/common/arm_bl2_setup.c
+++ b/plat/arm/common/arm_bl2_setup.c
@@ -42,7 +42,7 @@ CASSERT(BL2_BASE >= ARM_TB_FW_CONFIG_LIMIT, assert_bl2_base_overflows);
 
 #if LOAD_IMAGE_V2
 
-#pragma weak bl2_plat_handle_post_image_load
+#pragma weak arm_bl2_plat_handle_post_image_load
 
 #else /* LOAD_IMAGE_V2 */
 
@@ -328,9 +328,14 @@ int arm_bl2_handle_post_image_load(unsigned int image_id)
  * This function can be used by the platforms to update/use image
  * information for given `image_id`.
  ******************************************************************************/
-int bl2_plat_handle_post_image_load(unsigned int image_id)
+int arm_bl2_plat_handle_post_image_load(unsigned int image_id)
 {
 	return arm_bl2_handle_post_image_load(image_id);
+}
+
+int bl2_plat_handle_post_image_load(unsigned int image_id)
+{
+	return arm_bl2_plat_handle_post_image_load(image_id);
 }
 
 #else /* LOAD_IMAGE_V2 */


### PR DESCRIPTION
Add another level of abstraction of weak defs for
arm_bl2_handle_post_image_load to prevent two weak definitions
of the same function

Change-Id: Ie953786f43b0f88257c82956ffaa5fe0d19603db
Signed-off-by: Daniel Boulby <daniel.boulby@arm.com>