### PR TITLE
Ensure the flow through switch statements is clear

### DIFF
--- a/bl1/bl1_fwu.c
+++ b/bl1/bl1_fwu.c
@@ -86,11 +86,9 @@ register_t bl1_fwu_smc_handler(unsigned int smc_fid,
 
 	case FWU_SMC_UPDATE_DONE:
 		bl1_fwu_done((void *)x1, NULL);
-		/* We should never return from bl1_fwu_done() */
-		break;
 
 	default:
-		assert(0);
+		assert(0); /* Unreachable */
 		break;
 	}
 
@@ -747,7 +745,7 @@ static int bl1_fwu_image_reset(unsigned int image_id, unsigned int flags)
 
 	case IMAGE_STATE_EXECUTED:
 	default:
-		assert(0);
+		assert(0); /* Unreachable */
 		break;
 	}
 

--- a/lib/libc/printf.c
+++ b/lib/libc/printf.c
@@ -166,6 +166,7 @@ loop:
 					padn = (padn * 10) + (ch - '0');
 					fmt++;
 				}
+				assert(0); /* Unreachable */
 			default:
 				/* Exit on any other format specifier */
 				return -1;

--- a/lib/libc/snprintf.c
+++ b/lib/libc/snprintf.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <assert.h>
 #include <debug.h>
 #include <platform.h>
 #include <stdarg.h>
@@ -117,6 +118,7 @@ int snprintf(char *s, size_t n, const char *fmt, ...)
 				ERROR("snprintf: specifier with ASCII code '%d' not supported.",
 				      *fmt);
 				plat_panic_handler();
+				assert(0); /* Unreachable */
 			}
 			fmt++;
 			continue;

--- a/plat/common/plat_gicv2.c
+++ b/plat/common/plat_gicv2.c
@@ -226,7 +226,7 @@ void plat_ic_set_interrupt_type(unsigned int id, unsigned int type)
 		gicv2_type = GICV2_INTR_GROUP1;
 		break;
 	default:
-		assert(false);
+		assert(0); /* Unreachable */
 		break;
 	}
 
@@ -266,7 +266,7 @@ void plat_ic_set_spi_routing(unsigned int id, unsigned int routing_mode,
 		proc_num = -1;
 		break;
 	default:
-		assert(false);
+		assert(0); /* Unreachable */
 		break;
 	}
 

--- a/plat/common/plat_gicv3.c
+++ b/plat/common/plat_gicv3.c
@@ -157,6 +157,7 @@ uint32_t plat_interrupt_type_to_line(uint32_t type,
 			return __builtin_ctz(SCR_IRQ_BIT);
 		else
 			return __builtin_ctz(SCR_FIQ_BIT);
+		assert(0); /* Unreachable */
 	case INTR_TYPE_NS:
 		/*
 		 * The Non secure interrupts will be signaled as FIQ in S-EL0/1
@@ -166,6 +167,7 @@ uint32_t plat_interrupt_type_to_line(uint32_t type,
 			return __builtin_ctz(SCR_FIQ_BIT);
 		else
 			return __builtin_ctz(SCR_IRQ_BIT);
+		assert(0); /* Unreachable */
 	case INTR_TYPE_EL3:
 		/*
 		 * The EL3 interrupts are signaled as FIQ in both S-EL0/1 and
@@ -255,7 +257,7 @@ void plat_ic_set_spi_routing(unsigned int id, unsigned int routing_mode,
 		irm = GICV3_IRM_ANY;
 		break;
 	default:
-		assert(false);
+		assert(0); /* Unreachable */
 		break;
 	}
 

--- a/plat/rockchip/rk3399/drivers/dp/cdn_dp.c
+++ b/plat/rockchip/rk3399/drivers/dp/cdn_dp.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <assert.h>
 #include <cdefs.h>
 #include <cdn_dp.h>
 #include <smccc.h>
@@ -38,6 +39,7 @@ uint64_t dp_hdcp_ctrl(uint64_t type)
 			return hdcp_handler(&key);
 		else
 			return PSCI_E_INVALID_PARAMS;
+		assert(0); /* Unreachable */
 	default:
 		return SMC_UNK;
 	}

--- a/plat/xilinx/zynqmp/pm_service/pm_api_ioctl.c
+++ b/plat/xilinx/zynqmp/pm_service/pm_api_ioctl.c
@@ -253,6 +253,7 @@ static enum pm_ret_status pm_ioctl_sd_dll_reset(enum pm_node_id nid,
 		if (type == PM_DLL_RESET_ASSERT)
 			break;
 		mdelay(1);
+		/* Fallthrough */
 	case PM_DLL_RESET_RELEASE:
 		ret = pm_mmio_write(ZYNQMP_SD_DLL_CTRL, mask, 0);
 		break;

--- a/services/spd/tlkd/tlkd_common.c
+++ b/services/spd/tlkd/tlkd_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -48,7 +48,7 @@ uint64_t tlkd_va_translate(uintptr_t va, int type)
 		ats12e0w(va);
 		break;
 	default:
-		assert(0);
+		assert(0); /* Unreachable */
 		break;
 	}
 

--- a/services/spd/tspd/tspd_main.c
+++ b/services/spd/tspd/tspd_main.c
@@ -592,6 +592,7 @@ static uintptr_t tspd_smc_handler(uint32_t smc_fid,
 
 			SMC_RET3(ns_cpu_context, x1, x2, x3);
 		}
+		assert(0); /* Unreachable */
 
 	/*
 	 * Request from the non-secure world to abort a preempted Yielding SMC


### PR DESCRIPTION
Ensure case clauses:
*   Terminate with an unconditional break, return or goto statement.
*   Use conditional break, return or goto statements as long as the end
    of the case clause is unreachable; such case clauses must terminate
    with assert(0) /* Unreachable */ or an unconditional  __dead2 function
    call
*   Only fallthough when doing otherwise would result in less
    readable/maintainable code; such case clauses must terminate with a
    /* Fallthrough */ comment to make it clear this is the case and
    indicate that a fallthrough is intended.

This reduces the chance of bugs appearing due to unintended flow through a
switch statement

Change-Id: I70fc2d1f4fd679042397dec12fd1982976646168
Signed-off-by: Daniel Boulby <daniel.boulby@arm.com>