### PR TITLE
Add missing barriers to Bakery Locks

### DIFF
--- a/include/lib/aarch32/arch_helpers.h
+++ b/include/lib/aarch32/arch_helpers.h
@@ -210,7 +210,12 @@ DEFINE_SYSOP_FUNC(sev)
 DEFINE_SYSOP_TYPE_FUNC(dsb, sy)
 DEFINE_SYSOP_TYPE_FUNC(dmb, sy)
 DEFINE_SYSOP_TYPE_FUNC(dmb, st)
+
+/* dmb ld is not valid for armv7/thumb machines */
+#if ARM_ARCH_MAJOR != 7
 DEFINE_SYSOP_TYPE_FUNC(dmb, ld)
+#endif
+
 DEFINE_SYSOP_TYPE_FUNC(dsb, ish)
 DEFINE_SYSOP_TYPE_FUNC(dsb, ishst)
 DEFINE_SYSOP_TYPE_FUNC(dmb, ish)
@@ -322,6 +327,11 @@ DEFINE_DCOP_PARAM_FUNC(cvac, DCCMVAC)
 /* Previously defined accessor functions with incomplete register names  */
 #define dsb()			dsbsy()
 #define dmb()			dmbsy()
+
+/* dmb ld is not valid for armv7/thumb machines, so alias it to dmb */
+#if ARM_ARCH_MAJOR == 7
+#define	dmbld()			dmb()
+#endif
 
 #define IS_IN_SECURE() \
 	(GET_NS_BIT(read_scr()) == 0)


### PR DESCRIPTION
With the current implementation, it's possible for a contender to
observe accesses in the Critical Section before acquiring or releasing
the lock. Insert fencing in the locking and release codes to prevent any
reorder.

Fixes ARM-software/tf-issues#609

Change-Id: I773b82aa41dd544a2d3dbacb9a4b42c9eb767bbb
Signed-off-by: Jeenu Viswambharan <jeenu.viswambharan@arm.com>