### PR TITLE
Allow D-Cache to remain on during core power-down

### DIFF
--- a/lib/cpus/aarch64/cortex_a53.S
+++ b/lib/cpus/aarch64/cortex_a53.S
@@ -228,11 +228,13 @@ endfunc cortex_a53_reset_func
 func cortex_a53_core_pwr_dwn
 	mov	x18, x30
 
+#if !TI_AM65X_WORKAROUND
 	/* ---------------------------------------------
 	 * Turn off caches.
 	 * ---------------------------------------------
 	 */
 	bl	cortex_a53_disable_dcache
+#endif
 
 	/* ---------------------------------------------
 	 * Flush L1 caches.
@@ -252,11 +254,13 @@ endfunc cortex_a53_core_pwr_dwn
 func cortex_a53_cluster_pwr_dwn
 	mov	x18, x30
 
+#if !TI_AM65X_WORKAROUND
 	/* ---------------------------------------------
 	 * Turn off caches.
 	 * ---------------------------------------------
 	 */
 	bl	cortex_a53_disable_dcache
+#endif
 
 	/* ---------------------------------------------
 	 * Flush L1 caches.

--- a/plat/ti/k3/common/plat_common.mk
+++ b/plat/ti/k3/common/plat_common.mk
@@ -12,7 +12,7 @@ COLD_BOOT_SINGLE_CPU	:=	1
 PROGRAMMABLE_RESET_ADDRESS:=	1
 
 # System coherency is managed in hardware
-WARMBOOT_ENABLE_DCACHE_EARLY:=	1
+HW_ASSISTED_COHERENCY	:=	1
 USE_COHERENT_MEM	:=	0
 
 # A53 erratum for SoC. (enable them all)
@@ -21,6 +21,10 @@ ERRATA_A53_835769	:=	1
 ERRATA_A53_836870	:=	1
 ERRATA_A53_843419	:=	1
 ERRATA_A53_855873	:=	1
+
+# Leave the caches enabled on core powerdown path
+TI_AM65X_WORKAROUND	:=	1
+$(eval $(call add_define,TI_AM65X_WORKAROUND))
 
 MULTI_CONSOLE_API	:=	1
 TI_16550_MDR_QUIRK	:=	1


### PR DESCRIPTION
Hello all,

The first two patches should be simple enough. The third is a bit more interesting and is kinda an RFC.

For K3, we have hardware assisted coherency but as I've argued before the flag "HW_ASSISTED_COHERENCY" is a misnomer and is targeted specifically for DynamIQ platforms. An example of this is in psci_do_pwrdown_sequence(), where we assume all platforms with the hardware assisted coherency flag will use a core's with a *_core_pwr_dwn function that will not disable the cache. This is not the case for K3 with A53 cores.

We introduce a new flag "DISABLE_DCACHE_LATE" designed as the inverse of "WARMBOOT_ENABLE_DCACHE_EARLY". It is for platforms that do not need (or cannot have due to hardware issues) cache disabled in the power down path.

As you can see we need to make a check for this flag in cortex_a53.S, is this the right thing to do? Should this check be added for all cores for consistency?

Thanks,
Andrew