### PR TITLE
Improvements to Mbed TLS shared heap code

### DIFF
--- a/include/plat/arm/board/common/board_arm_def.h
+++ b/include/plat/arm/board/common/board_arm_def.h
@@ -102,7 +102,7 @@
  * little space for growth.
  */
 #if TRUSTED_BOARD_BOOT
-# define PLAT_ARM_MAX_BL2_SIZE		0x1C000
+# define PLAT_ARM_MAX_BL2_SIZE		0x1D000
 #else
 # define PLAT_ARM_MAX_BL2_SIZE		0x11000
 #endif

--- a/plat/arm/common/arm_dyn_cfg.c
+++ b/plat/arm/common/arm_dyn_cfg.c
@@ -62,11 +62,15 @@ int arm_get_mbedtls_heap(void **heap_addr, size_t *heap_size)
 	int err;
 
 	/* If in BL2, retrieve the already allocated heap's info from DTB */
-	err = arm_get_dtb_mbedtls_heap_info(tb_fw_cfg_dtb, heap_addr,
-		heap_size);
-	if (err < 0) {
-		ERROR("BL2: unable to retrieve shared Mbed TLS heap "
-			"information from DTB\n");
+	if (tb_fw_cfg_dtb != NULL) {
+		err = arm_get_dtb_mbedtls_heap_info(tb_fw_cfg_dtb, heap_addr,
+			heap_size);
+		if (err < 0) {
+			ERROR("BL2: unable to retrieve shared Mbed TLS heap information from DTB\n");
+			panic();
+		}
+	} else {
+		ERROR("BL2: DTB missing, cannot get Mbed TLS heap\n");
 		panic();
 	}
 #endif
@@ -98,8 +102,7 @@ void arm_bl1_set_mbedtls_heap(void)
 		err = arm_set_dtb_mbedtls_heap_info(tb_fw_cfg_dtb,
 			mbedtls_heap_addr, mbedtls_heap_size);
 		if (err < 0) {
-			ERROR("BL1: unable to write shared Mbed TLS heap "
-				"information to DTB\n");
+			ERROR("BL1: unable to write shared Mbed TLS heap information to DTB\n");
 			panic();
 		}
 	}

--- a/plat/arm/common/arm_dyn_cfg.c
+++ b/plat/arm/common/arm_dyn_cfg.c
@@ -21,6 +21,7 @@
 
 /* Variable to store the address of TB_FW_CONFIG file */
 static void *tb_fw_cfg_dtb;
+static size_t tb_fw_cfg_dtb_size;
 
 
 #if TRUSTED_BOARD_BOOT
@@ -105,6 +106,13 @@ void arm_bl1_set_mbedtls_heap(void)
 			ERROR("BL1: unable to write shared Mbed TLS heap information to DTB\n");
 			panic();
 		}
+		/*
+		 * Ensure that the info written to the DTB is visible to other
+		 * images. It's critical because BL2 won't be able to proceed
+		 * without the heap info.
+		 */
+		flush_dcache_range((uintptr_t)tb_fw_cfg_dtb,
+			tb_fw_cfg_dtb_size);
 	}
 }
 
@@ -125,7 +133,8 @@ void arm_load_tb_fw_config(void)
 		SET_STATIC_PARAM_HEAD(image_info, PARAM_IMAGE_BINARY,
 				VERSION_2, image_info_t, 0),
 		.image_info.image_base = ARM_TB_FW_CONFIG_BASE,
-		.image_info.image_max_size = ARM_TB_FW_CONFIG_LIMIT - ARM_TB_FW_CONFIG_BASE,
+		.image_info.image_max_size =
+			ARM_TB_FW_CONFIG_LIMIT - ARM_TB_FW_CONFIG_BASE
 	};
 
 	VERBOSE("BL1: Loading TB_FW_CONFIG\n");
@@ -139,6 +148,7 @@ void arm_load_tb_fw_config(void)
 	/* At this point we know that a DTB is indeed available */
 	config_base = arm_tb_fw_info.image_info.image_base;
 	tb_fw_cfg_dtb = (void *)config_base;
+	tb_fw_cfg_dtb_size = (size_t)arm_tb_fw_info.image_info.image_max_size;
 
 	/* The BL2 ep_info arg0 is modified to point to TB_FW_CONFIG */
 	image_desc = bl1_plat_get_image_desc(BL2_IMAGE_ID);

--- a/plat/arm/common/arm_dyn_cfg_helpers.c
+++ b/plat/arm/common/arm_dyn_cfg_helpers.c
@@ -167,8 +167,6 @@ int arm_dyn_tb_fw_cfg_init(void *dtb, int *node)
 	return 0;
 }
 
-
-#if TRUSTED_BOARD_BOOT && LOAD_IMAGE_V2
 /*
  * Reads and returns the Mbed TLS shared heap information from the DTB.
  * This function is supposed to be called *only* when a DTB is present.
@@ -187,8 +185,7 @@ int arm_get_dtb_mbedtls_heap_info(void *dtb, void **heap_addr,
 	/* Verify the DTB is valid and get the root node */
 	err = arm_dyn_tb_fw_cfg_init(dtb, &dtb_root);
 	if (err < 0) {
-		ERROR("%s: Invalid TB_FW_CONFIG. Cannot retrieve Mbed TLS "
-			"heap information from DTB\n", __func__);
+		ERROR("Invalid TB_FW_CONFIG. Cannot retrieve Mbed TLS heap information from DTB\n");
 		return -1;
 	}
 
@@ -196,14 +193,14 @@ int arm_get_dtb_mbedtls_heap_info(void *dtb, void **heap_addr,
 	err = fdtw_read_cells(dtb, dtb_root,
 		DTB_PROP_MBEDTLS_HEAP_ADDR, 2, heap_addr);
 	if (err < 0) {
-		ERROR("%s: error while reading %s from DTB\n", __func__,
+		ERROR("Error while reading %s from DTB\n",
 			DTB_PROP_MBEDTLS_HEAP_ADDR);
 		return -1;
 	}
 	err = fdtw_read_cells(dtb, dtb_root,
 		DTB_PROP_MBEDTLS_HEAP_SIZE, 1, heap_size);
 	if (err < 0) {
-		ERROR("%s: error while reading %s from DTB\n", __func__,
+		ERROR("Error while reading %s from DTB\n",
 			DTB_PROP_MBEDTLS_HEAP_SIZE);
 		return -1;
 	}
@@ -234,8 +231,7 @@ int arm_set_dtb_mbedtls_heap_info(void *dtb, void *heap_addr, size_t heap_size)
 	 */
 	err = arm_dyn_tb_fw_cfg_init(dtb, &dtb_root);
 	if (err < 0) {
-		ERROR("%s: Invalid TB_FW_CONFIG loaded. Unable to get "
-			"root node\n", __func__);
+		ERROR("Invalid TB_FW_CONFIG loaded. Unable to get root node\n");
 		return -1;
 	}
 
@@ -249,19 +245,18 @@ int arm_set_dtb_mbedtls_heap_info(void *dtb, void *heap_addr, size_t heap_size)
 	err = fdtw_write_inplace_cells(dtb, dtb_root,
 		DTB_PROP_MBEDTLS_HEAP_ADDR, 2, &heap_addr);
 	if (err < 0) {
-		ERROR("%s: unable to write DTB property %s\n",
-			__func__, DTB_PROP_MBEDTLS_HEAP_ADDR);
+		ERROR("Unable to write DTB property %s\n",
+			DTB_PROP_MBEDTLS_HEAP_ADDR);
 		return -1;
 	}
 
 	err = fdtw_write_inplace_cells(dtb, dtb_root,
 		DTB_PROP_MBEDTLS_HEAP_SIZE, 1, &heap_size);
 	if (err < 0) {
-		ERROR("%s: unable to write DTB property %s\n",
-			__func__, DTB_PROP_MBEDTLS_HEAP_SIZE);
+		ERROR("Unable to write DTB property %s\n",
+			DTB_PROP_MBEDTLS_HEAP_SIZE);
 		return -1;
 	}
 
 	return 0;
 }
-#endif /* TRUSTED_BOARD_BOOT && LOAD_IMAGE_V2 */


### PR DESCRIPTION
This patch refines parts of the initial Mbed TLS shared heap implementation (https://github.com/ARM-software/arm-trusted-firmware/pull/1554). Each commit describes the various changes.