### PR TITLE
Fix the Cortex-ares errata reporting function name

### DIFF
--- a/lib/cpus/aarch64/cortex_ares.S
+++ b/lib/cpus/aarch64/cortex_ares.S
@@ -95,7 +95,7 @@ endfunc cortex_ares_core_pwr_dwn
 /*
  * Errata printing function for Cortex-Ares. Must follow AAPCS.
  */
-func cortex_a72_errata_report
+func cortex_ares_errata_report
 	stp	x8, x30, [sp, #-16]!
 
 	bl	cpu_get_rev_var
@@ -109,7 +109,7 @@ func cortex_a72_errata_report
 
 	ldp	x8, x30, [sp], #16
 	ret
-endfunc cortex_a72_errata_report
+endfunc cortex_ares_errata_report
 #endif
 
 	/* ---------------------------------------------


### PR DESCRIPTION
This patch fixes the name of the Cortex-ares errata function which was
previously named `cortex_a72_errata_report` which was an error.

Change-Id: Ia124df4628261021baa8d9a30308bc286d45712b
Signed-off-by: Soby Mathew <soby.mathew@arm.com>