### PR TITLE
Various corrections of typos

### DIFF
--- a/docs/change-log.rst
+++ b/docs/change-log.rst
@@ -61,11 +61,11 @@ New Features
 
 -  Introduce RAS handling on AArch64
 
-   -  Some RAS extensions are mandatory for ARMv8.2 CPUs, with others
-      mandatory for ARMv8.4 CPUs however, all extensions are also optional
-      extensions to the base ARMv8.0 architecture.
+   -  Some RAS extensions are mandatory for Armv8.2 CPUs, with others
+      mandatory for Armv8.4 CPUs however, all extensions are also optional
+      extensions to the base Armv8.0 architecture.
 
-   -  The ARMv8 RAS Extensions introduced Standard Error Records which are a
+   -  The Armv8 RAS Extensions introduced Standard Error Records which are a
       set of standard registers to configure RAS node policy and allow RAS
       Nodes to record and expose error information for error handling agents.
 
@@ -126,7 +126,7 @@ New Features
 
 -  Various changes to support Clang linker and assembler
 
-   -  The clang assembler/preprocessor is used when Clang is selected however,
+   -  The clang assembler/preprocessor is used when Clang is selected. However,
       the clang linker is not used because it is unable to link TF-A objects
       due to immaturity of clang linker functionality at this time.
 
@@ -213,11 +213,13 @@ New Features
 
    -  Allwinner sun50i_h6
 
-   -  NXP ls1043
+   -  NXP QorIQ LS1043A
 
    -  NXP i.MX8QX
 
    -  NXP i.MX8QM
+
+   -  NXP i.MX7Solo WaRP7
 
    -  TI K3
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -521,8 +521,8 @@ Common build options
        40 (LOG_LEVEL_INFO)
        50 (LOG_LEVEL_VERBOSE)
 
-   All log output up to and including the log level is compiled into the build.
-   The default value is 40 in debug builds and 20 in release builds.
+   All log output up to and including the selected log level is compiled into
+   the build. The default value is 40 in debug builds and 20 in release builds.
 
 -  ``NON_TRUSTED_WORLD_KEY``: This option is used when ``GENERATE_COT=1``. It
    specifies the file that contains the Non-Trusted World private key in PEM

--- a/include/common/debug.h
+++ b/include/common/debug.h
@@ -57,16 +57,16 @@
 		}					\
 	} while (false)
 
-#if LOG_LEVEL >= LOG_LEVEL_NOTICE
-# define NOTICE(...)	tf_log(LOG_MARKER_NOTICE __VA_ARGS__)
-#else
-# define NOTICE(...)	no_tf_log(LOG_MARKER_NOTICE __VA_ARGS__)
-#endif
-
 #if LOG_LEVEL >= LOG_LEVEL_ERROR
 # define ERROR(...)	tf_log(LOG_MARKER_ERROR __VA_ARGS__)
 #else
 # define ERROR(...)	no_tf_log(LOG_MARKER_ERROR __VA_ARGS__)
+#endif
+
+#if LOG_LEVEL >= LOG_LEVEL_NOTICE
+# define NOTICE(...)	tf_log(LOG_MARKER_NOTICE __VA_ARGS__)
+#else
+# define NOTICE(...)	no_tf_log(LOG_MARKER_NOTICE __VA_ARGS__)
 #endif
 
 #if LOG_LEVEL >= LOG_LEVEL_WARNING

--- a/plat/arm/common/arm_bl31_setup.c
+++ b/plat/arm/common/arm_bl31_setup.c
@@ -78,7 +78,7 @@ struct entry_point_info *bl31_plat_get_next_image_ep_info(uint32_t type)
 /*******************************************************************************
  * Perform any BL31 early platform setup common to ARM standard platforms.
  * Here is an opportunity to copy parameters passed by the calling EL (S-EL1
- * in BL2 & S-EL3 in BL1) before they are lost (potentially). This needs to be
+ * in BL2 & EL3 in BL1) before they are lost (potentially). This needs to be
  * done before the MMU is initialized so that the memory layout can be used
  * while creating page tables. BL2 has flushed this information to memory, so
  * we are guaranteed to pick up good data.

--- a/plat/hisilicon/poplar/bl31_plat_setup.c
+++ b/plat/hisilicon/poplar/bl31_plat_setup.c
@@ -61,7 +61,7 @@ entry_point_info_t *bl31_plat_get_next_image_ep_info(uint32_t type)
 /*******************************************************************************
  * Perform any BL31 early platform setup common to ARM standard platforms.
  * Here is an opportunity to copy parameters passed by the calling EL (S-EL1
- * in BL2 & S-EL3 in BL1) before they are lost (potentially). This needs to be
+ * in BL2 & EL3 in BL1) before they are lost (potentially). This needs to be
  * done before the MMU is initialized so that the memory layout can be used
  * while creating page tables. BL2 has flushed this information to memory, so
  * we are guaranteed to pick up good data.

--- a/plat/layerscape/common/ls_bl31_setup.c
+++ b/plat/layerscape/common/ls_bl31_setup.c
@@ -58,7 +58,7 @@ entry_point_info_t *bl31_plat_get_next_image_ep_info(uint32_t type)
 /*******************************************************************************
  * Perform any BL31 early platform setup common to Layerscape platforms.
  * Here is an opportunity to copy parameters passed by the calling EL (S-EL1
- * in BL2 & S-EL3 in BL1) before they are lost (potentially). This needs to be
+ * in BL2 & EL3 in BL1) before they are lost (potentially). This needs to be
  * done before the MMU is initialized so that the memory layout can be used
  * while creating page tables. BL2 has flushed this information to memory, so
  * we are guaranteed to pick up good data.

--- a/plat/marvell/common/marvell_bl31_setup.c
+++ b/plat/marvell/common/marvell_bl31_setup.c
@@ -62,7 +62,7 @@ entry_point_info_t *bl31_plat_get_next_image_ep_info(uint32_t type)
 /*****************************************************************************
  * Perform any BL31 early platform setup common to ARM standard platforms.
  * Here is an opportunity to copy parameters passed by the calling EL (S-EL1
- * in BL2 & S-EL3 in BL1) before they are lost (potentially). This needs to be
+ * in BL2 & EL3 in BL1) before they are lost (potentially). This needs to be
  * done before the MMU is initialized so that the memory layout can be used
  * while creating page tables. BL2 has flushed this information to memory, so
  * we are guaranteed to pick up good data.

--- a/plat/mediatek/mt6795/bl31_plat_setup.c
+++ b/plat/mediatek/mt6795/bl31_plat_setup.c
@@ -165,7 +165,7 @@ entry_point_info_t *bl31_plat_get_next_image_ep_info(uint32_t type)
 
 /*******************************************************************************
  * Perform any BL3-1 early platform setup. Here is an opportunity to copy
- * parameters passed by the calling EL (S-EL1 in BL2 & S-EL3 in BL1) before they
+ * parameters passed by the calling EL (S-EL1 in BL2 & EL3 in BL1) before they
  * are lost (potentially). This needs to be done before the MMU is initialized
  * so that the memory layout can be used while creating page tables.
  * BL2 has flushed this information to memory, so we are guaranteed to pick up

--- a/plat/mediatek/mt8173/bl31_plat_setup.c
+++ b/plat/mediatek/mt8173/bl31_plat_setup.c
@@ -86,7 +86,7 @@ entry_point_info_t *bl31_plat_get_next_image_ep_info(uint32_t type)
 
 /*******************************************************************************
  * Perform any BL3-1 early platform setup. Here is an opportunity to copy
- * parameters passed by the calling EL (S-EL1 in BL2 & S-EL3 in BL1) before they
+ * parameters passed by the calling EL (S-EL1 in BL2 & EL3 in BL1) before they
  * are lost (potentially). This needs to be done before the MMU is initialized
  * so that the memory layout can be used while creating page tables.
  * BL2 has flushed this information to memory, so we are guaranteed to pick up

--- a/plat/qemu/qemu_bl31_setup.c
+++ b/plat/qemu/qemu_bl31_setup.c
@@ -30,7 +30,7 @@ static entry_point_info_t bl33_image_ep_info;
 
 /*******************************************************************************
  * Perform any BL3-1 early platform setup.  Here is an opportunity to copy
- * parameters passed by the calling EL (S-EL1 in BL2 & S-EL3 in BL1) before
+ * parameters passed by the calling EL (S-EL1 in BL2 & EL3 in BL1) before
  * they are lost (potentially). This needs to be done before the MMU is
  * initialized so that the memory layout can be used while creating page
  * tables. BL2 has flushed this information to memory, so we are guaranteed

--- a/plat/rockchip/common/bl31_plat_setup.c
+++ b/plat/rockchip/common/bl31_plat_setup.c
@@ -54,7 +54,7 @@ void params_early_setup(void *plat_param_from_bl2)
 
 /*******************************************************************************
  * Perform any BL3-1 early platform setup. Here is an opportunity to copy
- * parameters passed by the calling EL (S-EL1 in BL2 & S-EL3 in BL1) before they
+ * parameters passed by the calling EL (S-EL1 in BL2 & EL3 in BL1) before they
  * are lost (potentially). This needs to be done before the MMU is initialized
  * so that the memory layout can be used while creating page tables.
  * BL2 has flushed this information to memory, so we are guaranteed to pick up

--- a/plat/rpi3/rpi3_bl31_setup.c
+++ b/plat/rpi3/rpi3_bl31_setup.c
@@ -47,7 +47,7 @@ entry_point_info_t *bl31_plat_get_next_image_ep_info(uint32_t type)
 
 /*******************************************************************************
  * Perform any BL31 early platform setup. Here is an opportunity to copy
- * parameters passed by the calling EL (S-EL1 in BL2 & S-EL3 in BL1) before
+ * parameters passed by the calling EL (S-EL1 in BL2 & EL3 in BL1) before
  * they are lost (potentially). This needs to be done before the MMU is
  * initialized so that the memory layout can be used while creating page
  * tables. BL2 has flushed this information to memory, so we are guaranteed

--- a/plat/xilinx/zynqmp/bl31_zynqmp_setup.c
+++ b/plat/xilinx/zynqmp/bl31_zynqmp_setup.c
@@ -50,7 +50,7 @@ static inline void bl31_set_default_config(void)
 
 /*
  * Perform any BL31 specific platform actions. Here is an opportunity to copy
- * parameters passed by the calling EL (S-EL1 in BL2 & S-EL3 in BL1) before they
+ * parameters passed by the calling EL (S-EL1 in BL2 & EL3 in BL1) before they
  * are lost (potentially). This needs to be done before the MMU is initialized
  * so that the memory layout can be used while creating page tables.
  */


### PR DESCRIPTION
This patch fixes typos in both code comments and documentation and adds some small clarifications in documentation.