### PR TITLE
trusty: Fix return value of trusty_init()

### DIFF
--- a/services/spd/trusty/trusty.c
+++ b/services/spd/trusty/trusty.c
@@ -322,7 +322,7 @@ static int32_t trusty_init(void)
 	fpregs_context_restore(get_fpregs_ctx(cm_get_context(NON_SECURE)));
 	cm_set_next_eret_context(NON_SECURE);
 
-	return 0;
+	return 1;
 }
 
 static void trusty_cpu_suspend(uint32_t off)


### PR DESCRIPTION
The value used to signal failure is 0. It is needed to return a different value on success.