### PR TITLE
plat/arm: allow RESET_TO_BL31 for CSS-based platforms

### DIFF
--- a/plat/arm/board/juno/platform.mk
+++ b/plat/arm/board/juno/platform.mk
@@ -90,6 +90,11 @@ endif
 
 endif
 
+ifneq (${RESET_TO_BL31},0)
+  $(error "Using BL31 as the reset vector is not supported on ${PLATFORM} platform. \
+  Please set RESET_TO_BL31 to 0.")
+endif
+
 # Errata workarounds for Cortex-A53:
 ERRATA_A53_826319		:=	1
 ERRATA_A53_835769		:=	1

--- a/plat/arm/css/common/css_common.mk
+++ b/plat/arm/css/common/css_common.mk
@@ -39,11 +39,6 @@ BL31_SOURCES		+=	plat/arm/css/drivers/scp/css_pm_scmi.c		\
 				plat/arm/css/drivers/mhu/css_mhu_doorbell.c
 endif
 
-ifneq (${RESET_TO_BL31},0)
-  $(error "Using BL31 as the reset vector is not supported on CSS platforms. \
-  Please set RESET_TO_BL31 to 0.")
-endif
-
 # Process CSS_LOAD_SCP_IMAGES flag
 $(eval $(call assert_boolean,CSS_LOAD_SCP_IMAGES))
 $(eval $(call add_define,CSS_LOAD_SCP_IMAGES))

--- a/plat/arm/css/sgi/sgi-common.mk
+++ b/plat/arm/css/sgi/sgi-common.mk
@@ -67,6 +67,11 @@ HW_CONFIG		:=	${BUILD_PLAT}/fdts/${PLAT}.dtb
 # Add the HW_CONFIG to FIP and specify the same to certtool
 $(eval $(call TOOL_ADD_PAYLOAD,${HW_CONFIG},--hw-config))
 
+ifneq (${RESET_TO_BL31},0)
+  $(error "Using BL31 as the reset vector is not supported on ${PLATFORM} platform. \
+  Please set RESET_TO_BL31 to 0.")
+endif
+
 $(eval $(call add_define,SGI_PLAT))
 
 override CSS_LOAD_SCP_IMAGES	:=	0

--- a/plat/arm/css/sgm/sgm-common.mk
+++ b/plat/arm/css/sgm/sgm-common.mk
@@ -45,6 +45,11 @@ BL31_SOURCES		+=	$(SGM_CPU_SOURCES)			\
 				${CSS_SGM_BASE}/sgm_bl31_setup.c	\
 				${CSS_SGM_BASE}/sgm_plat_config.c
 
+ifneq (${RESET_TO_BL31},0)
+  $(error "Using BL31 as the reset vector is not supported on ${PLATFORM} platform. \
+  Please set RESET_TO_BL31 to 0.")
+endif
+
 # sgm uses CCI-500 as Cache Coherent Interconnect
 ARM_CCI_PRODUCT_ID	:=	500
 


### PR DESCRIPTION
This lets any future CSS platforms to use RESET_TO_BL31 flag.

Change-Id: I32a90fce43cb0c6f4d33589653a0fd6a7ecc9577
Signed-off-by: Deepak Pandey <Deepak.Pandey@arm.com>