### PR TITLE
tzc: Fix MISRA defects

### DIFF
--- a/drivers/arm/tzc/tzc_dmc500.c
+++ b/drivers/arm/tzc/tzc_dmc500.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -36,7 +36,7 @@ static unsigned int g_sys_if_count;
  * Structure for configured regions attributes in DMC500.
  */
 typedef struct tzc_dmc500_regions {
-	tzc_region_attributes_t sec_attr;
+	unsigned int sec_attr;
 	int is_enabled;
 } tzc_dmc500_regions_t;
 
@@ -63,7 +63,7 @@ DEFINE_TZC_COMMON_CONFIGURE_REGION(_dmc500)
 
 static inline unsigned int _tzc_dmc500_read_region_attr_0(
 					uintptr_t dmc_si_base,
-					int region_no)
+					unsigned int region_no)
 {
 	return mmio_read_32(dmc_si_base +
 			TZC_REGION_OFFSET(TZC_DMC500_REGION_SIZE, region_no) +
@@ -144,8 +144,8 @@ int tzc_dmc500_verify_complete(void)
  * and is always enabled; this cannot be changed. This function only changes
  * the access permissions.
  */
-void tzc_dmc500_configure_region0(tzc_region_attributes_t sec_attr,
-					unsigned int nsaid_permissions)
+void tzc_dmc500_configure_region0(unsigned int sec_attr,
+				  unsigned int nsaid_permissions)
 {
 	int dmc_inst, sys_if;
 
@@ -172,17 +172,17 @@ void tzc_dmc500_configure_region0(tzc_region_attributes_t sec_attr,
  * Region 0 is special; it is preferable to use tzc_dmc500_configure_region0
  * for this region (see comment for that function).
  */
-void tzc_dmc500_configure_region(int region_no,
+void tzc_dmc500_configure_region(unsigned int region_no,
 			unsigned long long region_base,
 			unsigned long long region_top,
-			tzc_region_attributes_t sec_attr,
+			unsigned int sec_attr,
 			unsigned int nsaid_permissions)
 {
 	int dmc_inst, sys_if;
 
 	assert(g_driver_data);
 	/* Do range checks on regions. */
-	assert(region_no >= 0 && region_no <= MAX_REGION_VAL);
+	assert((region_no >= 0U) && (region_no <= MAX_REGION_VAL));
 
 	/*
 	 * Do address range check based on DMC-TZ configuration. A 43bit address
@@ -192,7 +192,7 @@ void tzc_dmc500_configure_region(int region_no,
 		(region_base < region_top)));
 
 	/* region_base and (region_top + 1) must be 4KB aligned */
-	assert(((region_base | (region_top + 1)) & (4096 - 1)) == 0);
+	assert(((region_base | (region_top + 1U)) & (4096U - 1U)) == 0U);
 
 	for (dmc_inst = 0; dmc_inst < g_driver_data->dmc_count; dmc_inst++) {
 		assert(DMC_INST_BASE_ADDR(dmc_inst));
@@ -209,7 +209,7 @@ void tzc_dmc500_configure_region(int region_no,
 }
 
 /* Sets the action value for all the DMC instances */
-void tzc_dmc500_set_action(tzc_action_t action)
+void tzc_dmc500_set_action(unsigned int action)
 {
 	int dmc_inst;
 

--- a/include/drivers/arm/tzc400.h
+++ b/include/drivers/arm/tzc400.h
@@ -4,83 +4,84 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __TZC400_H__
-#define __TZC400_H__
+#ifndef TZC400_H
+#define TZC400_H
 
 #include <tzc_common.h>
+#include <utils_def.h>
 
-#define BUILD_CONFIG_OFF			0x000
-#define GATE_KEEPER_OFF				0x008
-#define SPECULATION_CTRL_OFF			0x00c
-#define INT_STATUS				0x010
-#define INT_CLEAR				0x014
+#define BUILD_CONFIG_OFF			U(0x000)
+#define GATE_KEEPER_OFF				U(0x008)
+#define SPECULATION_CTRL_OFF			U(0x00c)
+#define INT_STATUS				U(0x010)
+#define INT_CLEAR				U(0x014)
 
-#define FAIL_ADDRESS_LOW_OFF			0x020
-#define FAIL_ADDRESS_HIGH_OFF			0x024
-#define FAIL_CONTROL_OFF			0x028
-#define FAIL_ID					0x02c
+#define FAIL_ADDRESS_LOW_OFF			U(0x020)
+#define FAIL_ADDRESS_HIGH_OFF			U(0x024)
+#define FAIL_CONTROL_OFF			U(0x028)
+#define FAIL_ID					U(0x02c)
 
 /* ID registers not common across different varieties of TZC */
-#define PID5					0xFD4
-#define PID6					0xFD8
-#define PID7					0xFDC
+#define PID5					U(0xFD4)
+#define PID6					U(0xFD8)
+#define PID7					U(0xFDC)
 
 #define BUILD_CONFIG_NF_SHIFT			24
-#define BUILD_CONFIG_NF_MASK			0x3
+#define BUILD_CONFIG_NF_MASK			U(0x3)
 #define BUILD_CONFIG_AW_SHIFT			8
-#define BUILD_CONFIG_AW_MASK			0x3f
+#define BUILD_CONFIG_AW_MASK			U(0x3f)
 #define BUILD_CONFIG_NR_SHIFT			0
-#define BUILD_CONFIG_NR_MASK			0x1f
+#define BUILD_CONFIG_NR_MASK			U(0x1f)
 
 /*
  * Number of gate keepers is implementation defined. But we know the max for
  * this device is 4. Get implementation details from BUILD_CONFIG.
  */
 #define GATE_KEEPER_OS_SHIFT			16
-#define GATE_KEEPER_OS_MASK			0xf
+#define GATE_KEEPER_OS_MASK			U(0xf)
 #define GATE_KEEPER_OR_SHIFT			0
-#define GATE_KEEPER_OR_MASK			0xf
-#define GATE_KEEPER_FILTER_MASK			0x1
+#define GATE_KEEPER_OR_MASK			U(0xf)
+#define GATE_KEEPER_FILTER_MASK			U(0x1)
 
 /* Speculation is enabled by default. */
-#define SPECULATION_CTRL_WRITE_DISABLE		(1 << 1)
-#define SPECULATION_CTRL_READ_DISABLE		(1 << 0)
+#define SPECULATION_CTRL_WRITE_DISABLE		BIT_32(1)
+#define SPECULATION_CTRL_READ_DISABLE		BIT_32(0)
 
 /* Max number of filters allowed is 4. */
 #define INT_STATUS_OVERLAP_SHIFT		16
-#define INT_STATUS_OVERLAP_MASK			0xf
+#define INT_STATUS_OVERLAP_MASK			U(0xf)
 #define INT_STATUS_OVERRUN_SHIFT		8
-#define INT_STATUS_OVERRUN_MASK			0xf
+#define INT_STATUS_OVERRUN_MASK			U(0xf)
 #define INT_STATUS_STATUS_SHIFT			0
-#define INT_STATUS_STATUS_MASK			0xf
+#define INT_STATUS_STATUS_MASK			U(0xf)
 
 #define INT_CLEAR_CLEAR_SHIFT			0
-#define INT_CLEAR_CLEAR_MASK			0xf
+#define INT_CLEAR_CLEAR_MASK			U(0xf)
 
-#define FAIL_CONTROL_DIR_SHIFT			(1 << 24)
-#define FAIL_CONTROL_DIR_READ			0x0
-#define FAIL_CONTROL_DIR_WRITE			0x1
-#define FAIL_CONTROL_NS_SHIFT			(1 << 21)
-#define FAIL_CONTROL_NS_SECURE			0x0
-#define FAIL_CONTROL_NS_NONSECURE		0x1
-#define FAIL_CONTROL_PRIV_SHIFT			(1 << 20)
-#define FAIL_CONTROL_PRIV_PRIV			0x0
-#define FAIL_CONTROL_PRIV_UNPRIV		0x1
+#define FAIL_CONTROL_DIR_SHIFT			24
+#define FAIL_CONTROL_DIR_READ			U(0)
+#define FAIL_CONTROL_DIR_WRITE			U(1)
+#define FAIL_CONTROL_NS_SHIFT			21
+#define FAIL_CONTROL_NS_SECURE			U(0)
+#define FAIL_CONTROL_NS_NONSECURE		U(1)
+#define FAIL_CONTROL_PRIV_SHIFT			20
+#define FAIL_CONTROL_PRIV_PRIV			U(0)
+#define FAIL_CONTROL_PRIV_UNPRIV		U(1)
 
 /*
  * FAIL_ID_ID_MASK depends on AID_WIDTH which is platform specific.
  * Platform should provide the value on initialisation.
  */
 #define FAIL_ID_VNET_SHIFT			24
-#define FAIL_ID_VNET_MASK			0xf
+#define FAIL_ID_VNET_MASK			U(0xf)
 #define FAIL_ID_ID_SHIFT			0
 
-#define TZC_400_PERIPHERAL_ID			0x460
+#define TZC_400_PERIPHERAL_ID			U(0x460)
 
 /* Filter enable bits in a TZC */
-#define TZC_400_REGION_ATTR_F_EN_MASK		0xf
-#define TZC_400_REGION_ATTR_FILTER_BIT(x)	((1 << x)		\
-					<< TZC_REGION_ATTR_F_EN_SHIFT)
+#define TZC_400_REGION_ATTR_F_EN_MASK		U(0xf)
+#define TZC_400_REGION_ATTR_FILTER_BIT(x)				\
+				((U(1) << (x)) << TZC_REGION_ATTR_F_EN_SHIFT)
 #define TZC_400_REGION_ATTR_FILTER_BIT_ALL				\
 				(TZC_400_REGION_ATTR_F_EN_MASK <<	\
 				TZC_REGION_ATTR_F_EN_SHIFT)
@@ -89,8 +90,8 @@
  * All TZC region configuration registers are placed one after another. It
  * depicts size of block of registers for programming each region.
  */
-#define TZC_400_REGION_SIZE			0x20
-#define TZC_400_ACTION_OFF			0x4
+#define TZC_400_REGION_SIZE			U(0x20)
+#define TZC_400_ACTION_OFF			U(0x4)
 
 #ifndef __ASSEMBLY__
 
@@ -101,15 +102,15 @@
  * Function & variable prototypes
  ******************************************************************************/
 void tzc400_init(uintptr_t base);
-void tzc400_configure_region0(tzc_region_attributes_t sec_attr,
+void tzc400_configure_region0(unsigned int sec_attr,
 			   unsigned int ns_device_access);
 void tzc400_configure_region(unsigned int filters,
-			  int region,
+			  unsigned int region,
 			  unsigned long long region_base,
 			  unsigned long long region_top,
-			  tzc_region_attributes_t sec_attr,
+			  unsigned int sec_attr,
 			  unsigned int nsaid_permissions);
-void tzc400_set_action(tzc_action_t action);
+void tzc400_set_action(unsigned int action);
 void tzc400_enable_filters(void);
 void tzc400_disable_filters(void);
 
@@ -119,7 +120,7 @@ static inline void tzc_init(uintptr_t base)
 }
 
 static inline void tzc_configure_region0(
-			tzc_region_attributes_t sec_attr,
+			unsigned int sec_attr,
 			unsigned int ns_device_access)
 {
 	tzc400_configure_region0(sec_attr, ns_device_access);
@@ -127,17 +128,17 @@ static inline void tzc_configure_region0(
 
 static inline void tzc_configure_region(
 			  unsigned int filters,
-			  int region,
+			  unsigned int region,
 			  unsigned long long region_base,
 			  unsigned long long region_top,
-			  tzc_region_attributes_t sec_attr,
+			  unsigned int sec_attr,
 			  unsigned int ns_device_access)
 {
 	tzc400_configure_region(filters, region, region_base,
 			region_top, sec_attr, ns_device_access);
 }
 
-static inline void tzc_set_action(tzc_action_t action)
+static inline void tzc_set_action(unsigned int action)
 {
 	tzc400_set_action(action);
 }
@@ -155,4 +156,4 @@ static inline void tzc_disable_filters(void)
 
 #endif /* __ASSEMBLY__ */
 
-#endif /* __TZC400__ */
+#endif /* TZC400_H */

--- a/include/drivers/arm/tzc_common.h
+++ b/include/drivers/arm/tzc_common.h
@@ -1,11 +1,13 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __TZC_COMMON_H__
-#define __TZC_COMMON_H__
+#ifndef TZC_COMMON_H
+#define TZC_COMMON_H
+
+#include <utils_def.h>
 
 /*
  * Offset of core registers from the start of the base of configuration
@@ -13,53 +15,15 @@
  */
 
 /* ID Registers */
-#define PID0_OFF					0xfe0
-#define PID1_OFF					0xfe4
-#define PID2_OFF					0xfe8
-#define PID3_OFF					0xfec
-#define PID4_OFF					0xfd0
-#define CID0_OFF					0xff0
-#define CID1_OFF					0xff4
-#define CID2_OFF					0xff8
-#define CID3_OFF					0xffc
-
-/* Bit positions of TZC_ACTION registers */
-#define TZC_ACTION_RV_SHIFT				0
-#define TZC_ACTION_RV_MASK				0x3
-#define TZC_ACTION_RV_LOWOK				0x0
-#define TZC_ACTION_RV_LOWERR				0x1
-#define TZC_ACTION_RV_HIGHOK				0x2
-#define TZC_ACTION_RV_HIGHERR				0x3
-
-/* Used along with 'tzc_region_attributes_t' below */
-#define TZC_REGION_ATTR_S_RD_SHIFT			30
-#define TZC_REGION_ATTR_S_WR_SHIFT			31
-#define TZC_REGION_ATTR_F_EN_SHIFT			0
-#define TZC_REGION_ATTR_SEC_SHIFT			30
-#define TZC_REGION_ATTR_S_RD_MASK			0x1
-#define TZC_REGION_ATTR_S_WR_MASK			0x1
-#define TZC_REGION_ATTR_SEC_MASK			0x3
-
-#define TZC_REGION_ACCESS_WR_EN_SHIFT			16
-#define TZC_REGION_ACCESS_RD_EN_SHIFT			0
-#define TZC_REGION_ACCESS_ID_MASK			0xf
-
-/* Macros for allowing Non-Secure access to a region based on NSAID */
-#define TZC_REGION_ACCESS_RD(nsaid)				\
-	((1 << ((nsaid) & TZC_REGION_ACCESS_ID_MASK)) <<	\
-	 TZC_REGION_ACCESS_RD_EN_SHIFT)
-#define TZC_REGION_ACCESS_WR(nsaid)				\
-	((1 << ((nsaid) & TZC_REGION_ACCESS_ID_MASK)) <<	\
-	 TZC_REGION_ACCESS_WR_EN_SHIFT)
-#define TZC_REGION_ACCESS_RDWR(nsaid)				\
-	(TZC_REGION_ACCESS_RD(nsaid) |				\
-	TZC_REGION_ACCESS_WR(nsaid))
-
-#ifndef __ASSEMBLY__
-
-/* Returns offset of registers to program for a given region no */
-#define TZC_REGION_OFFSET(region_size, region_no)	\
-				((region_size) * (region_no))
+#define PID0_OFF					U(0xfe0)
+#define PID1_OFF					U(0xfe4)
+#define PID2_OFF					U(0xfe8)
+#define PID3_OFF					U(0xfec)
+#define PID4_OFF					U(0xfd0)
+#define CID0_OFF					U(0xff0)
+#define CID1_OFF					U(0xff4)
+#define CID2_OFF					U(0xff8)
+#define CID3_OFF					U(0xffc)
 
 /*
  * What type of action is expected when an access violation occurs.
@@ -73,23 +37,61 @@
  *  TZC_ACTION_ERR_INT - Raise interrupt, raise exception -> sync
  *                       external data abort
  */
-typedef enum {
-	TZC_ACTION_NONE = 0,
-	TZC_ACTION_ERR = 1,
-	TZC_ACTION_INT = 2,
-	TZC_ACTION_ERR_INT = (TZC_ACTION_ERR | TZC_ACTION_INT)
-} tzc_action_t;
+#define TZC_ACTION_NONE			U(0)
+#define TZC_ACTION_ERR			U(1)
+#define TZC_ACTION_INT			U(2)
+#define TZC_ACTION_ERR_INT		(TZC_ACTION_ERR | TZC_ACTION_INT)
+
+/* Bit positions of TZC_ACTION registers */
+#define TZC_ACTION_RV_SHIFT				0
+#define TZC_ACTION_RV_MASK				U(0x3)
+#define TZC_ACTION_RV_LOWOK				U(0x0)
+#define TZC_ACTION_RV_LOWERR				U(0x1)
+#define TZC_ACTION_RV_HIGHOK				U(0x2)
+#define TZC_ACTION_RV_HIGHERR				U(0x3)
 
 /*
  * Controls secure access to a region. If not enabled secure access is not
  * allowed to region.
  */
-typedef enum {
-	TZC_REGION_S_NONE = 0,
-	TZC_REGION_S_RD = 1,
-	TZC_REGION_S_WR = 2,
-	TZC_REGION_S_RDWR = (TZC_REGION_S_RD | TZC_REGION_S_WR)
-} tzc_region_attributes_t;
+#define TZC_REGION_S_NONE		U(0)
+#define TZC_REGION_S_RD			U(1)
+#define TZC_REGION_S_WR			U(2)
+#define TZC_REGION_S_RDWR		(TZC_REGION_S_RD | TZC_REGION_S_WR)
+
+#define TZC_REGION_ATTR_S_RD_SHIFT			30
+#define TZC_REGION_ATTR_S_WR_SHIFT			31
+#define TZC_REGION_ATTR_F_EN_SHIFT			0
+#define TZC_REGION_ATTR_SEC_SHIFT			30
+#define TZC_REGION_ATTR_S_RD_MASK			U(0x1)
+#define TZC_REGION_ATTR_S_WR_MASK			U(0x1)
+#define TZC_REGION_ATTR_SEC_MASK			U(0x3)
+
+#define TZC_REGION_ACCESS_WR_EN_SHIFT			16
+#define TZC_REGION_ACCESS_RD_EN_SHIFT			0
+#define TZC_REGION_ACCESS_ID_MASK			U(0xf)
+
+/* Macros for allowing Non-Secure access to a region based on NSAID */
+#define TZC_REGION_ACCESS_RD(nsaid)				\
+	((U(1) << (nsaid & TZC_REGION_ACCESS_ID_MASK)) <<	\
+	 TZC_REGION_ACCESS_RD_EN_SHIFT)
+#define TZC_REGION_ACCESS_WR(nsaid)				\
+	((U(1) << (nsaid & TZC_REGION_ACCESS_ID_MASK)) <<	\
+	 TZC_REGION_ACCESS_WR_EN_SHIFT)
+#define TZC_REGION_ACCESS_RDWR(nsaid)				\
+	(TZC_REGION_ACCESS_RD(nsaid) |				\
+	TZC_REGION_ACCESS_WR(nsaid))
+
+/* Returns offset of registers to program for a given region no */
+#define TZC_REGION_OFFSET(region_size, region_no)	\
+				((region_size) * (region_no))
+
+#ifndef __ASSEMBLY__
+
+#if !ERROR_DEPRECATED
+typedef unsigned int tzc_action_t;
+typedef unsigned int tzc_region_attributes_t;
+#endif
 
 #endif /* __ASSEMBLY__ */
-#endif /* __TZC_COMMON_H__ */
+#endif /* TZC_COMMON_H */

--- a/include/drivers/arm/tzc_dmc500.h
+++ b/include/drivers/arm/tzc_dmc500.h
@@ -1,38 +1,39 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef __TZC_DMC500_H__
-#define __TZC_DMC500_H__
+#ifndef TZC_DMC500_H
+#define TZC_DMC500_H
 
 #include <tzc_common.h>
+#include <utils_def.h>
 
-#define SI_STATUS_OFFSET				0x000
-#define SI_STATE_CTRL_OFFSET				0x030
-#define SI_FLUSH_CTRL_OFFSET				0x034
-#define SI_INT_CONTROL_OFFSET				0x048
+#define SI_STATUS_OFFSET				U(0x000)
+#define SI_STATE_CTRL_OFFSET				U(0x030)
+#define SI_FLUSH_CTRL_OFFSET				U(0x034)
+#define SI_INT_CONTROL_OFFSET				U(0x048)
 
-#define SI_INT_STATUS_OFFSET				0x004
-#define SI_TZ_FAIL_ADDRESS_LOW_OFFSET			0x008
-#define SI_TZ_FAIL_ADDRESS_HIGH_OFFSET			0x00c
-#define SI_FAIL_CONTROL_OFFSET				0x010
-#define SI_FAIL_ID_OFFSET				0x014
-#define SI_INT_CLR_OFFSET				0x04c
+#define SI_INT_STATUS_OFFSET				U(0x004)
+#define SI_TZ_FAIL_ADDRESS_LOW_OFFSET			U(0x008)
+#define SI_TZ_FAIL_ADDRESS_HIGH_OFFSET			U(0x00c)
+#define SI_FAIL_CONTROL_OFFSET				U(0x010)
+#define SI_FAIL_ID_OFFSET				U(0x014)
+#define SI_INT_CLR_OFFSET				U(0x04c)
 
 /*
  * DMC-500 has 2 system interfaces each having a similar set of regs
  * to configure each interface.
  */
-#define SI0_BASE					0x0000
-#define SI1_BASE					0x0200
+#define SI0_BASE					U(0x0000)
+#define SI1_BASE					U(0x0200)
 
 /* Bit positions of SIx_SI_STATUS */
-#define SI_EMPTY_SHIFT					0x01
-#define SI_STALL_ACK_SHIFT				0x00
-#define SI_EMPTY_MASK					0x01
-#define SI_STALL_ACK_MASK				0x01
+#define SI_EMPTY_SHIFT					1
+#define SI_STALL_ACK_SHIFT				0
+#define SI_EMPTY_MASK					U(0x01)
+#define SI_STALL_ACK_MASK				U(0x01)
 
 /* Bit positions of SIx_SI_INT_STATUS */
 #define PMU_REQ_INT_OVERFLOW_STATUS_SHIFT		18
@@ -40,11 +41,11 @@
 #define PMU_REQ_INT_STATUS_SHIFT			2
 #define FAILED_ACCESS_INT_INFO_TZ_OVERLAP_STATUS_SHIFT	1
 #define FAILED_ACCESS_INT_STATUS_SHIFT			0
-#define PMU_REQ_INT_OVERFLOW_STATUS_MASK		0x1
-#define FAILED_ACCESS_INT_OVERFLOW_STATUS_MASK		0x1
-#define PMU_REQ_INT_STATUS_MASK				0x1
-#define FAILED_ACCESS_INT_INFO_TZ_OVERLAP_STATUS_MASK	0x1
-#define FAILED_ACCESS_INT_STATUS_MASK			0x1
+#define PMU_REQ_INT_OVERFLOW_STATUS_MASK		U(0x1)
+#define FAILED_ACCESS_INT_OVERFLOW_STATUS_MASK		U(0x1)
+#define PMU_REQ_INT_STATUS_MASK				U(0x1)
+#define FAILED_ACCESS_INT_INFO_TZ_OVERLAP_STATUS_MASK	U(0x1)
+#define FAILED_ACCESS_INT_STATUS_MASK			U(0x1)
 
 /* Bit positions of SIx_TZ_FAIL_CONTROL */
 #define DIRECTION_SHIFT					24
@@ -52,21 +53,21 @@
 #define PRIVILEGED_SHIFT				20
 #define FAILED_ACCESS_INT_INFO_RANK_MASKED_SHIFT	3
 #define FAILED_ACCESS_INT_INFO_UNMAPPED_SHIFT		2
-#define FAILED_ACCESS_INT_TZ_FAIL_SHIFT			0x1
+#define FAILED_ACCESS_INT_TZ_FAIL_SHIFT			1
 #define FAILED_ACCESS_INT_INFO_OUTSIDE_DEFAULT_SHIFT	0
-#define DIRECTION_MASK					0x1
-#define NON_SECURE_MASK					0x1
-#define PRIVILEGED_MASK					0x1
-#define FAILED_ACCESS_INT_INFO_RANK_MASKED_MASK		0x1
-#define FAILED_ACCESS_INT_INFO_UNMAPPED_MASK		0x1
-#define FAILED_ACCESS_INT_TZ_FAIL_MASK			1
-#define FAILED_ACCESS_INT_INFO_OUTSIDE_DEFAULT_MASK	0x1
+#define DIRECTION_MASK					U(0x1)
+#define NON_SECURE_MASK					U(0x1)
+#define PRIVILEGED_MASK					U(0x1)
+#define FAILED_ACCESS_INT_INFO_RANK_MASKED_MASK		U(0x1)
+#define FAILED_ACCESS_INT_INFO_UNMAPPED_MASK		U(0x1)
+#define FAILED_ACCESS_INT_TZ_FAIL_MASK			U(0x1)
+#define FAILED_ACCESS_INT_INFO_OUTSIDE_DEFAULT_MASK	U(0x1)
 
 /* Bit positions of SIx_FAIL_STATUS */
 #define FAIL_ID_VNET_SHIFT				24
 #define FAIL_ID_ID_SHIFT				0
-#define FAIL_ID_VNET_MASK				0xf
-#define FAIL_ID_ID_MASK					0xffffff
+#define FAIL_ID_VNET_MASK				U(0xf)
+#define FAIL_ID_ID_MASK					U(0xffffff)
 
 /* Bit positions of SIx_SI_STATE_CONTRL */
 #define SI_STALL_REQ_GO					0x0
@@ -81,44 +82,44 @@
 #define PMU_REQ_INT_EN_SHIFT				2
 #define OVERLAP_DETECT_INT_EN_SHIFT			1
 #define FAILED_ACCESS_INT_EN_SHIFT			0
-#define PMU_REQ_INT_EN_MASK				0x1
-#define OVERLAP_DETECT_INT_EN_MASK			0x1
-#define FAILED_ACCESS_INT_EN_MASK			0x1
-#define PMU_REQ_INT_EN					0x1
-#define OVERLAP_DETECT_INT_EN				0x1
-#define FAILED_ACCESS_INT_EN				0x1
+#define PMU_REQ_INT_EN_MASK				U(0x1)
+#define OVERLAP_DETECT_INT_EN_MASK			U(0x1)
+#define FAILED_ACCESS_INT_EN_MASK			U(0x1)
+#define PMU_REQ_INT_EN					U(0x1)
+#define OVERLAP_DETECT_INT_EN				U(0x1)
+#define FAILED_ACCESS_INT_EN				U(0x1)
 
 /* Bit positions of SIx_SI_INT_CLR */
 #define PMU_REQ_OFLOW_CLR_SHIFT				18
 #define FAILED_ACCESS_OFLOW_CLR_SHIFT			16
 #define PMU_REQ_INT_CLR_SHIFT				2
 #define FAILED_ACCESS_INT_CLR_SHIFT			0
-#define PMU_REQ_OFLOW_CLR_MASK				0x1
-#define FAILED_ACCESS_OFLOW_CLR_MASK			0x1
-#define PMU_REQ_INT_CLR_MASK				0x1
-#define FAILED_ACCESS_INT_CLR_MASK			0x1
-#define PMU_REQ_OFLOW_CLR				0x1
-#define FAILED_ACCESS_OFLOW_CLR				0x1
-#define PMU_REQ_INT_CLR					0x1
-#define FAILED_ACCESS_INT_CLR				0x1
+#define PMU_REQ_OFLOW_CLR_MASK				U(0x1)
+#define FAILED_ACCESS_OFLOW_CLR_MASK			U(0x1)
+#define PMU_REQ_INT_CLR_MASK				U(0x1)
+#define FAILED_ACCESS_INT_CLR_MASK			U(0x1)
+#define PMU_REQ_OFLOW_CLR				U(0x1)
+#define FAILED_ACCESS_OFLOW_CLR				U(0x1)
+#define PMU_REQ_INT_CLR					U(0x1)
+#define FAILED_ACCESS_INT_CLR				U(0x1)
 
 /* Macro to get the correct base register for a system interface */
 #define IFACE_OFFSET(sys_if)	((sys_if) ? SI1_BASE : SI0_BASE)
 
-#define MAX_SYS_IF_COUNT				2
+#define MAX_SYS_IF_COUNT				U(2)
 #define MAX_REGION_VAL					8
 
 /* DMC-500 supports striping across a max of 4 DMC instances */
 #define MAX_DMC_COUNT					4
 
 /* Consist of part_number_1 and part_number_0 */
-#define DMC500_PERIPHERAL_ID				0x0450
+#define DMC500_PERIPHERAL_ID				U(0x0450)
 
 /* Filter enable bits in a TZC */
-#define TZC_DMC500_REGION_ATTR_F_EN_MASK		0x1
+#define TZC_DMC500_REGION_ATTR_F_EN_MASK		U(0x1)
 
 /* Length of registers for configuring each region */
-#define TZC_DMC500_REGION_SIZE				0x018
+#define TZC_DMC500_REGION_SIZE				U(0x018)
 
 #ifndef __ASSEMBLY__
 
@@ -134,18 +135,17 @@ typedef struct tzc_dmc500_driver_data {
 } tzc_dmc500_driver_data_t;
 
 void tzc_dmc500_driver_init(const tzc_dmc500_driver_data_t *plat_driver_data);
-void tzc_dmc500_configure_region0(tzc_region_attributes_t sec_attr,
+void tzc_dmc500_configure_region0(unsigned int sec_attr,
 				unsigned int nsaid_permissions);
-void tzc_dmc500_configure_region(int region_no,
+void tzc_dmc500_configure_region(unsigned int region_no,
 				unsigned long long region_base,
 				unsigned long long region_top,
-				tzc_region_attributes_t sec_attr,
+				unsigned int sec_attr,
 				unsigned int nsaid_permissions);
-void tzc_dmc500_set_action(tzc_action_t action);
+void tzc_dmc500_set_action(unsigned int action);
 void tzc_dmc500_config_complete(void);
 int tzc_dmc500_verify_complete(void);
 
 
 #endif /* __ASSEMBLY__ */
-#endif /* __TZC_DMC500_H__ */
-
+#endif /* TZC_DMC500_H */

--- a/include/plat/arm/common/arm_def.h
+++ b/include/plat/arm/common/arm_def.h
@@ -53,9 +53,9 @@
 #define ARM_DRAM_ID			2
 
 /* The first 4KB of Trusted SRAM are used as shared memory */
-#define ARM_TRUSTED_SRAM_BASE		0x04000000
+#define ARM_TRUSTED_SRAM_BASE		UL(0x04000000)
 #define ARM_SHARED_RAM_BASE		ARM_TRUSTED_SRAM_BASE
-#define ARM_SHARED_RAM_SIZE		0x00001000	/* 4 KB */
+#define ARM_SHARED_RAM_SIZE		UL(0x00001000)	/* 4 KB */
 
 /* The remaining Trusted SRAM is used to load the BL images */
 #define ARM_BL_RAM_BASE			(ARM_SHARED_RAM_BASE +	\
@@ -68,7 +68,7 @@
  *   - SCP TZC DRAM: If present, DRAM reserved for SCP use
  *   - AP TZC DRAM: The remaining TZC secured DRAM reserved for AP use
  */
-#define ARM_TZC_DRAM1_SIZE		ULL(0x01000000)
+#define ARM_TZC_DRAM1_SIZE		UL(0x01000000)
 
 #define ARM_SCP_TZC_DRAM1_BASE		(ARM_DRAM1_BASE +		\
 					 ARM_DRAM1_SIZE -		\
@@ -84,7 +84,7 @@
  * placed here.
  */
 #define ARM_EL3_TZC_DRAM1_BASE		(ARM_SCP_TZC_DRAM1_BASE - ARM_EL3_TZC_DRAM1_SIZE)
-#define ARM_EL3_TZC_DRAM1_SIZE		ULL(0x00200000) /* 2 MB */
+#define ARM_EL3_TZC_DRAM1_SIZE		UL(0x00200000) /* 2 MB */
 #define ARM_EL3_TZC_DRAM1_END		(ARM_EL3_TZC_DRAM1_BASE +	\
 					ARM_EL3_TZC_DRAM1_SIZE - 1)
 
@@ -122,7 +122,7 @@
 #define ARM_OPTEE_PAGEABLE_LOAD_BASE	(ARM_AP_TZC_DRAM1_BASE + \
 					 ARM_AP_TZC_DRAM1_SIZE - \
 					 ARM_OPTEE_PAGEABLE_LOAD_SIZE)
-#define ARM_OPTEE_PAGEABLE_LOAD_SIZE	0x400000
+#define ARM_OPTEE_PAGEABLE_LOAD_SIZE	UL(0x400000)
 #define ARM_OPTEE_PAGEABLE_LOAD_MEM	MAP_REGION_FLAT(		\
 					ARM_OPTEE_PAGEABLE_LOAD_BASE,	\
 					ARM_OPTEE_PAGEABLE_LOAD_SIZE,	\
@@ -144,12 +144,12 @@
 #define ARM_NS_DRAM1_END		(ARM_NS_DRAM1_BASE +		\
 					 ARM_NS_DRAM1_SIZE - 1)
 
-#define ARM_DRAM1_BASE			ULL(0x80000000)
-#define ARM_DRAM1_SIZE			ULL(0x80000000)
+#define ARM_DRAM1_BASE			UL(0x80000000)
+#define ARM_DRAM1_SIZE			UL(0x80000000)
 #define ARM_DRAM1_END			(ARM_DRAM1_BASE +		\
 					 ARM_DRAM1_SIZE - 1)
 
-#define ARM_DRAM2_BASE			ULL(0x880000000)
+#define ARM_DRAM2_BASE			UL(0x880000000)
 #define ARM_DRAM2_SIZE			PLAT_ARM_DRAM2_SIZE
 #define ARM_DRAM2_END			(ARM_DRAM2_BASE +		\
 					 ARM_DRAM2_SIZE - 1)
@@ -293,16 +293,16 @@
 					 ARM_BL_REGIONS)
 
 /* Memory mapped Generic timer interfaces  */
-#define ARM_SYS_CNTCTL_BASE		0x2a430000
-#define ARM_SYS_CNTREAD_BASE		0x2a800000
-#define ARM_SYS_TIMCTL_BASE		0x2a810000
-#define ARM_SYS_CNT_BASE_S		0x2a820000
-#define ARM_SYS_CNT_BASE_NS		0x2a830000
+#define ARM_SYS_CNTCTL_BASE		UL(0x2a430000)
+#define ARM_SYS_CNTREAD_BASE		UL(0x2a800000)
+#define ARM_SYS_TIMCTL_BASE		UL(0x2a810000)
+#define ARM_SYS_CNT_BASE_S		UL(0x2a820000)
+#define ARM_SYS_CNT_BASE_NS		UL(0x2a830000)
 
 #define ARM_CONSOLE_BAUDRATE		115200
 
 /* Trusted Watchdog constants */
-#define ARM_SP805_TWDG_BASE		0x2a490000
+#define ARM_SP805_TWDG_BASE		UL(0x2a490000)
 #define ARM_SP805_TWDG_CLK_HZ		32768
 /* The TBBR document specifies a watchdog timeout of 256 seconds. SP805
  * asserts reset after two consecutive countdowns (2 x 128 = 256 sec) */
@@ -344,7 +344,7 @@
  * This is known only to the platform as it might have a combination of
  * integrated and external caches.
  */
-#define CACHE_WRITEBACK_GRANULE		(1 << ARM_CACHE_WRITEBACK_SHIFT)
+#define CACHE_WRITEBACK_GRANULE		(U(1) << ARM_CACHE_WRITEBACK_SHIFT)
 
 /*
  * To enable TB_FW_CONFIG to be loaded by BL1, define the corresponding base

--- a/include/plat/arm/common/plat_arm.h
+++ b/include/plat/arm/common/plat_arm.h
@@ -25,7 +25,7 @@ struct bl_params;
 typedef struct arm_tzc_regions_info {
 	unsigned long long base;
 	unsigned long long end;
-	tzc_region_attributes_t sec_attr;
+	unsigned int sec_attr;
 	unsigned int nsaid_permissions;
 } arm_tzc_regions_info_t;
 

--- a/plat/arm/common/arm_tzc400.c
+++ b/plat/arm/common/arm_tzc400.c
@@ -24,7 +24,7 @@
 void arm_tzc400_setup(const arm_tzc_regions_info_t *tzc_regions)
 {
 #ifndef EL3_PAYLOAD_BASE
-	int region_index = 1;
+	unsigned int region_index = 1U;
 	const arm_tzc_regions_info_t *p;
 	const arm_tzc_regions_info_t init_tzc_regions[] = {
 		ARM_TZC_REGIONS_DEF,
@@ -55,7 +55,7 @@ void arm_tzc400_setup(const arm_tzc_regions_info_t *tzc_regions)
 		region_index++;
 	}
 
-	INFO("Total %d regions set.\n", region_index);
+	INFO("Total %u regions set.\n", region_index);
 
 #else /* if defined(EL3_PAYLOAD_BASE) */
 

--- a/plat/arm/common/arm_tzc_dmc500.c
+++ b/plat/arm/common/arm_tzc_dmc500.c
@@ -20,7 +20,7 @@ void arm_tzc_dmc500_setup(tzc_dmc500_driver_data_t *plat_driver_data,
 			const arm_tzc_regions_info_t *tzc_regions)
 {
 #ifndef EL3_PAYLOAD_BASE
-	int region_index = 1;
+	unsigned int region_index = 1U;
 	const arm_tzc_regions_info_t *p;
 	const arm_tzc_regions_info_t init_tzc_regions[] = {
 		ARM_TZC_REGIONS_DEF,
@@ -50,7 +50,7 @@ void arm_tzc_dmc500_setup(tzc_dmc500_driver_data_t *plat_driver_data,
 		region_index++;
 	}
 
-	INFO("Total %d regions set.\n", region_index);
+	INFO("Total %u regions set.\n", region_index);
 
 #else
 	/* Allow secure access only to DRAM for EL3 payloads */


### PR DESCRIPTION
The definitions FAIL_CONTROL_*_SHIFT were incorrect, they have been fixed.

The types tzc_region_attributes_t and tzc_action_t have been removed and replaced by unsigned int because it is not allowed to do logical operations on enums.

Also, fix some address definitions in arm_def.h.