### PR TITLE
aarch32: PAR_ADDR_MASK should explicitly use BIT_64

### DIFF
--- a/include/lib/aarch32/arch.h
+++ b/include/lib/aarch32/arch.h
@@ -576,7 +576,7 @@
 #define PAR_F_SHIFT	U(0)
 #define PAR_F_MASK	ULL(0x1)
 #define PAR_ADDR_SHIFT	U(12)
-#define PAR_ADDR_MASK	(BIT(40) - ULL(1)) /* 40-bits-wide page address */
+#define PAR_ADDR_MASK	(BIT_64(40) - ULL(1)) /* 40-bits-wide page address */
 
 /*******************************************************************************
  * Definitions for system register interface to AMU for ARMv8.4 onwards


### PR DESCRIPTION
PAR register used here is a 64 bit register.
On AARCH32 BIT macro is BIT_32.
PAR_ADDR_MASK should then use BIT_64 to avoid overflow.

Signed-off-by: Yann Gautier <yann.gautier@st.com>