### PR TITLE
Allow setting log level back to compile time value

### DIFF
--- a/common/tf_log.c
+++ b/common/tf_log.c
@@ -49,7 +49,7 @@ void tf_log(const char *fmt, ...)
 /*
  * The helper function to set the log level dynamically by platform. The
  * maximum log level is determined by `LOG_LEVEL` build flag at compile time
- * and this helper can set a lower log level than the one at compile.
+ * and this helper can set a lower (or equal) log level than the one at compile.
  */
 void tf_log_set_max_level(unsigned int log_level)
 {
@@ -57,6 +57,6 @@ void tf_log_set_max_level(unsigned int log_level)
 	assert((log_level % 10U) == 0U);
 
 	/* Cap log_level to the compile time maximum. */
-	if (log_level < (unsigned int)LOG_LEVEL)
+	if (log_level <= (unsigned int)LOG_LEVEL)
 		max_log_level = log_level;
 }


### PR DESCRIPTION
When using the tf_log_set_max_level() function, one can dynamically
set the log level to a value smaller than then compile time specified
one, but not equal. This means that when the log level have been
lowered, it can't be reset to the previous value. This commit modifies
this function to allow setting the log level back to the compile time
value.

Fixes ARM-software/tf-issues#624

Change-Id: Ib157715c8835982ce4977ba67a48e18ff23d5a61
Signed-off-by: Junhan Zhou <Junhan@mellanox.com>