### PR TITLE
Allwinner PMIC fixes

### DIFF
--- a/drivers/mentor/i2c/mi2cv.c
+++ b/drivers/mentor/i2c/mi2cv.c
@@ -15,6 +15,7 @@
 #include <delay_timer.h>
 #include <errno.h>
 #include <mentor/mi2cv.h>
+#include <mentor_i2c_plat.h>
 #include <mmio.h>
 
 #if LOG_LEVEL >= LOG_LEVEL_VERBOSE

--- a/plat/allwinner/common/include/mentor_i2c_plat.h
+++ b/plat/allwinner/common/include/mentor_i2c_plat.h
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  * https://spdx.org/licenses
  */
-
 /* This driver provides I2C support for Allwinner sunXi SoCs */
 
-#include <mmio.h>
+#ifndef SUNXI_I2C_H
+#define SUNXI_I2C_H
 
 #define CONFIG_SYS_TCLK			24000000
 #define CONFIG_SYS_I2C_SPEED		100000
@@ -25,4 +25,4 @@ struct  mentor_i2c_regs {
 	uint32_t soft_reset;
 };
 
-#include "../mentor/i2c/mi2cv.c"
+#endif

--- a/plat/allwinner/sun50i_h6/platform.mk
+++ b/plat/allwinner/sun50i_h6/platform.mk
@@ -15,8 +15,8 @@ PLAT_INCLUDES		:=	-Iinclude/plat/arm/common		\
 				-I${AW_PLAT}/${PLAT}/include
 
 PLAT_BL_COMMON_SOURCES	:=	drivers/console/${ARCH}/console.S	\
+				drivers/mentor/i2c/mi2cv.c		\
 				drivers/ti/uart/${ARCH}/16550_console.S	\
-				${AW_DRIVERS}/sunxi_i2c.c		\
 				${XLAT_TABLES_LIB_SRCS}			\
 				${AW_PLAT}/common/plat_helpers.S	\
 				${AW_PLAT}/common/sunxi_common.c

--- a/plat/allwinner/sun50i_h6/sunxi_power.c
+++ b/plat/allwinner/sun50i_h6/sunxi_power.c
@@ -120,10 +120,9 @@ void __dead2 sunxi_power_down(void)
 
 	switch (pmic) {
 	case AXP805:
-		val = 0x26; /* Default value for REG 32H */
+		sunxi_init_r_i2c();
 		axp_i2c_read(AXP805_ADDR, 0x32, &val);
-		val |= 0x80;
-		axp_i2c_write(AXP805_ADDR, 0x32, val);
+		axp_i2c_write(AXP805_ADDR, 0x32, val | 0x80);
 		break;
 	default:
 		break;

--- a/plat/allwinner/sun50i_h6/sunxi_power.c
+++ b/plat/allwinner/sun50i_h6/sunxi_power.c
@@ -28,13 +28,8 @@ static int sunxi_init_r_i2c(void)
 {
 	uint32_t reg;
 
-	/* get currently configured function for pins PL0 and PL1 */
-	reg = mmio_read_32(SUNXI_R_PIO_BASE + 0x00);
-	if ((reg & 0xff) == 0x33) {
-		NOTICE("PMIC: already configured for TWI\n");
-	}
-
 	/* switch pins PL0 and PL1 to I2C */
+	reg = mmio_read_32(SUNXI_R_PIO_BASE + 0x00);
 	mmio_write_32(SUNXI_R_PIO_BASE + 0x00, (reg & ~0xff) | 0x33);
 
 	/* level 2 drive strength */
@@ -47,13 +42,11 @@ static int sunxi_init_r_i2c(void)
 
 	/* assert & de-assert reset of R_I2C */
 	reg = mmio_read_32(SUNXI_R_PRCM_BASE + 0x19c);
-	mmio_write_32(SUNXI_R_PRCM_BASE + 0x19c, 0);
-	reg = mmio_read_32(SUNXI_R_PRCM_BASE + 0x19c);
-	mmio_write_32(SUNXI_R_PRCM_BASE + 0x19c, reg | 0x00010000);
+	mmio_write_32(SUNXI_R_PRCM_BASE + 0x19c, reg & ~BIT(16));
+	mmio_write_32(SUNXI_R_PRCM_BASE + 0x19c, reg | BIT(16));
 
 	/* un-gate R_I2C clock */
-	reg = mmio_read_32(SUNXI_R_PRCM_BASE + 0x19c);
-	mmio_write_32(SUNXI_R_PRCM_BASE + 0x19c, reg | 0x00000001);
+	mmio_write_32(SUNXI_R_PRCM_BASE + 0x19c, reg | BIT(16) | BIT(0));
 
 	/* call mi2cv driver */
 	i2c_init((void *)SUNXI_R_I2C_BASE);

--- a/plat/marvell/a8k/common/a8k_common.mk
+++ b/plat/marvell/a8k/common/a8k_common.mk
@@ -57,9 +57,9 @@ BLE_PORTING_SOURCES	:=	$(PLAT_FAMILY_BASE)/$(PLAT)/board/dram_port.c \
 
 MARVELL_MOCHI_DRV	+=	$(MARVELL_DRV_BASE)/mochi/cp110_setup.c
 
-BLE_SOURCES		:=	$(PLAT_COMMON_BASE)/plat_ble_setup.c		\
+BLE_SOURCES		:=	drivers/mentor/i2c/mi2cv.c			\
+				$(PLAT_COMMON_BASE)/plat_ble_setup.c		\
 				$(MARVELL_MOCHI_DRV)			       \
-				$(MARVELL_DRV_BASE)/i2c/a8k_i2c.c	 	\
 				$(PLAT_COMMON_BASE)/plat_pm.c		 	\
 				$(MARVELL_DRV_BASE)/thermal.c			\
 				$(PLAT_COMMON_BASE)/plat_thermal.c		\

--- a/plat/marvell/a8k/common/include/mentor_i2c_plat.h
+++ b/plat/marvell/a8k/common/include/mentor_i2c_plat.h
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier:     BSD-3-Clause
  * https://spdx.org/licenses
  */
-
 /* This driver provides I2C support for Marvell A8K and compatible SoCs */
 
-#include <mmio.h>
+#ifndef A8K_I2C_H
+#define A8K_I2C_H
 
 #define CONFIG_SYS_TCLK			250000000
 #define CONFIG_SYS_I2C_SPEED		100000
@@ -30,4 +30,4 @@ struct  mentor_i2c_regs {
 	uint32_t unstuck;
 };
 
-#include "../../mentor/i2c/mi2cv.c"
+#endif


### PR DESCRIPTION
Fix some minor things we discussed before that didn't make it into the original PR.
This addresses some minor issues during the Allwinner I2C platform setup and improves the code readability on the way. Also this (re-)initialises the I2C controller (again) just before we are using it in the PSCI handler for powering down the system, so we can cope with anything the rich OS may have done meanwhile.
Also this changes the I2C driver stubs for Allwinner and Marvell to be header files instead, and let the actual driver include them.
@Icenowy: Could you please have a look and confirm that these changs are fine? I briefly tested it yesterday on my PineH64 board.
@kostapr: Can you please check that the third patch matches what you were talking about before?
