### PR TITLE
Add PSCI core power down for K3

### DIFF
--- a/plat/ti/k3/common/k3_psci.c
+++ b/plat/ti/k3/common/k3_psci.c
@@ -76,10 +76,19 @@ static int k3_pwr_domain_on(u_register_t mpidr)
 
 void k3_pwr_domain_off(const psci_power_state_t *target_state)
 {
+	int core_id, device, ret;
+
 	/* Prevent interrupts from spuriously waking up this cpu */
 	k3_gic_cpuif_disable();
 
-	/* TODO: Indicate to System firmware about powering down */
+	core_id = plat_my_core_pos();
+	device = PLAT_PROC_DEVICE_START_ID + core_id;
+
+	ret = ti_sci_device_put(device);
+	if (ret) {
+		ERROR("Request to stop core failed: %d\n", ret);
+		return;
+	}
 }
 
 void k3_pwr_domain_on_finish(const psci_power_state_t *target_state)


### PR DESCRIPTION
Use TI-SCI messages to request core power down from system controller
firmware.

Signed-off-by: Andrew F. Davis <afd@ti.com>