### PR TITLE
psci: early op validation and migrate info

### DIFF
--- a/include/lib/psci/psci.h
+++ b/include/lib/psci/psci.h
@@ -326,6 +326,7 @@ typedef struct plat_psci_ops {
 	int (*write_mem_protect)(int val);
 	int (*system_reset2)(int is_vendor,
 				int reset_type, u_register_t cookie);
+	int (*migrate_info)(u_register_t *mpidr);
 } plat_psci_ops_t;
 
 /*******************************************************************************
@@ -333,6 +334,7 @@ typedef struct plat_psci_ops {
  ******************************************************************************/
 unsigned int psci_version(void);
 int psci_op_allowed(uint32_t smc_fid);
+int psci_migrate_info(u_register_t *mpidr);
 int psci_cpu_on(u_register_t target_cpu,
 		uintptr_t entrypoint,
 		u_register_t context_id);

--- a/include/lib/psci/psci.h
+++ b/include/lib/psci/psci.h
@@ -311,6 +311,7 @@ typedef struct plat_psci_ops {
 	void (*system_reset)(void) __dead2;
 	int (*validate_power_state)(unsigned int power_state,
 				    psci_power_state_t *req_state);
+	int (*validate_power_operation)(uint32_t smc_fid);
 	int (*validate_ns_entrypoint)(uintptr_t ns_entrypoint);
 	void (*get_sys_suspend_power_state)(
 				    psci_power_state_t *req_state);
@@ -331,6 +332,7 @@ typedef struct plat_psci_ops {
  * Function & Data prototypes
  ******************************************************************************/
 unsigned int psci_version(void);
+int psci_op_allowed(uint32_t smc_fid);
 int psci_cpu_on(u_register_t target_cpu,
 		uintptr_t entrypoint,
 		u_register_t context_id);

--- a/include/lib/psci/psci_compat.h
+++ b/include/lib/psci/psci_compat.h
@@ -77,6 +77,7 @@ typedef struct plat_pm_ops {
 	void (*system_reset)(void) __dead2;
 	int (*validate_power_state)(unsigned int power_state);
 	int (*validate_ns_entrypoint)(unsigned long ns_entrypoint);
+	int (*validate_power_operation)(unsigned int smc_fid);
 	unsigned int (*get_sys_suspend_power_state)(void);
 } plat_pm_ops_t;
 

--- a/include/lib/psci/psci_compat.h
+++ b/include/lib/psci/psci_compat.h
@@ -79,6 +79,7 @@ typedef struct plat_pm_ops {
 	int (*validate_ns_entrypoint)(unsigned long ns_entrypoint);
 	int (*validate_power_operation)(unsigned int smc_fid);
 	unsigned int (*get_sys_suspend_power_state)(void);
+	int (*migrate_info)(u_register_t *mpidr);
 } plat_pm_ops_t;
 
 /*******************************************************************************

--- a/plat/compat/plat_pm_compat.c
+++ b/plat/compat/plat_pm_compat.c
@@ -135,6 +135,15 @@ static int validate_ns_entrypoint_compat(uintptr_t ns_entrypoint)
 }
 
 /*******************************************************************************
+ * The PSCI compatibility helper for plat_pm_ops_t 'validate_power_operation'
+ * hook.
+ ******************************************************************************/
+static int validate_power_operation_compat(uint32_t smc_fid)
+{
+	return pm_ops->validate_power_operation(smc_fid);
+}
+
+/*******************************************************************************
  * The PSCI compatibility helper for plat_pm_ops_t 'affinst_standby' hook.
  ******************************************************************************/
 static void cpu_standby_compat(plat_local_state_t cpu_state)
@@ -278,6 +287,9 @@ int plat_setup_psci_ops(uintptr_t sec_entrypoint,
 		compat_psci_ops.validate_ns_entrypoint =
 				validate_ns_entrypoint_compat;
 
+	if (pm_ops->validate_power_operation)
+		compat_psci_ops.validate_power_operation =
+				validate_power_operation_compat;
 	if (pm_ops->affinst_standby)
 		compat_psci_ops.cpu_standby = cpu_standby_compat;
 

--- a/plat/compat/plat_pm_compat.c
+++ b/plat/compat/plat_pm_compat.c
@@ -144,6 +144,14 @@ static int validate_power_operation_compat(uint32_t smc_fid)
 }
 
 /*******************************************************************************
+ * The PSCI compatibility helper for plat_pm_ops_t 'migrate_info' hook.
+ ******************************************************************************/
+static int migrate_info_compat(u_register_t *mpidr)
+{
+	return pm_ops->migrate_info(mpidr);
+}
+
+/*******************************************************************************
  * The PSCI compatibility helper for plat_pm_ops_t 'affinst_standby' hook.
  ******************************************************************************/
 static void cpu_standby_compat(plat_local_state_t cpu_state)
@@ -319,6 +327,10 @@ int plat_setup_psci_ops(uintptr_t sec_entrypoint,
 	if (pm_ops->get_sys_suspend_power_state)
 		compat_psci_ops.get_sys_suspend_power_state =
 				get_sys_suspend_power_state_compat;
+
+	if (pm_ops->migrate_info)
+		compat_psci_ops.migrate_info =
+				migrate_info_compat;
 
 	*psci_ops = &compat_psci_ops;
 	return 0;


### PR DESCRIPTION
The following pull request implements two different hooks
1. early platform validation: allows the platform to deny PSCI operations early in the process. The hook is used in the system suspend scenario since there are platforms (rcar-gen3) that can only enter suspend from the boot cpu (whichever that might happen to be).
2. platform hook for migrate info: current migrate capabilities fully depend on the SPD. In the case of OPTEED, there are no migrate restrictions (so all CPUs could be hotplugged). This creates a problem for platforms in which some CPUs cant be hotplugged (rcar-gen3 for instance can't hotplug the boot cpu). with this commit a platform hook is provided to allow the platform to communicate its restrictions when the SPD has none.