### PR TITLE
xlat: Fix checks in mmap_add() and mmap_add_ctx()

### DIFF
--- a/lib/xlat_tables/xlat_tables_common.c
+++ b/lib/xlat_tables/xlat_tables_common.c
@@ -176,7 +176,7 @@ void mmap_add(const mmap_region_t *mm)
 {
 	const mmap_region_t *mm_cursor = mm;
 
-	while (mm_cursor->attr != 0U) {
+	while ((mm_cursor->size != 0U) || (mm_cursor->attr != 0U)) {
 		mmap_add_region(mm_cursor->base_pa, mm_cursor->base_va,
 				mm_cursor->size, mm_cursor->attr);
 		mm_cursor++;

--- a/lib/xlat_tables_v2/xlat_tables_core.c
+++ b/lib/xlat_tables_v2/xlat_tables_core.c
@@ -815,7 +815,7 @@ void mmap_add_ctx(xlat_ctx_t *ctx, const mmap_region_t *mm)
 {
 	const mmap_region_t *mm_cursor = mm;
 
-	while (mm_cursor->attr != 0U) {
+	while (mm_cursor->granularity != 0U) {
 		mmap_add_region_ctx(ctx, mm_cursor);
 		mm_cursor++;
 	}


### PR DESCRIPTION
Commit 79621f0038b789de23ecc8891024f7cf6aa65999 broke sgi575.

It is possible to have a region with 0 as value for the attributes. It means device memory, read only, secure, executable. This is legitimate if the code is in flash and the code is executed from there.

This is the case for SGI_MAP_FLASH0_RO, defined in the file plat/arm/css/sgi/sgi_plat.c.

This problem is solved by checking both size and attributes in xlat v1. In xlat v2, it is enough to check the granularity, as it can never be 0.