### PR TITLE
sgm: increase SCP_BL2 maximum size

### DIFF
--- a/plat/arm/css/sgm/include/sgm_base_platform_def.h
+++ b/plat/arm/css/sgm/include/sgm_base_platform_def.h
@@ -139,13 +139,13 @@
  * PLAT_CSS_MAX_SCP_BL2_SIZE is calculated using the current
  * SCP_BL2 size plus a little space for growth.
  */
-#define PLAT_CSS_MAX_SCP_BL2_SIZE	0x15000
+#define PLAT_CSS_MAX_SCP_BL2_SIZE	0x18000
 
 /*
  * PLAT_CSS_MAX_SCP_BL2U_SIZE is calculated using the current
  * SCP_BL2U size plus a little space for growth.
  */
-#define PLAT_CSS_MAX_SCP_BL2U_SIZE	0x15000
+#define PLAT_CSS_MAX_SCP_BL2U_SIZE	0x18000
 
 /*
  * Most platform porting definitions provided by included headers


### PR DESCRIPTION
For sgm775 the SCP_BL2 build in debug mode is around 94KiB which
is higher than the maximum size for SCP_BL2.

This patch increase the maximum allowed size for SCP_BL2 to
96KiB.

Change-Id: Ibca0daadba41429301c651ae21cbba87e45ccddf
Signed-off-by: Elieva Pignat <Elieva.Pignat@arm.com>