### PR TITLE
marvell: Continue migration to new APIs

### DIFF
--- a/plat/marvell/a8k/common/include/a8k_plat_def.h
+++ b/plat/marvell/a8k/common/include/a8k_plat_def.h
@@ -148,7 +148,8 @@
  * it is discarded and BL31 is loaded over the top.
  */
 #ifdef SCP_IMAGE
-#define SCP_BL2_BASE                    BL31_BASE
+#define SCP_BL2_BASE			BL31_BASE
+#define SCP_BL2_SIZE			BL31_LIMIT
 #endif
 
 #ifndef __ASSEMBLER__

--- a/plat/marvell/a8k/common/include/platform_def.h
+++ b/plat/marvell/a8k/common/include/platform_def.h
@@ -71,14 +71,6 @@
  * PLAT_MARVELL_FIP_BASE	= 0x4120000
  */
 
-/*
- * Since BL33 is loaded by BL2 (and validated by BL31) to DRAM offset 0,
- * it is allowed to load/copy images to 'NULL' pointers
- */
-#if defined(IMAGE_BL2) || defined(IMAGE_BL31)
-#define PLAT_ALLOW_ZERO_ADDR_COPY
-#endif
-
 #define PLAT_MARVELL_SRAM_BASE			0xFFE1C048
 #define PLAT_MARVELL_SRAM_END			0xFFE78000
 
@@ -199,7 +191,10 @@
 #define TRUSTED_DRAM_BASE			PLAT_MARVELL_TRUSTED_DRAM_BASE
 #define TRUSTED_DRAM_SIZE			PLAT_MARVELL_TRUSTED_DRAM_SIZE
 
+#ifdef BL32
 #define BL32_BASE				TRUSTED_DRAM_BASE
+#define BL32_LIMIT				TRUSTED_DRAM_SIZE
+#endif
 
 #define MVEBU_PMU_IRQ_WA
 

--- a/plat/marvell/common/aarch64/marvell_bl2_mem_params_desc.c
+++ b/plat/marvell/common/aarch64/marvell_bl2_mem_params_desc.c
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <bl_common.h>
+#include <desc_image_load.h>
+#include <marvell_def.h>
+#include <platform.h>
+#include <platform_def.h>
+
+
+/*******************************************************************************
+ * Following descriptor provides BL image/ep information that gets used
+ * by BL2 to load the images and also subset of this information is
+ * passed to next BL image. The image loading sequence is managed by
+ * populating the images in required loading order. The image execution
+ * sequence is managed by populating the `next_handoff_image_id` with
+ * the next executable image id.
+ ******************************************************************************/
+static bl_mem_params_node_t bl2_mem_params_descs[] = {
+#ifdef SCP_BL2_BASE
+	/* Fill SCP_BL2 related information if it exists */
+    {
+	    .image_id = SCP_BL2_IMAGE_ID,
+
+	    SET_STATIC_PARAM_HEAD(ep_info, PARAM_IMAGE_BINARY,
+		    VERSION_2, entry_point_info_t, SECURE | NON_EXECUTABLE),
+
+	    SET_STATIC_PARAM_HEAD(image_info, PARAM_IMAGE_BINARY,
+		    VERSION_2, image_info_t, 0),
+	    .image_info.image_base = SCP_BL2_BASE,
+	    .image_info.image_max_size = SCP_BL2_SIZE,
+
+	    .next_handoff_image_id = INVALID_IMAGE_ID,
+    },
+#endif /* SCP_BL2_BASE */
+
+#ifdef EL3_PAYLOAD_BASE
+	/* Fill EL3 payload related information (BL31 is EL3 payload)*/
+    {
+	    .image_id = BL31_IMAGE_ID,
+
+	    SET_STATIC_PARAM_HEAD(ep_info, PARAM_EP,
+		    VERSION_2, entry_point_info_t,
+		    SECURE | EXECUTABLE | EP_FIRST_EXE),
+	    .ep_info.pc = EL3_PAYLOAD_BASE,
+	    .ep_info.spsr = SPSR_64(MODE_EL3, MODE_SP_ELX,
+		    DISABLE_ALL_EXCEPTIONS),
+
+	    SET_STATIC_PARAM_HEAD(image_info, PARAM_EP,
+		    VERSION_2, image_info_t,
+		    IMAGE_ATTRIB_PLAT_SETUP | IMAGE_ATTRIB_SKIP_LOADING),
+
+	    .next_handoff_image_id = INVALID_IMAGE_ID,
+    },
+
+#else /* EL3_PAYLOAD_BASE */
+
+	/* Fill BL31 related information */
+    {
+	    .image_id = BL31_IMAGE_ID,
+
+	    SET_STATIC_PARAM_HEAD(ep_info, PARAM_EP,
+		    VERSION_2, entry_point_info_t,
+		    SECURE | EXECUTABLE | EP_FIRST_EXE),
+	    .ep_info.pc = BL31_BASE,
+	    .ep_info.spsr = SPSR_64(MODE_EL3, MODE_SP_ELX,
+		    DISABLE_ALL_EXCEPTIONS),
+#if DEBUG
+	    .ep_info.args.arg3 = MARVELL_BL31_PLAT_PARAM_VAL,
+#endif
+
+	    SET_STATIC_PARAM_HEAD(image_info, PARAM_EP,
+		    VERSION_2, image_info_t, IMAGE_ATTRIB_PLAT_SETUP),
+	    .image_info.image_base = BL31_BASE,
+	    .image_info.image_max_size = BL31_LIMIT - BL31_BASE,
+
+# ifdef BL32_BASE
+	    .next_handoff_image_id = BL32_IMAGE_ID,
+# else
+	    .next_handoff_image_id = BL33_IMAGE_ID,
+# endif
+    },
+
+# ifdef BL32_BASE
+	/* Fill BL32 related information */
+    {
+	    .image_id = BL32_IMAGE_ID,
+
+	    SET_STATIC_PARAM_HEAD(ep_info, PARAM_EP,
+		    VERSION_2, entry_point_info_t, SECURE | EXECUTABLE),
+	    .ep_info.pc = BL32_BASE,
+
+	    SET_STATIC_PARAM_HEAD(image_info, PARAM_EP,
+		    VERSION_2, image_info_t, 0),
+	    .image_info.image_base = BL32_BASE,
+	    .image_info.image_max_size = BL32_LIMIT - BL32_BASE,
+
+	    .next_handoff_image_id = BL33_IMAGE_ID,
+    },
+# endif /* BL32_BASE */
+
+	/* Fill BL33 related information */
+    {
+	    .image_id = BL33_IMAGE_ID,
+	    SET_STATIC_PARAM_HEAD(ep_info, PARAM_EP,
+		    VERSION_2, entry_point_info_t, NON_SECURE | EXECUTABLE),
+# ifdef PRELOADED_BL33_BASE
+	    .ep_info.pc = PRELOADED_BL33_BASE,
+
+	    SET_STATIC_PARAM_HEAD(image_info, PARAM_EP,
+		    VERSION_2, image_info_t, IMAGE_ATTRIB_SKIP_LOADING),
+# else
+	    .ep_info.pc = MARVELL_DRAM_BASE,
+
+	    SET_STATIC_PARAM_HEAD(image_info, PARAM_EP,
+		    VERSION_2, image_info_t, 0),
+	    .image_info.image_base = MARVELL_DRAM_BASE,
+	    .image_info.image_max_size = MARVELL_DRAM_SIZE,
+# endif /* PRELOADED_BL33_BASE */
+
+	    .next_handoff_image_id = INVALID_IMAGE_ID,
+    }
+#endif /* EL3_PAYLOAD_BASE */
+};
+
+REGISTER_BL_IMAGE_DESCS(bl2_mem_params_descs)

--- a/plat/marvell/common/marvell_bl1_setup.c
+++ b/plat/marvell/common/marvell_bl1_setup.c
@@ -21,7 +21,6 @@
 #pragma weak bl1_platform_setup
 #pragma weak bl1_plat_sec_mem_layout
 
-
 /* Data structure which holds the extents of the RAM for BL1*/
 static meminfo_t bl1_ram_layout;
 
@@ -35,8 +34,6 @@ meminfo_t *bl1_plat_sec_mem_layout(void)
  */
 void marvell_bl1_early_platform_setup(void)
 {
-	const size_t bl1_size = BL1_RAM_LIMIT - BL1_RAM_BASE;
-
 	/* Initialize the console to provide early debug support */
 	console_init(PLAT_MARVELL_BOOT_UART_BASE,
 		     PLAT_MARVELL_BOOT_UART_CLK_IN_HZ,
@@ -45,14 +42,6 @@ void marvell_bl1_early_platform_setup(void)
 	/* Allow BL1 to see the whole Trusted RAM */
 	bl1_ram_layout.total_base = MARVELL_BL_RAM_BASE;
 	bl1_ram_layout.total_size = MARVELL_BL_RAM_SIZE;
-
-	/* Calculate how much RAM BL1 is using and how much remains free */
-	bl1_ram_layout.free_base = MARVELL_BL_RAM_BASE;
-	bl1_ram_layout.free_size = MARVELL_BL_RAM_SIZE;
-	reserve_mem(&bl1_ram_layout.free_base,
-		    &bl1_ram_layout.free_size,
-		    BL1_RAM_BASE,
-		    bl1_size);
 }
 
 void bl1_early_platform_setup(void)

--- a/plat/marvell/common/marvell_bl2_setup.c
+++ b/plat/marvell/common/marvell_bl2_setup.c
@@ -6,131 +6,29 @@
  */
 
 #include <arch_helpers.h>
+#include <assert.h>
 #include <bl_common.h>
 #include <console.h>
+#include <debug.h>
+#include <desc_image_load.h>
 #include <marvell_def.h>
 #include <platform_def.h>
 #include <plat_marvell.h>
 #include <string.h>
+#include <utils.h>
 
 /* Data structure which holds the extents of the trusted SRAM for BL2 */
 static meminfo_t bl2_tzram_layout __aligned(CACHE_WRITEBACK_GRANULE);
 
-
-/*****************************************************************************
- * This structure represents the superset of information that is passed to
- * BL31, e.g. while passing control to it from BL2, bl31_params
- * and other platform specific parameters
- *****************************************************************************
- */
-typedef struct bl2_to_bl31_params_mem {
-	struct marvell_bl31_params bl31_params;
-	image_info_t bl31_image_info;
-	image_info_t bl32_image_info;
-	image_info_t bl33_image_info;
-	entry_point_info_t bl33_ep_info;
-	entry_point_info_t bl32_ep_info;
-	entry_point_info_t bl31_ep_info;
-} bl2_to_bl31_params_mem_t;
-
-
-static bl2_to_bl31_params_mem_t bl31_params_mem;
-
-
 /* Weak definitions may be overridden in specific MARVELL standard platform */
-#pragma weak bl2_early_platform_setup
+#pragma weak bl2_early_platform_setup2
 #pragma weak bl2_platform_setup
 #pragma weak bl2_plat_arch_setup
 #pragma weak bl2_plat_sec_mem_layout
-#pragma weak bl2_plat_get_bl31_params
-#pragma weak bl2_plat_get_bl31_ep_info
-#pragma weak bl2_plat_flush_bl31_params
-#pragma weak bl2_plat_set_bl31_ep_info
-#pragma weak bl2_plat_get_scp_bl2_meminfo
-#pragma weak bl2_plat_get_bl32_meminfo
-#pragma weak bl2_plat_set_bl32_ep_info
-#pragma weak bl2_plat_get_bl33_meminfo
-#pragma weak bl2_plat_set_bl33_ep_info
-
 
 meminfo_t *bl2_plat_sec_mem_layout(void)
 {
 	return &bl2_tzram_layout;
-}
-
-/*****************************************************************************
- * This function assigns a pointer to the memory that the platform has kept
- * aside to pass platform specific and trusted firmware related information
- * to BL31. This memory is allocated by allocating memory to
- * bl2_to_bl31_params_mem_t structure which is a superset of all the
- * structure whose information is passed to BL31
- * NOTE: This function should be called only once and should be done
- * before generating params to BL31
- *****************************************************************************
- */
-void *bl2_plat_get_bl31_params(void)
-{
-	struct marvell_bl31_params *bl2_to_bl31_params;
-
-	/*
-	 * Initialise the memory for all the arguments that needs to
-	 * be passed to BL31
-	 */
-	memset(&bl31_params_mem, 0, sizeof(bl2_to_bl31_params_mem_t));
-
-	/* Assign memory for TF related information */
-	bl2_to_bl31_params = &bl31_params_mem.bl31_params;
-	SET_PARAM_HEAD(bl2_to_bl31_params, PARAM_BL31, VERSION_1, 0);
-
-	/* Fill BL31 related information */
-	bl2_to_bl31_params->bl31_image_info = &bl31_params_mem.bl31_image_info;
-	SET_PARAM_HEAD(bl2_to_bl31_params->bl31_image_info, PARAM_IMAGE_BINARY,
-		VERSION_1, 0);
-
-	/* Fill BL32 related information if it exists */
-#if BL32_BASE
-	bl2_to_bl31_params->bl32_ep_info = &bl31_params_mem.bl32_ep_info;
-	SET_PARAM_HEAD(bl2_to_bl31_params->bl32_ep_info, PARAM_EP,
-		VERSION_1, 0);
-	bl2_to_bl31_params->bl32_image_info = &bl31_params_mem.bl32_image_info;
-	SET_PARAM_HEAD(bl2_to_bl31_params->bl32_image_info, PARAM_IMAGE_BINARY,
-		VERSION_1, 0);
-#endif
-
-	/* Fill BL33 related information */
-	bl2_to_bl31_params->bl33_ep_info = &bl31_params_mem.bl33_ep_info;
-	SET_PARAM_HEAD(bl2_to_bl31_params->bl33_ep_info,
-		PARAM_EP, VERSION_1, 0);
-
-	/* BL33 expects to receive the primary CPU MPID (through x0) */
-	bl2_to_bl31_params->bl33_ep_info->args.arg0 = 0xffff & read_mpidr();
-
-	bl2_to_bl31_params->bl33_image_info = &bl31_params_mem.bl33_image_info;
-	SET_PARAM_HEAD(bl2_to_bl31_params->bl33_image_info, PARAM_IMAGE_BINARY,
-		VERSION_1, 0);
-
-	return (void *)bl2_to_bl31_params;
-}
-
-/* Flush the TF params and the TF plat params */
-void bl2_plat_flush_bl31_params(void)
-{
-	flush_dcache_range((unsigned long)&bl31_params_mem,
-			sizeof(bl2_to_bl31_params_mem_t));
-}
-
-/*****************************************************************************
- * This function returns a pointer to the shared memory that the platform
- * has kept to point to entry point information of BL31 to BL2
- *****************************************************************************
- */
-struct entry_point_info *bl2_plat_get_bl31_ep_info(void)
-{
-#if DEBUG
-	bl31_params_mem.bl31_ep_info.args.arg1 = MARVELL_BL31_PLAT_PARAM_VAL;
-#endif
-
-	return &bl31_params_mem.bl31_ep_info;
 }
 
 /*****************************************************************************
@@ -193,87 +91,36 @@ void bl2_plat_arch_setup(void)
 	marvell_bl2_plat_arch_setup();
 }
 
-/*****************************************************************************
- * Populate the extents of memory available for loading SCP_BL2 (if used),
- * i.e. anywhere in trusted RAM as long as it doesn't overwrite BL2.
- *****************************************************************************
- */
-void bl2_plat_get_scp_bl2_meminfo(meminfo_t *scp_bl2_meminfo)
+int marvell_bl2_handle_post_image_load(unsigned int image_id)
 {
-	*scp_bl2_meminfo = bl2_tzram_layout;
+	int err = 0;
+	bl_mem_params_node_t *bl_mem_params = get_bl_mem_params_node(image_id);
+
+	assert(bl_mem_params);
+
+	switch (image_id) {
+
+	case BL33_IMAGE_ID:
+		/* BL33 expects to receive the primary CPU MPID (through r0) */
+		bl_mem_params->ep_info.args.arg0 = 0xffff & read_mpidr();
+		bl_mem_params->ep_info.spsr = marvell_get_spsr_for_bl33_entry();
+		break;
+
+	default:
+		/* Do nothing in default case */
+		break;
+	}
+
+	return err;
+
 }
 
-/*****************************************************************************
- * Before calling this function BL31 is loaded in memory and its entrypoint
- * is set by load_image. This is a placeholder for the platform to change
- * the entrypoint of BL31 and set SPSR and security state.
- * On MARVELL std. platforms we only set the security state of the entrypoint
- *****************************************************************************
- */
-void bl2_plat_set_bl31_ep_info(image_info_t *bl31_image_info,
-			       entry_point_info_t *bl31_ep_info)
+/*******************************************************************************
+ * This function can be used by the platforms to update/use image
+ * information for given `image_id`.
+ ******************************************************************************/
+int bl2_plat_handle_post_image_load(unsigned int image_id)
 {
-	SET_SECURITY_STATE(bl31_ep_info->h.attr, SECURE);
-	bl31_ep_info->spsr = SPSR_64(MODE_EL3, MODE_SP_ELX,
-					DISABLE_ALL_EXCEPTIONS);
+	return marvell_bl2_handle_post_image_load(image_id);
 }
 
-/*****************************************************************************
- * Populate the extents of memory available for loading BL32
- *****************************************************************************
- */
-#ifdef BL32_BASE
-void bl2_plat_get_bl32_meminfo(meminfo_t *bl32_meminfo)
-{
-	/*
-	 * Populate the extents of memory available for loading BL32.
-	 */
-	bl32_meminfo->total_base = BL32_BASE;
-	bl32_meminfo->free_base = BL32_BASE;
-	bl32_meminfo->total_size =
-			(TRUSTED_DRAM_BASE + TRUSTED_DRAM_SIZE) - BL32_BASE;
-	bl32_meminfo->free_size =
-			(TRUSTED_DRAM_BASE + TRUSTED_DRAM_SIZE) - BL32_BASE;
-}
-#endif
-
-/*****************************************************************************
- * Before calling this function BL32 is loaded in memory and its entrypoint
- * is set by load_image. This is a placeholder for the platform to change
- * the entrypoint of BL32 and set SPSR and security state.
- * On MARVELL std. platforms we only set the security state of the entrypoint
- *****************************************************************************
- */
-void bl2_plat_set_bl32_ep_info(image_info_t *bl32_image_info,
-			       entry_point_info_t *bl32_ep_info)
-{
-	SET_SECURITY_STATE(bl32_ep_info->h.attr, SECURE);
-	bl32_ep_info->spsr = marvell_get_spsr_for_bl32_entry();
-}
-
-/*****************************************************************************
- * Before calling this function BL33 is loaded in memory and its entrypoint
- * is set by load_image. This is a placeholder for the platform to change
- * the entrypoint of BL33 and set SPSR and security state.
- * On MARVELL std. platforms we only set the security state of the entrypoint
- *****************************************************************************
- */
-void bl2_plat_set_bl33_ep_info(image_info_t *image,
-			       entry_point_info_t *bl33_ep_info)
-{
-
-	SET_SECURITY_STATE(bl33_ep_info->h.attr, NON_SECURE);
-	bl33_ep_info->spsr = marvell_get_spsr_for_bl33_entry();
-}
-
-/*****************************************************************************
- * Populate the extents of memory available for loading BL33
- *****************************************************************************
- */
-void bl2_plat_get_bl33_meminfo(meminfo_t *bl33_meminfo)
-{
-	bl33_meminfo->total_base = MARVELL_DRAM_BASE;
-	bl33_meminfo->total_size = MARVELL_DRAM_SIZE;
-	bl33_meminfo->free_base = MARVELL_DRAM_BASE;
-	bl33_meminfo->free_size = MARVELL_DRAM_SIZE;
-}

--- a/plat/marvell/common/marvell_common.mk
+++ b/plat/marvell/common/marvell_common.mk
@@ -20,7 +20,7 @@ $(eval $(call add_define,ARO_ENABLE))
 LLC_ENABLE			:= 1
 $(eval $(call add_define,LLC_ENABLE))
 
-PLAT_INCLUDES		+=	-I. -Iinclude/common/tbbr		\
+PLAT_INCLUDES		+=	-I. -Iinclude/common -Iinclude/common/tbbr	\
 				-I$(MARVELL_PLAT_INCLUDE_BASE)/common	\
 				-I$(MARVELL_PLAT_INCLUDE_BASE)/common/aarch64
 
@@ -46,8 +46,12 @@ endif
 BL2_SOURCES		+=	drivers/io/io_fip.c					\
 				drivers/io/io_memmap.c					\
 				drivers/io/io_storage.c					\
+				common/desc_image_load.c				\
 				$(MARVELL_PLAT_BASE)/common/marvell_bl2_setup.c		\
-				$(MARVELL_PLAT_BASE)/common/marvell_io_storage.c
+				$(MARVELL_PLAT_BASE)/common/marvell_io_storage.c	\
+				$(MARVELL_PLAT_BASE)/common/aarch64/marvell_bl2_mem_params_desc.c	\
+				$(MARVELL_PLAT_BASE)/common/marvell_image_load.c
+
 
 BL31_SOURCES		+=	$(MARVELL_PLAT_BASE)/common/marvell_bl31_setup.c	\
 				$(MARVELL_PLAT_BASE)/common/marvell_pm.c		\

--- a/plat/marvell/common/marvell_image_load.c
+++ b/plat/marvell/common/marvell_image_load.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <bl_common.h>
+#include <desc_image_load.h>
+#include <platform.h>
+#include <platform_def.h>
+
+/*******************************************************************************
+ * This function flushes the data structures so that they are visible
+ * in memory for the next BL image.
+ ******************************************************************************/
+void plat_flush_next_bl_params(void)
+{
+	flush_bl_params_desc();
+}
+
+/*******************************************************************************
+ * This function returns the list of loadable images.
+ ******************************************************************************/
+bl_load_info_t *plat_get_bl_image_load_info(void)
+{
+	return get_bl_load_info_from_mem_params_desc();
+}
+
+/*******************************************************************************
+ * This function returns the list of executable images.
+ ******************************************************************************/
+bl_params_t *plat_get_next_bl_params(void)
+{
+	return get_next_bl_params_from_mem_params_desc();
+}


### PR DESCRIPTION
- Fix build issue
- Add initial memory parameters descriptors for BL2
- Migrate to image load V2

Basic build an run test passed on MacchiatoBin board.
Need to fix the service CPU (CM3) image load procesure and test
OPTEE functionality, which probably wiull require additional work.

Signed-off-by: Konstantin Porotchkin <kostap@marvell.com>