### PR TITLE
Fix service CPU image load at BL2 stage and update maintainers list

### DIFF
--- a/include/plat/marvell/a8k/common/plat_marvell.h
+++ b/include/plat/marvell/a8k/common/plat_marvell.h
@@ -125,4 +125,6 @@ void marvell_ble_prepare_exit(void);
 void marvell_exit_bootrom(uintptr_t base);
 
 int plat_marvell_early_cpu_powerdown(void);
+int bl2_plat_handle_scp_bl2(image_info_t *scp_bl2_image_info);
+
 #endif /* __PLAT_MARVELL_H__ */

--- a/maintainers.rst
+++ b/maintainers.rst
@@ -81,6 +81,7 @@ Marvell platform ports and SoC drivers
 :F: docs/plat/marvell/
 :F: plat/marvell/
 :F: drivers/marvell/
+:F: tools/doimage/
 
 NVidia platform ports
 ---------------------

--- a/plat/marvell/common/marvell_bl2_setup.c
+++ b/plat/marvell/common/marvell_bl2_setup.c
@@ -105,7 +105,15 @@ int marvell_bl2_handle_post_image_load(unsigned int image_id)
 		bl_mem_params->ep_info.args.arg0 = 0xffff & read_mpidr();
 		bl_mem_params->ep_info.spsr = marvell_get_spsr_for_bl33_entry();
 		break;
-
+#ifdef SCP_BL2_BASE
+	case SCP_BL2_IMAGE_ID:
+		/* The subsequent handling of SCP_BL2 is platform specific */
+		err = bl2_plat_handle_scp_bl2(&bl_mem_params->image_info);
+		if (err) {
+			WARN("Failure in platform-specific handling of SCP_BL2 image.\n");
+		}
+		break;
+#endif
 	default:
 		/* Do nothing in default case */
 		break;


### PR DESCRIPTION
This patch declares Marvell ownership on tools/doimage folder and fixes A8K service CPU (MSS) FW image load at BL2 stage