### PR TITLE
poplar: fix build error with POPLAR_RECOVERY=1

### DIFF
--- a/plat/hisilicon/poplar/bl1_plat_setup.c
+++ b/plat/hisilicon/poplar/bl1_plat_setup.c
@@ -92,8 +92,8 @@ void bl1_plat_arch_setup(void)
 void bl1_platform_setup(void)
 {
 	int i;
-	struct mmc_device_info info;
 #if !POPLAR_RECOVERY
+	struct mmc_device_info info;
 	dw_mmc_params_t params = EMMC_INIT_PARAMS(POPLAR_EMMC_DESC_BASE);
 #endif
 

--- a/plat/hisilicon/poplar/bl2_plat_setup.c
+++ b/plat/hisilicon/poplar/bl2_plat_setup.c
@@ -333,9 +333,9 @@ void bl2_plat_get_bl33_meminfo(meminfo_t *bl33_meminfo)
 
 void bl2_early_platform_setup(meminfo_t *mem_layout)
 {
+#if !POPLAR_RECOVERY
 	struct mmc_device_info info;
 
-#if !POPLAR_RECOVERY
 	dw_mmc_params_t params = EMMC_INIT_PARAMS(POPLAR_EMMC_DESC_BASE);
 #endif
 


### PR DESCRIPTION
Commit eba1b6b3c724 ("plat/poplar: migrate to mmc framework") defines
variable 'info' without !POPLAR_RECOVERY protection, and hence causes
the following unused variable error with POPLAR_RECOVERY=1 build.

plat/hisilicon/poplar/bl1_plat_setup.c: In function ‘bl1_platform_setup’:
plat/hisilicon/poplar/bl1_plat_setup.c:95:25: error: unused variable ‘info’ [-Werror=unused-variable]
  struct mmc_device_info info;
                         ^~~~

The patches fixes the build error with POPLAR_RECOVERY=1.

Signed-off-by: Shawn Guo <shawn.guo@linaro.org>