### PR TITLE
psci: allow the platform to validate the power operation early

### DIFF
--- a/docs/platform-migration-guide.rst
+++ b/docs/platform-migration-guide.rst
@@ -155,6 +155,7 @@ for the ``plat_psci_ops`` structure which is declared as :
         void (*system_reset)(void) __dead2;
         int (*validate_power_state)(unsigned int power_state,
                         psci_power_state_t *req_state);
+        int (*validate_power_operation)(uint32_t smc_fid);
         int (*validate_ns_entrypoint)(unsigned long ns_entrypoint);
         void (*get_sys_suspend_power_state)(
                         psci_power_state_t *req_state);
@@ -573,6 +574,17 @@ call to validate the ``power_state`` parameter of the PSCI API. If the
 ``power_state`` is known to be invalid, the platform must return
 PSCI\_E\_INVALID\_PARAMS as an error, which is propagated back to the Normal
 world PSCI client.
+
+plat\_pm\_ops.validate\_power\_operation()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This function is called by the PSCI implementation before executing the SMC
+handler; it allows the platform to check if the requested operation can be
+allowed (ie, the platform can hotplug CPU0 or use CPUx to enter system suspend).
+If the operation can be allowed then the platform must return PSCI\_E\_SUCCESS.
+Otherwise PSCI will propagate PSCI\_E\_DENIED back to the Normal world client.
+
+The implementation of this interface is optional for the platform.
 
 plat\_pm\_ops.validate\_ns\_entrypoint()
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/include/lib/psci/psci.h
+++ b/include/lib/psci/psci.h
@@ -311,6 +311,7 @@ typedef struct plat_psci_ops {
 	void (*system_reset)(void) __dead2;
 	int (*validate_power_state)(unsigned int power_state,
 				    psci_power_state_t *req_state);
+	int (*validate_power_operation)(uint32_t smc_fid);
 	int (*validate_ns_entrypoint)(uintptr_t ns_entrypoint);
 	void (*get_sys_suspend_power_state)(
 				    psci_power_state_t *req_state);
@@ -331,6 +332,7 @@ typedef struct plat_psci_ops {
  * Function & Data prototypes
  ******************************************************************************/
 unsigned int psci_version(void);
+int psci_op_allowed(uint32_t smc_fid);
 int psci_cpu_on(u_register_t target_cpu,
 		uintptr_t entrypoint,
 		u_register_t context_id);

--- a/include/lib/psci/psci_compat.h
+++ b/include/lib/psci/psci_compat.h
@@ -77,6 +77,7 @@ typedef struct plat_pm_ops {
 	void (*system_reset)(void) __dead2;
 	int (*validate_power_state)(unsigned int power_state);
 	int (*validate_ns_entrypoint)(unsigned long ns_entrypoint);
+	int (*validate_power_operation)(unsigned int smc_fid);
 	unsigned int (*get_sys_suspend_power_state)(void);
 } plat_pm_ops_t;
 

--- a/plat/compat/plat_pm_compat.c
+++ b/plat/compat/plat_pm_compat.c
@@ -135,6 +135,15 @@ static int validate_ns_entrypoint_compat(uintptr_t ns_entrypoint)
 }
 
 /*******************************************************************************
+ * The PSCI compatibility helper for plat_pm_ops_t 'validate_power_operation'
+ * hook.
+ ******************************************************************************/
+static int validate_power_operation_compat(uint32_t smc_fid)
+{
+	return pm_ops->validate_power_operation(smc_fid);
+}
+
+/*******************************************************************************
  * The PSCI compatibility helper for plat_pm_ops_t 'affinst_standby' hook.
  ******************************************************************************/
 static void cpu_standby_compat(plat_local_state_t cpu_state)
@@ -277,6 +286,10 @@ int plat_setup_psci_ops(uintptr_t sec_entrypoint,
 	if (pm_ops->validate_ns_entrypoint)
 		compat_psci_ops.validate_ns_entrypoint =
 				validate_ns_entrypoint_compat;
+
+	if (pm_ops->validate_power_operation)
+		compat_psci_ops.validate_power_operation =
+				validate_power_operation_compat;
 
 	if (pm_ops->affinst_standby)
 		compat_psci_ops.cpu_standby = cpu_standby_compat;


### PR DESCRIPTION
This hooks allows any platform to implement an early validation of
every single PSCI request.

For instance this could be used to prevent any CPUs from requesting
suspend entry or cpu offlinining.

Signed-off-by: Jorge Ramirez-Ortiz <jramirez@baylibre.com>