### PR TITLE
pl011: cnds: cbmem: 16550: Fix comments

### DIFF
--- a/drivers/arm/pl011/aarch32/pl011_console.S
+++ b/drivers/arm/pl011/aarch32/pl011_console.S
@@ -89,8 +89,9 @@ endfunc console_pl011_core_init
 	.globl console_pl011_register
 
 	/* -------------------------------------------------------
-	 * init console_pl011_register(console_pl011_t *console,
-	 *	uintptr_t base, uint32_t clk, uint32_t baud)
+	 * int console_pl011_register(uintptr_t baseaddr,
+	 *     uint32_t clock, uint32_t baud,
+	 *     console_pl011_t *console);
 	 * Function to initialize and register a new PL011
 	 * console. Storage passed in for the console struct
 	 * *must* be persistent (i.e. not from the stack).

--- a/drivers/arm/pl011/aarch64/pl011_console.S
+++ b/drivers/arm/pl011/aarch64/pl011_console.S
@@ -85,8 +85,9 @@ endfunc console_pl011_core_init
 	.globl console_pl011_register
 
 	/* -----------------------------------------------
-	 * int console_pl011_register(console_pl011_t *console,
-		uintptr_t base, uint32_t clk, uint32_t baud)
+	 * int console_pl011_register(uintptr_t baseaddr,
+	 *     uint32_t clock, uint32_t baud,
+	 *     console_pl011_t *console);
 	 * Function to initialize and register a new PL011
 	 * console. Storage passed in for the console struct
 	 * *must* be persistent (i.e. not from the stack).

--- a/drivers/cadence/uart/aarch64/cdns_console.S
+++ b/drivers/cadence/uart/aarch64/cdns_console.S
@@ -54,8 +54,9 @@ endfunc console_cdns_core_init
 	.globl console_cdns_register
 
 	/* -----------------------------------------------
-	 * int console_cdns_register(console_cdns_t *console,
-		uintptr_t base, uint32_t clk, uint32_t baud)
+	 * int console_cdns_register(uint64_t baseaddr,
+	 *     uint32_t clock, uint32_t baud,
+	 *     console_cdns_t *console);
 	 * Function to initialize and register a new CDNS
 	 * console. Storage passed in for the console struct
 	 * *must* be persistent (i.e. not from the stack).

--- a/drivers/coreboot/cbmem_console/aarch64/cbmem_console.S
+++ b/drivers/coreboot/cbmem_console/aarch64/cbmem_console.S
@@ -19,8 +19,8 @@
 	.globl console_cbmc_flush
 
 	/* -----------------------------------------------
-	 * int console_cbmc_register(console_cbmc_t *console,
-	 *			     uintptr_t base)
+	 * int console_cbmc_register(uintptr_t base,
+	 *                           console_cbmc_t *console);
 	 * Registers a new CBMEM console instance. Reads
 	 * the size field from the buffer header structure
 	 * and stores it in our console_cbmc_t struct, so

--- a/drivers/ti/uart/aarch64/16550_console.S
+++ b/drivers/ti/uart/aarch64/16550_console.S
@@ -87,8 +87,9 @@ endfunc console_16550_core_init
 	.globl console_16550_register
 
 	/* -----------------------------------------------
-	 * int console_16550_register(console_16550_t *console,
-		uintptr_t base, uint32_t clk, uint32_t baud)
+	 * int console_16550_register(uintptr_t baseaddr,
+	 *     uint32_t clock, uint32_t baud,
+	 *     console_16550_t *console);
 	 * Function to initialize and register a new 16550
 	 * console. Storage passed in for the console struct
 	 * *must* be persistent (i.e. not from the stack).


### PR DESCRIPTION
The comments with the prototypes of the register functions of the console drivers are incorrect. The arguments are wrong. This patch fixes them.