### PR TITLE
Qemu updates

### DIFF
--- a/plat/qemu/platform.mk
+++ b/plat/qemu/platform.mk
@@ -27,6 +27,9 @@ include lib/libfdt/libfdt.mk
 
 # Enable new version of image loading on QEMU platforms
 LOAD_IMAGE_V2		:=	1
+ifneq ($(LOAD_IMAGE_V2),1)
+$(error Error: qemu needs LOAD_IMAGE_V2=1)
+endif
 
 ifeq ($(NEED_BL32),yes)
 $(eval $(call add_define,QEMU_LOAD_BL32))
@@ -132,12 +135,11 @@ BL2_SOURCES		+=	drivers/io/io_semihosting.c		\
 				plat/qemu/qemu_io_storage.c		\
 				plat/qemu/${ARCH}/plat_helpers.S	\
 				plat/qemu/qemu_bl2_setup.c		\
-				plat/qemu/dt.c
-ifeq (${LOAD_IMAGE_V2},1)
-BL2_SOURCES		+=	plat/qemu/qemu_bl2_mem_params_desc.c	\
+				plat/qemu/dt.c				\
+				plat/qemu/qemu_bl2_mem_params_desc.c	\
 				plat/qemu/qemu_image_load.c		\
 				common/desc_image_load.c
-endif
+
 ifeq ($(add-lib-optee),yes)
 BL2_SOURCES		+=	lib/optee/optee_utils.c
 endif

--- a/plat/qemu/qemu_bl1_setup.c
+++ b/plat/qemu/qemu_bl1_setup.c
@@ -31,14 +31,6 @@ void bl1_early_platform_setup(void)
 	/* Allow BL1 to see the whole Trusted RAM */
 	bl1_tzram_layout.total_base = BL_RAM_BASE;
 	bl1_tzram_layout.total_size = BL_RAM_SIZE;
-
-#if !LOAD_IMAGE_V2
-	/* Calculate how much RAM BL1 is using and how much remains free */
-	bl1_tzram_layout.free_base = BL_RAM_BASE;
-	bl1_tzram_layout.free_size = BL_RAM_SIZE;
-	reserve_mem(&bl1_tzram_layout.free_base, &bl1_tzram_layout.free_size,
-		    BL1_RAM_BASE, BL1_RAM_LIMIT - BL1_RAM_BASE);
-#endif /* !LOAD_IMAGE_V2 */
 }
 
 /******************************************************************************
@@ -65,46 +57,3 @@ void bl1_platform_setup(void)
 {
 	plat_qemu_io_setup();
 }
-
-#if !LOAD_IMAGE_V2
-/*******************************************************************************
- * Function that takes a memory layout into which BL2 has been loaded and
- * populates a new memory layout for BL2 that ensures that BL1's data sections
- * resident in secure RAM are not visible to BL2.
- ******************************************************************************/
-void bl1_init_bl2_mem_layout(const meminfo_t *bl1_mem_layout,
-			     meminfo_t *bl2_mem_layout)
-{
-	const size_t bl1_size = BL1_RAM_LIMIT - BL1_RAM_BASE;
-
-	assert(bl1_mem_layout != NULL);
-	assert(bl2_mem_layout != NULL);
-
-	/* Check that BL1's memory is lying outside of the free memory */
-	assert((BL1_RAM_LIMIT <= bl1_mem_layout->free_base) ||
-	       (BL1_RAM_BASE >= (bl1_mem_layout->free_base +
-				 bl1_mem_layout->free_size)));
-
-	/* Remove BL1 RW data from the scope of memory visible to BL2 */
-	*bl2_mem_layout = *bl1_mem_layout;
-	reserve_mem(&bl2_mem_layout->total_base,
-		    &bl2_mem_layout->total_size,
-		    BL1_RAM_BASE,
-		    bl1_size);
-
-	flush_dcache_range((unsigned long)bl2_mem_layout, sizeof(meminfo_t));
-}
-
-/*******************************************************************************
- * Before calling this function BL2 is loaded in memory and its entrypoint
- * is set by load_image. This is a placeholder for the platform to change
- * the entrypoint of BL2 and set SPSR and security state.
- * On ARM standard platforms we only set the security state of the entrypoint
- ******************************************************************************/
-void bl1_plat_set_bl2_ep_info(image_info_t *bl2_image,
-				entry_point_info_t *bl2_ep)
-{
-	SET_SECURITY_STATE(bl2_ep->h.attr, SECURE);
-	bl2_ep->spsr = SPSR_64(MODE_EL1, MODE_SP_ELX, DISABLE_ALL_EXCEPTIONS);
-}
-#endif /* !LOAD_IMAGE_V2 */

--- a/plat/qemu/qemu_bl2_setup.c
+++ b/plat/qemu/qemu_bl2_setup.c
@@ -117,10 +117,11 @@ struct entry_point_info *bl2_plat_get_bl31_ep_info(void)
 }
 #endif /* !LOAD_IMAGE_V2 */
 
-
-
-void bl2_early_platform_setup(meminfo_t *mem_layout)
+void bl2_early_platform_setup2(u_register_t arg0, u_register_t arg1,
+			       u_register_t arg2, u_register_t arg3)
 {
+	meminfo_t *mem_layout = (void *)arg1;
+
 	/* Initialize the console to provide early debug support */
 	qemu_console_init();
 

--- a/plat/qemu/qemu_bl31_setup.c
+++ b/plat/qemu/qemu_bl31_setup.c
@@ -9,6 +9,7 @@
 #include <gic_common.h>
 #include <gicv2.h>
 #include <platform_def.h>
+#include <platform.h>
 #include "qemu_private.h"
 
 /*
@@ -35,18 +36,12 @@ static entry_point_info_t bl33_image_ep_info;
  * tables. BL2 has flushed this information to memory, so we are guaranteed
  * to pick up good data.
  ******************************************************************************/
-#if LOAD_IMAGE_V2
 void bl31_early_platform_setup(void *from_bl2,
 			       void *plat_params_from_bl2)
-#else
-void bl31_early_platform_setup(bl31_params_t *from_bl2,
-				void *plat_params_from_bl2)
-#endif
 {
 	/* Initialize the console to provide early debug support */
 	qemu_console_init();
 
-#if LOAD_IMAGE_V2
 	/*
 	 * Check params passed from BL2
 	 */
@@ -74,32 +69,6 @@ void bl31_early_platform_setup(bl31_params_t *from_bl2,
 
 	if (!bl33_image_ep_info.pc)
 		panic();
-
-#else /* LOAD_IMAGE_V2 */
-
-	/*
-	 * Check params passed from BL2 should not be NULL,
-	 */
-	assert(from_bl2 != NULL);
-	assert(from_bl2->h.type == PARAM_BL31);
-	assert(from_bl2->h.version >= VERSION_1);
-	/*
-	 * In debug builds, we pass a special value in 'plat_params_from_bl2'
-	 * to verify platform parameters from BL2 to BL3-1.
-	 * In release builds, it's not used.
-	 */
-	assert(((unsigned long long)plat_params_from_bl2) ==
-		QEMU_BL31_PLAT_PARAM_VAL);
-
-	/*
-	 * Copy BL3-2 (if populated by BL2) and BL3-3 entry point information.
-	 * They are stored in Secure RAM, in BL2's address space.
-	 */
-	if (from_bl2->bl32_ep_info)
-		bl32_image_ep_info = *from_bl2->bl32_ep_info;
-	bl33_image_ep_info = *from_bl2->bl33_ep_info;
-
-#endif /* !LOAD_IMAGE_V2 */
 }
 
 void bl31_plat_arch_setup(void)

--- a/plat/qemu/qemu_bl31_setup.c
+++ b/plat/qemu/qemu_bl31_setup.c
@@ -36,8 +36,8 @@ static entry_point_info_t bl33_image_ep_info;
  * tables. BL2 has flushed this information to memory, so we are guaranteed
  * to pick up good data.
  ******************************************************************************/
-void bl31_early_platform_setup(void *from_bl2,
-			       void *plat_params_from_bl2)
+void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
+				u_register_t arg2, u_register_t arg3)
 {
 	/* Initialize the console to provide early debug support */
 	qemu_console_init();
@@ -45,7 +45,7 @@ void bl31_early_platform_setup(void *from_bl2,
 	/*
 	 * Check params passed from BL2
 	 */
-	bl_params_t *params_from_bl2 = (bl_params_t *)from_bl2;
+	bl_params_t *params_from_bl2 = (bl_params_t *)arg0;
 
 	assert(params_from_bl2);
 	assert(params_from_bl2->h.type == PARAM_BL_PARAMS);


### PR DESCRIPTION
Makes LOAD_IMAGE_V2=1 mandatory

And addresses https://github.com/ARM-software/tf-issues/issues/613 by replacing bl31_early_platform_setup() and bl2_early_platform_setup()