### PR TITLE
BL31: Fix warning about BL32 init function

### DIFF
--- a/bl31/bl31_main.c
+++ b/bl31/bl31_main.c
@@ -108,10 +108,8 @@ void bl31_main(void)
 
 		int32_t rc = (*bl32_init)();
 
-		if (rc != 0) {
-			WARN("BL31: BL32 initialization failed (rc = %d)\n",
-			     rc);
-		}
+		if (rc == 0)
+			WARN("BL31: BL32 initialization failed\n");
 	}
 	/*
 	 * We are ready to enter the next EL. Prepare entry into the image


### PR DESCRIPTION
The expected value for failure is 0, so the warning only has to be shown in that case. This is the way the TSPD has done it since it was introduced, and the way SPM and OP-TEE do it.

Trusty wrongly returns 0 on success.

In the case of TLK, the return value of tlkd_init() is passed from the secure world in register X1 when calling the SMC TLK_ENTRY_DONE.