### PR TITLE
drivers: imx: mxc_usdhc: Do not set MMC_RSP_48 for MMC_RESPONSE_R2

### DIFF
--- a/drivers/imx/usdhc/imx_usdhc.c
+++ b/drivers/imx/usdhc/imx_usdhc.c
@@ -160,7 +160,7 @@ static int imx_usdhc_send_cmd(struct mmc_cmd *cmd)
 		mixctl |= MIXCTRL_DMAEN;
 	}
 
-	if (cmd->resp_type & MMC_RSP_48)
+	if (cmd->resp_type & MMC_RSP_48 && cmd->resp_type != MMC_RESPONSE_R2)
 		xfertype |= XFERTYPE_RSPTYP_48;
 	else if (cmd->resp_type & MMC_RSP_136)
 		xfertype |= XFERTYPE_RSPTYP_136;


### PR DESCRIPTION
After merging in PR-1596 we found breakage in the i.MX7 MMC driver.
This PR fixes the breakage in the right place - our driver, where before the main MMC driver had been erroneously churned by us.

Please apply.