### PR TITLE
Convert BL31 error message into warning

### DIFF
--- a/bl31/bl31_main.c
+++ b/bl31/bl31_main.c
@@ -109,7 +109,8 @@ void bl31_main(void)
 		int32_t rc = (*bl32_init)();
 
 		if (rc != 0) {
-			ERROR("BL31: BL32 initialization failed (rc = %d)", rc);
+			WARN("BL31: BL32 initialization failed (rc = %d)\n",
+			     rc);
 		}
 	}
 	/*


### PR DESCRIPTION
If BL32 isn't present or it fails to initialize the current code prints an error message in both debug and release builds. This is too verbose for release builds, so it has been converted into a warning.

Also, it was missing a newline at the end of the message.