### PR TITLE
drivers: mmc: Fix R2 response type definition

### DIFF
--- a/drivers/mmc/mmc.c
+++ b/drivers/mmc/mmc.c
@@ -427,7 +427,7 @@ static int mmc_enumerate(unsigned int clk, unsigned int bus_width)
 	}
 
 	/* CMD2: Card Identification */
-	ret = mmc_send_cmd(MMC_CMD(2), 0, MMC_RESPONSE_R(2), NULL);
+	ret = mmc_send_cmd(MMC_CMD(2), 0, MMC_RESPONSE_R2, NULL);
 	if (ret != 0) {
 		return ret;
 	}
@@ -452,7 +452,7 @@ static int mmc_enumerate(unsigned int clk, unsigned int bus_width)
 
 	/* CMD9: CSD Register */
 	ret = mmc_send_cmd(MMC_CMD(9), rca << RCA_SHIFT_OFFSET,
-			   MMC_RESPONSE_R(2), &resp_data[0]);
+			   MMC_RESPONSE_R2, &resp_data[0]);
 	if (ret != 0) {
 		return ret;
 	}


### PR DESCRIPTION
The Poplar is broken on eMMC initialization because of commit
2a82a9c95f6c ("drivers: emmc: dw_mmc: Add response flag into response ID
definition").  It changes the driver behavior on response type handling
in dw_send_cmd(), because MMC_RESPONSE_R(2) and MMC_RESPONSE_R2 are
different things.  MMC core is still sending the former while we already
changed to check the latter in dw_mmc driver.

This patch fixes R2 response type in MMC core code.  It's the same
thing as what commit 94522ff7f6d2 ("drivers: mmc: Fix R3 response type
definition") does for R3 response.

With this fix, Poplar is back to work.

Signed-off-by: Shawn Guo <shawn.guo@linaro.org>