### PR TITLE
tools: Make invocation of host compiler correct

### DIFF
--- a/tools/cert_create/Makefile
+++ b/tools/cert_create/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -22,7 +22,7 @@ OBJECTS := src/cert.o \
            src/tbbr/tbb_ext.o \
            src/tbbr/tbb_key.o
 
-CFLAGS := -Wall -std=c99
+HOSTCCFLAGS := -Wall -std=c99
 
 MAKE_HELPERS_DIRECTORY := ../../make_helpers/
 include ${MAKE_HELPERS_DIRECTORY}build_macros.mk
@@ -46,9 +46,9 @@ endif
 endif
 
 ifeq (${DEBUG},1)
-  CFLAGS += -g -O0 -DDEBUG -DLOG_LEVEL=40
+  HOSTCCFLAGS += -g -O0 -DDEBUG -DLOG_LEVEL=40
 else
-  CFLAGS += -O2 -DLOG_LEVEL=20
+  HOSTCCFLAGS += -O2 -DLOG_LEVEL=20
 endif
 ifeq (${V},0)
   Q := @
@@ -57,7 +57,7 @@ else
 endif
 
 $(eval $(call add_define,USE_TBBR_DEFS))
-CFLAGS += ${DEFINES}
+HOSTCCFLAGS += ${DEFINES}
 
 # Make soft links and include from local directory otherwise wrong headers
 # could get pulled in from firmware tree.
@@ -72,15 +72,15 @@ HOSTCC ?= gcc
 all: clean ${BINARY}
 
 ${BINARY}: ${OBJECTS} Makefile
-	@echo "  LD      $@"
+	@echo "  HOSTLD  $@"
 	@echo 'const char build_msg[] = "Built : "__TIME__", "__DATE__; \
                 const char platform_msg[] = "${PLAT_MSG}";' | \
-                ${HOSTCC} -c ${CFLAGS} -xc - -o src/build_msg.o
+                ${HOSTCC} -c ${HOSTCCFLAGS} -xc - -o src/build_msg.o
 	${Q}${HOSTCC} src/build_msg.o ${OBJECTS} ${LIB_DIR} ${LIB} -o $@
 
 %.o: %.c
-	@echo "  CC      $<"
-	${Q}${HOSTCC} -c ${CFLAGS} ${INC_DIR} $< -o $@
+	@echo "  HOSTCC  $<"
+	${Q}${HOSTCC} -c ${HOSTCCFLAGS} ${INC_DIR} $< -o $@
 
 clean:
 	$(call SHELL_DELETE_ALL, src/build_msg.o ${OBJECTS})

--- a/tools/doimage/Makefile
+++ b/tools/doimage/Makefile
@@ -7,11 +7,11 @@
 PROJECT = doimage
 OBJECTS = doimage.o
 
-CFLAGS = -Wall -Werror
+HOSTCCFLAGS = -Wall -Werror
 ifeq (${DEBUG},1)
-  CFLAGS += -g -O0 -DDEBUG
+  HOSTCCFLAGS += -g -O0 -DDEBUG
 else
-  CFLAGS += -O2
+  HOSTCCFLAGS += -O2
 endif
 
 ifeq (${MARVELL_SECURE_BOOT},1)
@@ -19,13 +19,13 @@ DOIMAGE_CC_FLAGS := -DCONFIG_MVEBU_SECURE_BOOT
 DOIMAGE_LD_FLAGS := -lconfig -lmbedtls -lmbedcrypto -lmbedx509
 endif
 
-CFLAGS += ${DOIMAGE_CC_FLAGS}
+HOSTCCFLAGS += ${DOIMAGE_CC_FLAGS}
 
 # Make soft links and include from local directory otherwise wrong headers
 # could get pulled in from firmware tree.
 INCLUDE_PATHS = -I.
 
-CC := gcc
+HOSTCC ?= gcc
 RM := rm -rf
 
 .PHONY: all clean
@@ -33,15 +33,15 @@ RM := rm -rf
 all: ${PROJECT}
 
 ${PROJECT}: ${OBJECTS} Makefile
-	@echo "  LD      $@"
-	${Q}${CC} ${OBJECTS} ${DOIMAGE_LD_FLAGS} -o $@
+	@echo "  HOSTLD  $@"
+	${Q}${HOSTCC} ${OBJECTS} ${DOIMAGE_LD_FLAGS} -o $@
 	@echo
 	@echo "Built $@ successfully"
 	@echo
 
 %.o: %.c Makefile
-	@echo "  CC      $<"
-	${Q}${CC} -c ${CFLAGS} ${INCLUDE_PATHS} $< -o $@
+	@echo "  HOSTCC  $<"
+	${Q}${HOSTCC} -c ${HOSTCCFLAGS} ${INCLUDE_PATHS} $< -o $@
 
 clean:
 	${Q}${RM} ${PROJECT}

--- a/tools/fiptool/Makefile
+++ b/tools/fiptool/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2017, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2014-2018, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -13,11 +13,11 @@ OBJECTS := fiptool.o tbbr_config.o
 V ?= 0
 
 override CPPFLAGS += -D_GNU_SOURCE -D_XOPEN_SOURCE=700
-CFLAGS := -Wall -Werror -pedantic -std=c99
+HOSTCCFLAGS := -Wall -Werror -pedantic -std=c99
 ifeq (${DEBUG},1)
-  CFLAGS += -g -O0 -DDEBUG
+  HOSTCCFLAGS += -g -O0 -DDEBUG
 else
-  CFLAGS += -O2
+  HOSTCCFLAGS += -O2
 endif
 LDLIBS := -lcrypto
 
@@ -36,15 +36,15 @@ HOSTCC ?= gcc
 all: ${PROJECT}
 
 ${PROJECT}: ${OBJECTS} Makefile
-	@echo "  LD      $@"
+	@echo "  HOSTLD  $@"
 	${Q}${HOSTCC} ${OBJECTS} -o $@ ${LDLIBS}
 	@${ECHO_BLANK_LINE}
 	@echo "Built $@ successfully"
 	@${ECHO_BLANK_LINE}
 
 %.o: %.c %.h Makefile
-	@echo "  CC      $<"
-	${Q}${HOSTCC} -c ${CPPFLAGS} ${CFLAGS} ${INCLUDE_PATHS} $< -o $@
+	@echo "  HOSTCC  $<"
+	${Q}${HOSTCC} -c ${CPPFLAGS} ${HOSTCCFLAGS} ${INCLUDE_PATHS} $< -o $@
 
 clean:
 	$(call SHELL_DELETE_ALL, ${PROJECT} ${OBJECTS})

--- a/tools/stm32image/Makefile
+++ b/tools/stm32image/Makefile
@@ -12,11 +12,12 @@ PROJECT := stm32image${BIN_EXT}
 OBJECTS := stm32image.o
 V := 0
 
-CFLAGS := -Wall -Werror -pedantic -std=c99 -D_GNU_SOURCE
+HOSTCCFLAGS := -Wall -Werror -pedantic -std=c99 -D_GNU_SOURCE
+
 ifeq (${DEBUG},1)
-  CFLAGS += -g -O0 -DDEBUG
+  HOSTCCFLAGS += -g -O0 -DDEBUG
 else
-  CFLAGS += -O2
+  HOSTCCFLAGS += -O2
 endif
 
 ifeq (${V},0)
@@ -25,22 +26,22 @@ else
   Q :=
 endif
 
-CC := gcc
+HOSTCC := gcc
 
 .PHONY: all clean distclean
 
 all: ${PROJECT}
 
 ${PROJECT}: ${OBJECTS} Makefile
-	@echo "  LD      $@"
-	${Q}${CC} ${OBJECTS} -o $@
+	@echo "  HOSTLD  $@"
+	${Q}${HOSTCC} ${OBJECTS} -o $@
 	@${ECHO_BLANK_LINE}
 	@echo "Built $@ successfully"
 	@${ECHO_BLANK_LINE}
 
 %.o: %.c Makefile
-	@echo "  CC      $<"
-	${Q}${CC} -c ${CFLAGS} $< -o $@
+	@echo "  HOSTCC  $<"
+	${Q}${HOSTCC} -c ${HOSTCCFLAGS} $< -o $@
 
 clean:
 	$(call SHELL_DELETE_ALL, ${PROJECT} ${OBJECTS})


### PR DESCRIPTION
HOSTCC should be used in any of the tools inside the tools/ directory instead of CC. That way it is possible to override both values from the command line when building the Trusted Firmware and the tools at the same time. Also, use HOSTCCFLAGS instead of CFLAGS.

Also, instead of printing the strings CC and LD in the console during the compilation of the tools, HOSTCC and HOSTLD have to be used for clarity. This is how it is done in other projects like U-Boot or Linux.