### PR TITLE
psci: implement platform hook to migrate_info

### DIFF
--- a/include/lib/psci/psci.h
+++ b/include/lib/psci/psci.h
@@ -322,12 +322,14 @@ typedef struct plat_psci_ops {
 	int (*write_mem_protect)(int val);
 	int (*system_reset2)(int is_vendor,
 				int reset_type, u_register_t cookie);
+	int (*migrate_info)(u_register_t *mpidr);
 } plat_psci_ops_t;
 
 /*******************************************************************************
  * Function & Data prototypes
  ******************************************************************************/
 unsigned int psci_version(void);
+int psci_migrate_info(u_register_t *mpidr);
 int psci_cpu_on(u_register_t target_cpu,
 		uintptr_t entrypoint,
 		u_register_t context_id);

--- a/lib/psci/psci_main.c
+++ b/lib/psci/psci_main.c
@@ -44,6 +44,23 @@ int psci_cpu_on(u_register_t target_cpu,
 	return psci_cpu_on_start(target_cpu, &ep);
 }
 
+int psci_platform_migrate_info(u_register_t *mpidr)
+{
+	int rc;
+
+	if (psci_plat_pm_ops->migrate_info == NULL) {
+		/* no migrate restrictions */
+		return PSCI_TOS_NOT_PRESENT_MP;
+	}
+
+	rc = psci_plat_pm_ops->migrate_info(mpidr);
+
+	assert((rc == PSCI_TOS_UP_MIG_CAP) || (rc == PSCI_TOS_NOT_UP_MIG_CAP) ||
+	       (rc == PSCI_TOS_NOT_PRESENT_MP) || (rc == PSCI_E_NOT_SUPPORTED));
+
+	return rc;
+}
+
 unsigned int psci_version(void)
 {
 	return PSCI_MAJOR_VER | PSCI_MINOR_VER;
@@ -276,8 +293,14 @@ int psci_migrate(u_register_t target_cpu)
 int psci_migrate_info_type(void)
 {
 	u_register_t resident_cpu_mpidr;
+	int rc;
 
-	return psci_spd_migrate_info(&resident_cpu_mpidr);
+	rc = psci_spd_migrate_info(&resident_cpu_mpidr);
+	if ((rc != PSCI_TOS_NOT_UP_MIG_CAP) && (rc != PSCI_TOS_UP_MIG_CAP))
+		return psci_platform_migrate_info(NULL);
+
+	return rc;
+
 }
 
 u_register_t psci_migrate_info_up_cpu(void)
@@ -290,8 +313,14 @@ u_register_t psci_migrate_info_up_cpu(void)
 	 * psci_spd_migrate_info() returns.
 	 */
 	rc = psci_spd_migrate_info(&resident_cpu_mpidr);
-	if ((rc != PSCI_TOS_NOT_UP_MIG_CAP) && (rc != PSCI_TOS_UP_MIG_CAP))
-		return (u_register_t)(register_t) PSCI_E_INVALID_PARAMS;
+	if ((rc != PSCI_TOS_NOT_UP_MIG_CAP) && (rc != PSCI_TOS_UP_MIG_CAP)) {
+		rc = psci_platform_migrate_info(&resident_cpu_mpidr);
+		if ((rc != PSCI_TOS_NOT_UP_MIG_CAP) &&
+		    (rc != PSCI_TOS_UP_MIG_CAP))
+			/* neither the SDP nor the platform have any migration
+			   restrictions: any core can be hotpluged */
+			return (u_register_t)(register_t) PSCI_E_INVALID_PARAMS;
+	}
 
 	return resident_cpu_mpidr;
 }


### PR DESCRIPTION
Even if the TrustedOS does not implement migrate restrictions, the
platform might.

This is the case when for instance a platform contains a migratable
TrustedOS but a certain CPU (tipically the boot cpu) can't be
hotpluged. This commit allows the implementation of such use case.