### PR TITLE
plat/arm/css/sgm: Reorder early platform init

### DIFF
--- a/plat/arm/css/sgm/sgm_bl1_setup.c
+++ b/plat/arm/css/sgm/sgm_bl1_setup.c
@@ -12,10 +12,12 @@
 
 void bl1_early_platform_setup(void)
 {
+
+	/* Initialize the console before anything else */
+	arm_bl1_early_platform_setup();
+
 	/* Initialize the platform configuration structure */
 	plat_config_init();
-
-	arm_bl1_early_platform_setup();
 
 #if !HW_ASSISTED_COHERENCY
 	/*


### PR DESCRIPTION
In the function, bl1_early_platform_setup in the file
plat/arm/css/sgm/sgm_bl1_setup.c:

  plat_config_init();

  arm_bl1_early_platform_setup();

The debug messages logged by plat_config_init() are lost because
the console is initialized in the function
arm_bl1_early_platform_setup()

To see the logs of plat_config_init, this fix re-orders above calls
so that the console is initialized before call to plat_config_init.

Change-Id: I2e98f1f67c591cca24e28905acd0838ea3697a7c
Signed-off-by: Girish Pathak <girish.pathak@arm.com>