### PR TITLE
ARM platforms: Reintroduce coherent memory for BL1 and BL2

### DIFF
--- a/plat/arm/common/arm_bl1_setup.c
+++ b/plat/arm/common/arm_bl1_setup.c
@@ -111,8 +111,11 @@ void bl1_early_platform_setup(void)
  *****************************************************************************/
 void arm_bl1_plat_arch_setup(void)
 {
-#if USE_COHERENT_MEM
-	/* ARM platforms dont use coherent memory in BL1 */
+#if USE_COHERENT_MEM && !ARM_CRYPTOCELL_INTEG
+	/*
+	 * Ensure ARM platforms don't use coherent memory in BL1 unless
+	 * cryptocell integration is enabled.
+	 */
 	assert((BL_COHERENT_RAM_END - BL_COHERENT_RAM_BASE) == 0U);
 #endif
 
@@ -122,7 +125,10 @@ void arm_bl1_plat_arch_setup(void)
 #if USE_ROMLIB
 		ARM_MAP_ROMLIB_CODE,
 		ARM_MAP_ROMLIB_DATA,
- #endif
+#endif
+#if ARM_CRYPTOCELL_INTEG
+		ARM_MAP_BL_COHERENT_RAM,
+#endif
 		{0}
 	};
 

--- a/plat/arm/common/arm_bl2_setup.c
+++ b/plat/arm/common/arm_bl2_setup.c
@@ -237,9 +237,11 @@ void bl2_platform_setup(void)
  ******************************************************************************/
 void arm_bl2_plat_arch_setup(void)
 {
-
-#if USE_COHERENT_MEM
-	/* Ensure ARM platforms dont use coherent memory in BL2 */
+#if USE_COHERENT_MEM && !ARM_CRYPTOCELL_INTEG
+	/*
+	 * Ensure ARM platforms don't use coherent memory in BL2 unless
+	 * cryptocell integration is enabled.
+	 */
 	assert((BL_COHERENT_RAM_END - BL_COHERENT_RAM_BASE) == 0U);
 #endif
 
@@ -249,6 +251,9 @@ void arm_bl2_plat_arch_setup(void)
 #if USE_ROMLIB
 		ARM_MAP_ROMLIB_CODE,
 		ARM_MAP_ROMLIB_DATA,
+#endif
+#if ARM_CRYPTOCELL_INTEG
+		ARM_MAP_BL_COHERENT_RAM,
 #endif
 		{0}
 	};

--- a/plat/arm/common/arm_common.mk
+++ b/plat/arm/common/arm_common.mk
@@ -138,6 +138,14 @@ ARM_CRYPTOCELL_INTEG		:=	0
 $(eval $(call assert_boolean,ARM_CRYPTOCELL_INTEG))
 $(eval $(call add_define,ARM_CRYPTOCELL_INTEG))
 
+# CryptoCell integration relies on coherent buffers for passing data from
+# the AP CPU to the CryptoCell
+ifeq (${ARM_CRYPTOCELL_INTEG},1)
+    ifeq (${USE_COHERENT_MEM},0)
+        $(error "ARM_CRYPTOCELL_INTEG needs USE_COHERENT_MEM to be set.")
+    endif
+endif
+
 PLAT_INCLUDES		+=	-Iinclude/common/tbbr				\
 				-Iinclude/plat/arm/common
 


### PR DESCRIPTION
The patch d323af9 removed the support for coherent memory in BL1 and
BL2 for ARM platforms. But the CryptoCell SBROM  integration depends
on use of coherent buffers for passing data from the AP CPU to the
CryptoCell. Hence this patch reintroduces support for coherent
memory in BL1 and BL2 if ARM_CRYPTOCELL_INTEG=1.

Change-Id: I011482dda7f7a3ec9e3e79bfb3f4fa03796f7e02
Signed-Off-by: Soby Mathew <soby.mathew@arm.com>