### PR TITLE
ARM Platforms:Enable non-secure access to UART1

### DIFF
--- a/plat/arm/css/common/css_common.mk
+++ b/plat/arm/css/common/css_common.mk
@@ -85,3 +85,12 @@ endif
 # Process CSS_USE_SCMI_SDS_DRIVER flag
 $(eval $(call assert_boolean,CSS_USE_SCMI_SDS_DRIVER))
 $(eval $(call add_define,CSS_USE_SCMI_SDS_DRIVER))
+
+# Process CSS_NON_SECURE_UART flag
+# This undocumented build option is only to enable debug access to the UART
+# from non secure code, which is useful on some platforms.
+# Default (obviously) is off.
+CSS_NON_SECURE_UART		:= 0
+$(eval $(call assert_boolean,CSS_NON_SECURE_UART))
+$(eval $(call add_define,CSS_NON_SECURE_UART))
+

--- a/plat/arm/soc/common/soc_css_security.c
+++ b/plat/arm/soc/common/soc_css_security.c
@@ -23,7 +23,7 @@ void soc_css_init_nic400(void)
 
 	/*
 	 * Allow non-secure access to some SOC regions, excluding UART1, which
-	 * remains secure.
+	 * remains secure (unless CSS_NON_SECURE_UART is set).
 	 * Note: This is the NIC-400 device on the SOC
 	 */
 	mmio_write_32(SOC_CSS_NIC400_BASE +
@@ -36,9 +36,15 @@ void soc_css_init_nic400(void)
 		NIC400_ADDR_CTRL_SECURITY_REG(SOC_CSS_NIC400_PL354_SMC), ~0);
 	mmio_write_32(SOC_CSS_NIC400_BASE +
 		NIC400_ADDR_CTRL_SECURITY_REG(SOC_CSS_NIC400_APB4_BRIDGE), ~0);
+#if  CSS_NON_SECURE_UART
+	/* Configure UART for non-secure access */
+	mmio_write_32(SOC_CSS_NIC400_BASE +
+		NIC400_ADDR_CTRL_SECURITY_REG(SOC_CSS_NIC400_BOOTSEC_BRIDGE), ~0);
+#else
 	mmio_write_32(SOC_CSS_NIC400_BASE +
 		NIC400_ADDR_CTRL_SECURITY_REG(SOC_CSS_NIC400_BOOTSEC_BRIDGE),
 		~SOC_CSS_NIC400_BOOTSEC_BRIDGE_UART1);
+#endif /* CSS_NON_SECURE_UART */
 
 }
 


### PR DESCRIPTION
Adds an undocumented build option that enables non-secure access to
the PL011 UART1.
This allows a custom build where the UART can be used as a serial debug
port for WinDbg (or other debugger) connection.

This option is not documented in the user guide, as it is provided as a
convenience for Windows debugging, and not intended for general use.
In particular, enabling non-secure access to the UART might allow
a denial of service attack!

Change-Id: I4cd7d59c2cac897cc654ab5e1188ff031114ed3c
Signed-off-by: Alexei Fedorov <Alexei.Fedorov@arm.com>
Signed-off-by: Evan Lloyd <evan.lloyd@arm.com>