### PR TITLE
plat/arm: relocate the jump_if_cpu_midr macro.

### DIFF
--- a/include/lib/cpus/aarch32/cpu_macros.S
+++ b/include/lib/cpus/aarch32/cpu_macros.S
@@ -214,5 +214,18 @@
 	bl	errata_print_msg
 	.endm
 #endif
+	/*
+	 * Helper macro that reads the part number of the current CPU and jumps
+	 * to the given label if it matches the CPU MIDR provided.
+	 *
+	 * Clobbers: r0-r1
+	 */
+	.macro  jump_if_cpu_midr _cpu_midr, _label
+	ldcopr	r0, MIDR
+	ubfx	r0, r0, #MIDR_PN_SHIFT, #12
+	ldr	r1, =((\_cpu_midr >> MIDR_PN_SHIFT) & MIDR_PN_MASK)
+	cmp	r0, r1
+	beq	\_label
+	.endm
 
 #endif /* __CPU_MACROS_S__ */

--- a/include/lib/cpus/aarch64/cpu_macros.S
+++ b/include/lib/cpus/aarch64/cpu_macros.S
@@ -272,3 +272,17 @@
 	cmp	\_reg, #1
 	beq	\_label
 	.endm
+
+	/*
+	 * Helper macro that reads the part number of the current
+	 * CPU and jumps to the given label if it matches the CPU
+	 * MIDR provided.
+	 *
+	 * Clobbers x0.
+	 */
+	.macro  jump_if_cpu_midr _cpu_midr, _label
+	mrs	x0, midr_el1
+	ubfx	x0, x0, MIDR_PN_SHIFT, #12
+	cmp	w0, #((\_cpu_midr >> MIDR_PN_SHIFT) & MIDR_PN_MASK)
+	b.eq	\_label
+	.endm

--- a/plat/arm/board/juno/aarch32/juno_helpers.S
+++ b/plat/arm/board/juno/aarch32/juno_helpers.S
@@ -10,6 +10,7 @@
 #include <cortex_a53.h>
 #include <cortex_a57.h>
 #include <cortex_a72.h>
+#include <cpu_macros.S>
 #include <v2m_def.h>
 #include "../juno_def.h"
 
@@ -31,21 +32,6 @@
 	.macro jump_to_handler _revision, _handler
 	cmp	r0, #\_revision
 	beq	\_handler
-	.endm
-
-	/* --------------------------------------------------------------------
-	 * Helper macro that reads the part number of the current CPU and jumps
-	 * to the given label if it matches the CPU MIDR provided.
-	 *
-	 * Clobbers r0.
-	 * --------------------------------------------------------------------
-	 */
-	.macro  jump_if_cpu_midr _cpu_midr, _label
-	ldcopr	r0, MIDR
-	ubfx	r0, r0, #MIDR_PN_SHIFT, #12
-	ldr	r1, =((\_cpu_midr >> MIDR_PN_SHIFT) & MIDR_PN_MASK)
-	cmp	r0, r1
-	beq	\_label
 	.endm
 
 	/* --------------------------------------------------------------------

--- a/plat/arm/board/juno/aarch64/juno_helpers.S
+++ b/plat/arm/board/juno/aarch64/juno_helpers.S
@@ -40,20 +40,6 @@
 	.endm
 
 	/* --------------------------------------------------------------------
-	 * Helper macro that reads the part number of the current CPU and jumps
-	 * to the given label if it matches the CPU MIDR provided.
-	 *
-	 * Clobbers x0.
-	 * --------------------------------------------------------------------
-	 */
-	.macro  jump_if_cpu_midr _cpu_midr, _label
-	mrs	x0, midr_el1
-	ubfx	x0, x0, MIDR_PN_SHIFT, #12
-	cmp     w0, #((\_cpu_midr >> MIDR_PN_SHIFT) & MIDR_PN_MASK)
-	b.eq	\_label
-	.endm
-
-	/* --------------------------------------------------------------------
 	 * Platform reset handler for Juno R0.
 	 *
 	 * Juno R0 has the following topology:

--- a/plat/arm/css/sgi/aarch64/sgi_helper.S
+++ b/plat/arm/css/sgi/aarch64/sgi_helper.S
@@ -8,6 +8,7 @@
 #include <asm_macros.S>
 #include <platform_def.h>
 #include <cortex_a75.h>
+#include <cpu_macros.S>
 
 	.globl	plat_arm_calc_core_pos
 	.globl	plat_reset_handler
@@ -47,21 +48,6 @@ func plat_arm_calc_core_pos
 	madd    x0, x1, x5, x0
 	ret
 endfunc plat_arm_calc_core_pos
-
-	/* ------------------------------------------------------
-	 * Helper macro that reads the part number of the current
-	 * CPU and jumps to the given label if it matches the CPU
-	 * MIDR provided.
-	 *
-	 * Clobbers x0.
-	 * -----------------------------------------------------
-	 */
-	.macro  jump_if_cpu_midr _cpu_midr, _label
-	mrs	x0, midr_el1
-	ubfx	x0, x0, MIDR_PN_SHIFT, #12
-	cmp	w0, #((\_cpu_midr >> MIDR_PN_SHIFT) & MIDR_PN_MASK)
-	b.eq	\_label
-	.endm
 
 	/* -----------------------------------------------------
 	 * void plat_reset_handler(void);

--- a/plat/arm/css/sgm/aarch64/css_sgm_helpers.S
+++ b/plat/arm/css/sgm/aarch64/css_sgm_helpers.S
@@ -9,6 +9,7 @@
 #include <platform_def.h>
 #include <cortex_a75.h>
 #include <cortex_a55.h>
+#include <cpu_macros.S>
 
 	.globl	plat_arm_calc_core_pos
 	.globl	plat_reset_handler
@@ -49,21 +50,6 @@ func plat_arm_calc_core_pos
 	madd	x0, x1, x5, x0
 	ret
 endfunc plat_arm_calc_core_pos
-
-	/* ------------------------------------------------------
-	 * Helper macro that reads the part number of the current
-	 * CPU and jumps to the given label if it matches the CPU
-	 * MIDR provided.
-	 *
-	 * Clobbers x0.
-	 * -----------------------------------------------------
-	 */
-	.macro  jump_if_cpu_midr _cpu_midr, _label
-	mrs	x0, midr_el1
-	ubfx	x0, x0, MIDR_PN_SHIFT, #12
-	cmp	w0, #((\_cpu_midr >> MIDR_PN_SHIFT) & MIDR_PN_MASK)
-	b.eq	\_label
-	.endm
 
 	/* -----------------------------------------------------
 	 * void plat_reset_handler(void);


### PR DESCRIPTION
macro jump_if_cpu_midr is used commonly by many arm platform.
It has now been relocated to common place to remove duplication
of code.

Change-Id: Ic0876097dbc085df4f90eadb4b7687dde7c726da
Signed-off-by: Deepak Pandey <Deepak.Pandey@arm.com>