### PR TITLE
Remove incorrect tabulation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ INCLUDE_TBBR_MK		:=	1
 
 ifneq (${SPD},none)
 ifeq (${ARCH},aarch32)
-	$(error "Error: SPD is incompatible with AArch32.")
+        $(error "Error: SPD is incompatible with AArch32.")
 endif
 ifdef EL3_PAYLOAD_BASE
         $(warning "SPD and EL3_PAYLOAD_BASE are incompatible build options.")


### PR DESCRIPTION
When attempting to compile TF-A with "SPD=something ARCH=aarch32", the
following error message is printed:

 Makefile:291: *** recipe commences before first target.  Stop.

This is because the call to the error function is indented using a tab
whereas it's not part of a rule's recipe. Replace the tab by spaces.