### PR TITLE
plat/arm: Remove option ARM_BOARD_OPTIMISE_MEM

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -707,14 +707,6 @@ Arm development platform specific build options
    sets the TSP location to DRAM and ignores the ``ARM_TSP_RAM_LOCATION`` build
    flag.
 
--  ``ARM_BOARD_OPTIMISE_MEM``: Boolean option to enable or disable optimisation
-   of the memory reserved for each image. This affects the maximum size of each
-   BL image as well as the number of allocated memory regions and translation
-   tables. By default this flag is 0, which means it uses the default
-   unoptimised values for these macros. Arm development platforms that wish to
-   optimise memory usage need to set this flag to 1 and must override the
-   related macros.
-
 -  ``ARM_CONFIG_CNTACR``: boolean option to unlock access to the ``CNTBase<N>``
    frame registers by setting the ``CNTCTLBase.CNTACR<N>`` register bits. The
    frame number ``<N>`` is defined by ``PLAT_ARM_NSTIMER_FRAME_ID``, which should

--- a/include/plat/arm/board/common/board_arm_def.h
+++ b/include/plat/arm/board/common/board_arm_def.h
@@ -8,7 +8,6 @@
 
 #include <v2m_def.h>
 
-
 /*
  * Required platform porting definitions common to all ARM
  * development platforms
@@ -40,90 +39,6 @@
 #elif defined(IMAGE_BL32)
 # define PLATFORM_STACK_SIZE 0x440
 #endif
-
-/*
- * The constants below are not optimised for memory usage. Platforms that wish
- * to optimise these constants should set `ARM_BOARD_OPTIMISE_MEM` to 1 and
- * provide there own values.
- */
-#if !ARM_BOARD_OPTIMISE_MEM
-/*
- * PLAT_ARM_MMAP_ENTRIES depends on the number of entries in the
- * plat_arm_mmap array defined for each BL stage.
- *
- * Provide relatively optimised values for the runtime images (BL31 and BL32).
- * Optimisation is less important for the other, transient boot images so a
- * common, maximum value is used across these images.
- *
- * They are also used for the dynamically mapped regions in the images that
- * enable dynamic memory mapping.
- */
-#if defined(IMAGE_BL31)
-# if ENABLE_SPM
-#  define PLAT_ARM_MMAP_ENTRIES		9
-#  define MAX_XLAT_TABLES		7
-#  define PLAT_SP_IMAGE_MMAP_REGIONS	7
-#  define PLAT_SP_IMAGE_MAX_XLAT_TABLES	10
-# else
-#  define PLAT_ARM_MMAP_ENTRIES		8
-#  define MAX_XLAT_TABLES		5
-# endif
-#elif defined(IMAGE_BL32)
-# define PLAT_ARM_MMAP_ENTRIES		8
-# define MAX_XLAT_TABLES		5
-#elif !USE_ROMLIB
-# define PLAT_ARM_MMAP_ENTRIES		11
-# define MAX_XLAT_TABLES		5
-#else
-# define PLAT_ARM_MMAP_ENTRIES		12
-# define MAX_XLAT_TABLES		6
-#endif
-
-/*
- * PLAT_ARM_MAX_BL1_RW_SIZE is calculated using the current BL1 RW debug size
- * plus a little space for growth.
- */
-#define PLAT_ARM_MAX_BL1_RW_SIZE	0xB000
-
-/*
- * PLAT_ARM_MAX_ROMLIB_RW_SIZE is define to use a full page
- */
-
-#if USE_ROMLIB
-#define PLAT_ARM_MAX_ROMLIB_RW_SIZE	0x1000
-#define PLAT_ARM_MAX_ROMLIB_RO_SIZE	0xe000
-#else
-#define PLAT_ARM_MAX_ROMLIB_RW_SIZE	0
-#define PLAT_ARM_MAX_ROMLIB_RO_SIZE	0
-#endif
-
-/*
- * PLAT_ARM_MAX_BL2_SIZE is calculated using the current BL2 debug size plus a
- * little space for growth.
- */
-#if TRUSTED_BOARD_BOOT
-# define PLAT_ARM_MAX_BL2_SIZE		0x1D000
-#else
-# define PLAT_ARM_MAX_BL2_SIZE		0x11000
-#endif
-
-/*
- * Since BL31 NOBITS overlays BL2 and BL1-RW, PLAT_ARM_MAX_BL31_SIZE is
- * calculated using the current BL31 PROGBITS debug size plus the sizes of
- * BL2 and BL1-RW
- */
-#define PLAT_ARM_MAX_BL31_SIZE		0x3B000
-
-#ifdef AARCH32
-/*
- * Since BL32 NOBITS overlays BL2 and BL1-RW, PLAT_ARM_MAX_BL32_SIZE is
- * calculated using the current SP_MIN PROGBITS debug size plus the sizes of
- * BL2 and BL1-RW
- */
-# define PLAT_ARM_MAX_BL32_SIZE		0x3B000
-#endif
-
-#endif /* ARM_BOARD_OPTIMISE_MEM */
 
 #define MAX_IO_DEVICES			3
 #define MAX_IO_HANDLES			4

--- a/plat/arm/board/common/board_common.mk
+++ b/plat/arm/board/common/board_common.mk
@@ -43,10 +43,3 @@ ifneq (${TRUSTED_BOARD_BOOT},0)
     BL1_SOURCES		+=	plat/arm/board/common/board_arm_trusted_boot.c
     BL2_SOURCES		+=	plat/arm/board/common/board_arm_trusted_boot.c
 endif
-
-# This flag controls whether memory usage needs to be optimised
-ARM_BOARD_OPTIMISE_MEM	?=	0
-
-# Process flags
-$(eval $(call assert_boolean,ARM_BOARD_OPTIMISE_MEM))
-$(eval $(call add_define,ARM_BOARD_OPTIMISE_MEM))

--- a/plat/arm/board/fvp/include/platform_def.h
+++ b/plat/arm/board/fvp/include/platform_def.h
@@ -64,6 +64,74 @@
  */
 #define PLAT_ARM_NS_IMAGE_OFFSET	(ARM_DRAM1_BASE + U(0x8000000))
 
+/*
+ * PLAT_ARM_MMAP_ENTRIES depends on the number of entries in the
+ * plat_arm_mmap array defined for each BL stage.
+ */
+#if defined(IMAGE_BL31)
+# if ENABLE_SPM
+#  define PLAT_ARM_MMAP_ENTRIES		9
+#  define MAX_XLAT_TABLES		7
+#  define PLAT_SP_IMAGE_MMAP_REGIONS	7
+#  define PLAT_SP_IMAGE_MAX_XLAT_TABLES	10
+# else
+#  define PLAT_ARM_MMAP_ENTRIES		8
+#  define MAX_XLAT_TABLES		5
+# endif
+#elif defined(IMAGE_BL32)
+# define PLAT_ARM_MMAP_ENTRIES		8
+# define MAX_XLAT_TABLES		5
+#elif !USE_ROMLIB
+# define PLAT_ARM_MMAP_ENTRIES		11
+# define MAX_XLAT_TABLES		5
+#else
+# define PLAT_ARM_MMAP_ENTRIES		12
+# define MAX_XLAT_TABLES		6
+#endif
+
+/*
+ * PLAT_ARM_MAX_BL1_RW_SIZE is calculated using the current BL1 RW debug size
+ * plus a little space for growth.
+ */
+#define PLAT_ARM_MAX_BL1_RW_SIZE	0xB000
+
+/*
+ * PLAT_ARM_MAX_ROMLIB_RW_SIZE is define to use a full page
+ */
+
+#if USE_ROMLIB
+#define PLAT_ARM_MAX_ROMLIB_RW_SIZE	0x1000
+#define PLAT_ARM_MAX_ROMLIB_RO_SIZE	0xe000
+#else
+#define PLAT_ARM_MAX_ROMLIB_RW_SIZE	0
+#define PLAT_ARM_MAX_ROMLIB_RO_SIZE	0
+#endif
+
+/*
+ * PLAT_ARM_MAX_BL2_SIZE is calculated using the current BL2 debug size plus a
+ * little space for growth.
+ */
+#if TRUSTED_BOARD_BOOT
+# define PLAT_ARM_MAX_BL2_SIZE		0x1D000
+#else
+# define PLAT_ARM_MAX_BL2_SIZE		0x11000
+#endif
+
+/*
+ * Since BL31 NOBITS overlays BL2 and BL1-RW, PLAT_ARM_MAX_BL31_SIZE is
+ * calculated using the current BL31 PROGBITS debug size plus the sizes of
+ * BL2 and BL1-RW
+ */
+#define PLAT_ARM_MAX_BL31_SIZE		0x3B000
+
+#ifdef AARCH32
+/*
+ * Since BL32 NOBITS overlays BL2 and BL1-RW, PLAT_ARM_MAX_BL32_SIZE is
+ * calculated using the current SP_MIN PROGBITS debug size plus the sizes of
+ * BL2 and BL1-RW
+ */
+# define PLAT_ARM_MAX_BL32_SIZE		0x3B000
+#endif
 
 /*
  * PL011 related constants

--- a/plat/arm/board/juno/include/platform_def.h
+++ b/plat/arm/board/juno/include/platform_def.h
@@ -76,11 +76,6 @@
 #endif /* TRUSTED_BOARD_BOOT */
 
 /*
- * If ARM_BOARD_OPTIMISE_MEM=0 then Juno uses the default, unoptimised values
- * defined for ARM development platforms.
- */
-#if ARM_BOARD_OPTIMISE_MEM
-/*
  * PLAT_ARM_MMAP_ENTRIES depends on the number of entries in the
  * plat_arm_mmap array defined for each BL stage.
  */
@@ -172,8 +167,6 @@
  * optimization by fixing the PLAT_LOG_LEVEL_ASSERT to LOG_LEVEL_INFO (40).
  */
 #define PLAT_LOG_LEVEL_ASSERT		40
-
-#endif /* ARM_BOARD_OPTIMISE_MEM */
 
 /* CCI related constants */
 #define PLAT_ARM_CCI_BASE		0x2c090000

--- a/plat/arm/board/juno/platform.mk
+++ b/plat/arm/board/juno/platform.mk
@@ -115,9 +115,6 @@ ERRATA_A72_859971		:=	0
 # power down sequence
 SKIP_A57_L1_FLUSH_PWR_DWN	:=	 1
 
-# Enable memory map related constants optimisation
-ARM_BOARD_OPTIMISE_MEM		:=	1
-
 # Do not enable SVE
 ENABLE_SVE_FOR_NS		:=	0
 

--- a/plat/arm/css/sgi/include/platform_def.h
+++ b/plat/arm/css/sgi/include/platform_def.h
@@ -26,29 +26,65 @@
 					CSS_SGI_MAX_CPUS_PER_CLUSTER * \
 					CSS_SGI_MAX_PE_PER_CPU)
 
-#if ARM_BOARD_OPTIMISE_MEM
-
-#if defined(IMAGE_BL31) || defined(IMAGE_BL32)
-# define PLAT_ARM_MMAP_ENTRIES		6
-# define MAX_XLAT_TABLES		4
-#else
-# define PLAT_ARM_MMAP_ENTRIES		10
+/*
+ * PLAT_ARM_MMAP_ENTRIES depends on the number of entries in the
+ * plat_arm_mmap array defined for each BL stage.
+ */
+#if defined(IMAGE_BL31)
+# if ENABLE_SPM
+#  define PLAT_ARM_MMAP_ENTRIES		9
+#  define MAX_XLAT_TABLES		7
+#  define PLAT_SP_IMAGE_MMAP_REGIONS	7
+#  define PLAT_SP_IMAGE_MAX_XLAT_TABLES	10
+# else
+#  define PLAT_ARM_MMAP_ENTRIES		8
+#  define MAX_XLAT_TABLES		5
+# endif
+#elif defined(IMAGE_BL32)
+# define PLAT_ARM_MMAP_ENTRIES		8
 # define MAX_XLAT_TABLES		5
-#endif
-
-#if TRUSTED_BOARD_BOOT
-# define PLAT_ARM_MAX_BL1_RW_SIZE	0xA000
+#elif !USE_ROMLIB
+# define PLAT_ARM_MMAP_ENTRIES		11
+# define MAX_XLAT_TABLES		5
 #else
-# define PLAT_ARM_MAX_BL1_RW_SIZE	0x6000
+# define PLAT_ARM_MMAP_ENTRIES		12
+# define MAX_XLAT_TABLES		6
 #endif
 
+/*
+ * PLAT_ARM_MAX_BL1_RW_SIZE is calculated using the current BL1 RW debug size
+ * plus a little space for growth.
+ */
+#define PLAT_ARM_MAX_BL1_RW_SIZE	0xB000
+
+/*
+ * PLAT_ARM_MAX_ROMLIB_RW_SIZE is define to use a full page
+ */
+
+#if USE_ROMLIB
+#define PLAT_ARM_MAX_ROMLIB_RW_SIZE	0x1000
+#define PLAT_ARM_MAX_ROMLIB_RO_SIZE	0xe000
+#else
+#define PLAT_ARM_MAX_ROMLIB_RW_SIZE	0
+#define PLAT_ARM_MAX_ROMLIB_RO_SIZE	0
+#endif
+
+/*
+ * PLAT_ARM_MAX_BL2_SIZE is calculated using the current BL2 debug size plus a
+ * little space for growth.
+ */
 #if TRUSTED_BOARD_BOOT
 # define PLAT_ARM_MAX_BL2_SIZE		0x1D000
 #else
-# define PLAT_ARM_MAX_BL2_SIZE		0xC000
+# define PLAT_ARM_MAX_BL2_SIZE		0x11000
 #endif
 
-#endif /* ARM_BOARD_OPTIMISE_MEM */
+/*
+ * Since BL31 NOBITS overlays BL2 and BL1-RW, PLAT_ARM_MAX_BL31_SIZE is
+ * calculated using the current BL31 PROGBITS debug size plus the sizes of
+ * BL2 and BL1-RW
+ */
+#define PLAT_ARM_MAX_BL31_SIZE		0x3B000
 
 #define PLAT_ARM_NSTIMER_FRAME_ID	0
 

--- a/plat/arm/css/sgm/include/sgm_base_platform_def.h
+++ b/plat/arm/css/sgm/include/sgm_base_platform_def.h
@@ -152,61 +152,39 @@
  */
 
 /*
- * If ARM_BOARD_OPTIMISE_MEM=0 then use the default, unoptimised values
- * defined for ARM development platforms.
- */
-#if ARM_BOARD_OPTIMISE_MEM
-/*
  * PLAT_ARM_MMAP_ENTRIES depends on the number of entries in the
  * plat_arm_mmap array defined for each BL stage.
  */
-#if IMAGE_BL1
-# if TRUSTED_BOARD_BOOT
-#  define PLAT_ARM_MMAP_ENTRIES		7
-# else
-#  define PLAT_ARM_MMAP_ENTRIES		6
-# endif /* TRUSTED_BOARD_BOOT */
-#elif IMAGE_BL2
-#  define PLAT_ARM_MMAP_ENTRIES		8
-#elif IMAGE_BL2U
-#  define PLAT_ARM_MMAP_ENTRIES		4
-#elif IMAGE_BL31
-#  define PLAT_ARM_MMAP_ENTRIES		6
-#elif IMAGE_BL32
-#  define PLAT_ARM_MMAP_ENTRIES		5
-#endif
-
-/*
- * Platform specific page table and MMU setup constants
- */
-#if IMAGE_BL1
-# if TRUSTED_BOARD_BOOT
-#  define MAX_XLAT_TABLES		4
-# else
-#  define MAX_XLAT_TABLES		3
-#endif
-#elif IMAGE_BL2
-#  define MAX_XLAT_TABLES		4
-#elif IMAGE_BL2U
-#  define MAX_XLAT_TABLES		4
-#elif IMAGE_BL31
-#  define MAX_XLAT_TABLES		2
-#elif IMAGE_BL32
-# if ARM_TSP_RAM_LOCATION_ID == ARM_DRAM_ID
-#  define MAX_XLAT_TABLES		3
-# else
-#  define MAX_XLAT_TABLES		2
-# endif
+#if defined(IMAGE_BL31)
+# define PLAT_ARM_MMAP_ENTRIES		8
+# define MAX_XLAT_TABLES		5
+#elif defined(IMAGE_BL32)
+# define PLAT_ARM_MMAP_ENTRIES		8
+# define MAX_XLAT_TABLES		5
+#elif !USE_ROMLIB
+# define PLAT_ARM_MMAP_ENTRIES		11
+# define MAX_XLAT_TABLES		5
+#else
+# define PLAT_ARM_MMAP_ENTRIES		12
+# define MAX_XLAT_TABLES		6
 #endif
 
 /*
  * PLAT_ARM_MAX_BL1_RW_SIZE is calculated using the current BL1 RW debug size
  * plus a little space for growth.
  */
-#if TRUSTED_BOARD_BOOT
-# define PLAT_ARM_MAX_BL1_RW_SIZE	0xA000
+#define PLAT_ARM_MAX_BL1_RW_SIZE	0xB000
+
+/*
+ * PLAT_ARM_MAX_ROMLIB_RW_SIZE is define to use a full page
+ */
+
+#if USE_ROMLIB
+#define PLAT_ARM_MAX_ROMLIB_RW_SIZE	0x1000
+#define PLAT_ARM_MAX_ROMLIB_RO_SIZE	0xe000
 #else
-# define PLAT_ARM_MAX_BL1_RW_SIZE	0x7000
+#define PLAT_ARM_MAX_ROMLIB_RW_SIZE	0
+#define PLAT_ARM_MAX_ROMLIB_RO_SIZE	0
 #endif
 
 /*
@@ -216,10 +194,15 @@
 #if TRUSTED_BOARD_BOOT
 # define PLAT_ARM_MAX_BL2_SIZE		0x1D000
 #else
-# define PLAT_ARM_MAX_BL2_SIZE		0xD000
+# define PLAT_ARM_MAX_BL2_SIZE		0x11000
 #endif
 
-#endif /* ARM_BOARD_OPTIMISE_MEM */
+/*
+ * Since BL31 NOBITS overlays BL2 and BL1-RW, PLAT_ARM_MAX_BL31_SIZE is
+ * calculated using the current BL31 PROGBITS debug size plus the sizes of
+ * BL2 and BL1-RW
+ */
+#define PLAT_ARM_MAX_BL31_SIZE		0x3B000
 
 /*******************************************************************************
  * Memprotect definitions


### PR DESCRIPTION
This option makes it hard to optimize the memory definitions of all Arm platforms because any change in the common defines must work in all of them. The best thing to do is to remove it and move the definition to each platform's header.

FVP, SGI and SGM were using the definitions in board_arm_def.h. The definitions have been copied to each platform's platform_def.h. Juno was already using the ones in platform_def.h, so there have been no changes.