### PR TITLE
 Deprecate weak crash console functions 

### DIFF
--- a/plat/arm/common/aarch64/arm_helpers.S
+++ b/plat/arm/common/aarch64/arm_helpers.S
@@ -8,9 +8,9 @@
 
 	.weak	plat_arm_calc_core_pos
 	.weak	plat_my_core_pos
-	.weak	plat_crash_console_init
-	.weak	plat_crash_console_putc
-	.weak	plat_crash_console_flush
+	.globl	plat_crash_console_init
+	.globl	plat_crash_console_putc
+	.globl	plat_crash_console_flush
 	.globl	platform_mem_init
 
 

--- a/plat/common/aarch32/crash_console_helpers.S
+++ b/plat/common/aarch32/crash_console_helpers.S
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * If a platform wishes to use the functions in this file it has to be added to
+ * the Makefile of the platform. It is not included in the common Makefile.
+ */
+
+#include <asm_macros.S>
+#include <console.h>
+
+	.globl	plat_crash_console_init
+	.globl	plat_crash_console_putc
+	.globl	plat_crash_console_flush
+
+#if MULTI_CONSOLE_API
+
+	/* -----------------------------------------------------
+	 * int plat_crash_console_init(void)
+	 * Use normal console by default. Switch it to crash
+	 * mode so serial consoles become active again.
+	 * NOTE: This default implementation will only work for
+	 * crashes that occur after a normal console (marked
+	 * valid for the crash state) has been registered with
+	 * the console framework. To debug crashes that occur
+	 * earlier, the platform has to override these functions
+	 * with an implementation that initializes a console
+	 * driver with hardcoded parameters. See
+	 * docs/porting-guide.rst for more information.
+	 * -----------------------------------------------------
+	 */
+func plat_crash_console_init
+#if defined(IMAGE_BL1)
+	/*
+	 * BL1 code can possibly crash so early that the data segment is not yet
+	 * accessible. Don't risk undefined behavior by trying to run the normal
+	 * console framework. Platforms that want to debug BL1 will need to
+	 * override this with custom functions that can run from registers only.
+	 */
+	mov	r0, #0
+	bx	lr
+#else	/* IMAGE_BL1 */
+	mov	r3, lr
+	mov	r0, #CONSOLE_FLAG_CRASH
+	bl	console_switch_state
+	mov	r0, #1
+	bx	r3
+#endif
+endfunc plat_crash_console_init
+
+	/* -----------------------------------------------------
+	 * void plat_crash_console_putc(int character)
+	 * Output through the normal console by default.
+	 * -----------------------------------------------------
+	 */
+func plat_crash_console_putc
+	b	console_putc
+endfunc plat_crash_console_putc
+
+	/* -----------------------------------------------------
+	 * void plat_crash_console_flush(void)
+	 * Flush normal console by default.
+	 * -----------------------------------------------------
+	 */
+func plat_crash_console_flush
+	b	console_flush
+endfunc plat_crash_console_flush
+
+#else	/* MULTI_CONSOLE_API */
+
+	/* -----------------------------------------------------
+	 * In the old API these are all no-op stubs that need to
+	 * be overridden by the platform to be useful.
+	 * -----------------------------------------------------
+	 */
+func plat_crash_console_init
+	mov	r0, #0
+	bx	lr
+endfunc plat_crash_console_init
+
+func plat_crash_console_putc
+	bx	lr
+endfunc plat_crash_console_putc
+
+func plat_crash_console_flush
+	bx	lr
+endfunc plat_crash_console_flush
+
+#endif

--- a/plat/common/aarch32/platform_helpers.S
+++ b/plat/common/aarch32/platform_helpers.S
@@ -8,9 +8,11 @@
 #include <asm_macros.S>
 
 	.weak	plat_report_exception
+#if !ERROR_DEPRECATED
 	.weak	plat_crash_console_init
 	.weak	plat_crash_console_putc
 	.weak	plat_crash_console_flush
+#endif
 	.weak	plat_reset_handler
 	.weak	plat_disable_acp
 	.weak	bl1_plat_prepare_exit
@@ -26,6 +28,7 @@ func plat_report_exception
 	bx	lr
 endfunc plat_report_exception
 
+#if !ERROR_DEPRECATED
 	/* -----------------------------------------------------
 	 * Placeholder function which should be redefined by
 	 * each platform.
@@ -54,6 +57,7 @@ func plat_crash_console_flush
 	mov	r0, #0
 	bx	lr
 endfunc plat_crash_console_flush
+#endif
 
 	/* -----------------------------------------------------
 	 * Placeholder function which should be redefined by

--- a/plat/common/aarch64/crash_console_helpers.S
+++ b/plat/common/aarch64/crash_console_helpers.S
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/*
+ * If a platform wishes to use the functions in this file it has to be added to
+ * the Makefile of the platform. It is not included in the common Makefile.
+ */
+
+#include <asm_macros.S>
+#include <console.h>
+
+	.globl	plat_crash_console_init
+	.globl	plat_crash_console_putc
+	.globl	plat_crash_console_flush
+
+#if MULTI_CONSOLE_API
+
+	/* -----------------------------------------------------
+	 * int plat_crash_console_init(void)
+	 * Use normal console by default. Switch it to crash
+	 * mode so serial consoles become active again.
+	 * NOTE: This default implementation will only work for
+	 * crashes that occur after a normal console (marked
+	 * valid for the crash state) has been registered with
+	 * the console framework. To debug crashes that occur
+	 * earlier, the platform has to override these functions
+	 * with an implementation that initializes a console
+	 * driver with hardcoded parameters. See
+	 * docs/porting-guide.rst for more information.
+	 * -----------------------------------------------------
+	 */
+func plat_crash_console_init
+#if defined(IMAGE_BL1)
+	/*
+	 * BL1 code can possibly crash so early that the data segment is not yet
+	 * accessible. Don't risk undefined behavior by trying to run the normal
+	 * console framework. Platforms that want to debug BL1 will need to
+	 * override this with custom functions that can run from registers only.
+	 */
+	mov	x0, #0
+	ret
+#else	/* IMAGE_BL1 */
+	mov	x3, x30
+	mov	x0, #CONSOLE_FLAG_CRASH
+	bl	console_switch_state
+	mov	x0, #1
+	ret	x3
+#endif
+endfunc plat_crash_console_init
+
+	/* -----------------------------------------------------
+	 * void plat_crash_console_putc(int character)
+	 * Output through the normal console by default.
+	 * -----------------------------------------------------
+	 */
+func plat_crash_console_putc
+	b	console_putc
+endfunc plat_crash_console_putc
+
+	/* -----------------------------------------------------
+	 * void plat_crash_console_flush(void)
+	 * Flush normal console by default.
+	 * -----------------------------------------------------
+	 */
+func plat_crash_console_flush
+	b	console_flush
+endfunc plat_crash_console_flush
+
+#else	/* MULTI_CONSOLE_API */
+
+	/* -----------------------------------------------------
+	 * In the old API these are all no-op stubs that need to
+	 * be overridden by the platform to be useful.
+	 * -----------------------------------------------------
+	 */
+func plat_crash_console_init
+	mov	x0, #0
+	ret
+endfunc plat_crash_console_init
+
+func plat_crash_console_putc
+	ret
+endfunc plat_crash_console_putc
+
+func plat_crash_console_flush
+	ret
+endfunc plat_crash_console_flush
+
+#endif

--- a/plat/common/aarch64/platform_helpers.S
+++ b/plat/common/aarch64/platform_helpers.S
@@ -10,9 +10,11 @@
 #include <platform_def.h>
 
 	.weak	plat_report_exception
+#if !ERROR_DEPRECATED
 	.weak	plat_crash_console_init
 	.weak	plat_crash_console_putc
 	.weak	plat_crash_console_flush
+#endif
 	.weak	plat_reset_handler
 	.weak	plat_disable_acp
 	.weak	bl1_plat_prepare_exit
@@ -37,6 +39,7 @@ func plat_report_exception
 	ret
 endfunc plat_report_exception
 
+#if !ERROR_DEPRECATED
 #if MULTI_CONSOLE_API
 	/* -----------------------------------------------------
 	 * int plat_crash_console_init(void)
@@ -109,6 +112,7 @@ func plat_crash_console_flush
 	ret
 endfunc plat_crash_console_flush
 #endif
+#endif /* ERROR_DEPRECATED */
 
 	/* -----------------------------------------------------
 	 * Placeholder function which should be redefined by

--- a/plat/hisilicon/hikey/aarch64/hikey_helpers.S
+++ b/plat/hisilicon/hikey/aarch64/hikey_helpers.S
@@ -12,6 +12,7 @@
 	.globl	platform_mem_init
 	.globl	plat_crash_console_init
 	.globl	plat_crash_console_putc
+	.globl	plat_crash_console_flush
 	.globl	plat_report_exception
 	.globl	plat_reset_handler
 
@@ -59,6 +60,19 @@ func plat_crash_console_putc
 	mov_imm	x1, CRASH_CONSOLE_BASE
 	b	console_core_putc
 endfunc plat_crash_console_putc
+
+	/* ---------------------------------------------
+	 * int plat_crash_console_flush()
+	 * Function to force a write of all buffered
+	 * data that hasn't been output.
+	 * Out : return -1 on error else return 0.
+	 * Clobber list : x0, x1
+	 * ---------------------------------------------
+	 */
+func plat_crash_console_flush
+	mov_imm	x0, CRASH_CONSOLE_BASE
+	b	console_core_flush
+endfunc plat_crash_console_flush
 
 	/* ---------------------------------------------
 	 * void plat_report_exception(unsigned int type)

--- a/plat/hisilicon/hikey960/aarch64/hikey960_helpers.S
+++ b/plat/hisilicon/hikey960/aarch64/hikey960_helpers.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -14,6 +14,7 @@
 	.globl	platform_mem_init
 	.globl	plat_crash_console_init
 	.globl	plat_crash_console_putc
+	.globl	plat_crash_console_flush
 	.globl	plat_report_exception
 	.globl	plat_reset_handler
 	.globl	clr_ex
@@ -63,6 +64,19 @@ func plat_crash_console_putc
 	mov_imm	x1, CRASH_CONSOLE_BASE
 	b	console_core_putc
 endfunc plat_crash_console_putc
+
+	/* ---------------------------------------------
+	 * int plat_crash_console_flush()
+	 * Function to force a write of all buffered
+	 * data that hasn't been output.
+	 * Out : return -1 on error else return 0.
+	 * Clobber list : x0, x1
+	 * ---------------------------------------------
+	 */
+func plat_crash_console_flush
+	mov_imm	x0, CRASH_CONSOLE_BASE
+	b	console_core_flush
+endfunc plat_crash_console_flush
 
 	/* ---------------------------------------------
 	 * void plat_report_exception(unsigned int type)

--- a/plat/imx/common/imx8_helpers.S
+++ b/plat/imx/common/imx8_helpers.S
@@ -16,6 +16,7 @@
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_crash_console_init
 	.globl	plat_crash_console_putc
+	.globl	plat_crash_console_flush
 	.globl	platform_mem_init
 	.globl  imx_mailbox_init
 
@@ -106,12 +107,18 @@ func plat_secondary_cold_boot_setup
 endfunc plat_secondary_cold_boot_setup
 
 func plat_crash_console_init
+	mov	x0, #1
 	ret
 endfunc plat_crash_console_init
 
 func plat_crash_console_putc
 	ret
 endfunc plat_crash_console_putc
+
+func plat_crash_console_flush
+	mov	x0, #0
+	ret
+endfunc plat_crash_console_flush
 
 func platform_mem_init
 	ret

--- a/plat/imx/imx7/warp7/aarch32/warp7_helpers.S
+++ b/plat/imx/imx7/warp7/aarch32/warp7_helpers.S
@@ -14,6 +14,7 @@
 	.globl	plat_get_my_entrypoint
 	.globl	plat_crash_console_init
 	.globl	plat_crash_console_putc
+	.globl	plat_crash_console_flush
 	.globl	plat_panic_handler
 
 	/* ---------------------------------------------
@@ -44,6 +45,12 @@ func plat_crash_console_putc
 	mov_imm r1, PLAT_WARP7_BOOT_UART_BASE
 	b	imx_crash_uart_putc
 endfunc plat_crash_console_putc
+
+func plat_crash_console_flush
+	/* Placeholder */
+	mov	r0, #0
+	bx	lr
+endfunc plat_crash_console_flush
 
 func plat_panic_handler
 	mov	r3, #HAB_ROM_VECTOR_TABLE_FAILSAFE

--- a/plat/marvell/common/aarch64/marvell_helpers.S
+++ b/plat/marvell/common/aarch64/marvell_helpers.S
@@ -18,6 +18,7 @@
 	.weak	plat_my_core_pos
 	.globl	plat_crash_console_init
 	.globl	plat_crash_console_putc
+	.globl	plat_crash_console_flush
 	.globl	platform_mem_init
 	.globl	disable_mmu_dcache
 	.globl	invalidate_tlb_all
@@ -78,6 +79,19 @@ func plat_crash_console_putc
 	mov_imm	x1, PLAT_MARVELL_CRASH_UART_BASE
 	b	console_core_putc
 endfunc plat_crash_console_putc
+
+	/* ---------------------------------------------
+	 * int plat_crash_console_flush()
+	 * Function to force a write of all buffered
+	 * data that hasn't been output.
+	 * Out : return -1 on error else return 0.
+	 * Clobber list : x0, x1
+	 * ---------------------------------------------
+	 */
+func plat_crash_console_flush
+	mov_imm	x0, PLAT_MARVELL_CRASH_UART_BASE
+	b	console_core_flush
+endfunc plat_crash_console_flush
 
 	/* ---------------------------------------------------------------------
 	 * We don't need to carry out any memory initialization on ARM

--- a/plat/nvidia/tegra/common/aarch64/tegra_helpers.S
+++ b/plat/nvidia/tegra/common/aarch64/tegra_helpers.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -36,6 +36,7 @@
 	.globl	platform_mem_init
 	.globl	plat_crash_console_init
 	.globl	plat_crash_console_putc
+	.globl	plat_crash_console_flush
 	.globl	tegra_secure_entrypoint
 	.globl	plat_reset_handler
 
@@ -239,6 +240,20 @@ func plat_crash_console_putc
 	ldr	x1, [x1]
 	b	console_core_putc
 endfunc plat_crash_console_putc
+
+	/* ---------------------------------------------
+	 * int plat_crash_console_flush()
+	 * Function to force a write of all buffered
+	 * data that hasn't been output.
+	 * Out : return -1 on error else return 0.
+	 * Clobber list : x0, x1
+	 * ---------------------------------------------
+	 */
+func plat_crash_console_flush
+	adr	x0, tegra_console_base
+	ldr	x0, [x0]
+	b	console_core_flush
+endfunc plat_crash_console_flush
 
 	/* ---------------------------------------------------
 	 * Function to handle a platform reset and store

--- a/plat/rockchip/rk3328/platform.mk
+++ b/plat/rockchip/rk3328/platform.mk
@@ -29,6 +29,7 @@ RK_GIC_SOURCES		:=	drivers/arm/gic/common/gic_common.c		\
 
 PLAT_BL_COMMON_SOURCES	:=	lib/xlat_tables/aarch64/xlat_tables.c		\
 				lib/xlat_tables/xlat_tables_common.c		\
+				plat/common/aarch64/crash_console_helpers.S	\
 				plat/common/plat_psci_common.c
 
 BL31_SOURCES		+=	${RK_GIC_SOURCES}				\

--- a/plat/rockchip/rk3368/platform.mk
+++ b/plat/rockchip/rk3368/platform.mk
@@ -26,6 +26,7 @@ RK_GIC_SOURCES         :=	drivers/arm/gic/common/gic_common.c		\
 
 PLAT_BL_COMMON_SOURCES	:=	lib/xlat_tables/xlat_tables_common.c		\
 				lib/xlat_tables/aarch64/xlat_tables.c		\
+				plat/common/aarch64/crash_console_helpers.S	\
 				plat/common/plat_psci_common.c
 
 BL31_SOURCES		+=	${RK_GIC_SOURCES}				\

--- a/plat/rockchip/rk3399/platform.mk
+++ b/plat/rockchip/rk3399/platform.mk
@@ -32,6 +32,7 @@ RK_GIC_SOURCES		:=	drivers/arm/gic/common/gic_common.c	\
 
 PLAT_BL_COMMON_SOURCES	:=	lib/xlat_tables/xlat_tables_common.c	\
 				lib/xlat_tables/aarch64/xlat_tables.c	\
+				plat/common/aarch64/crash_console_helpers.S \
 				plat/common/plat_psci_common.c
 
 BL31_SOURCES	+=	${RK_GIC_SOURCES}				\

--- a/plat/ti/k3/common/k3_helpers.S
+++ b/plat/ti/k3/common/k3_helpers.S
@@ -100,13 +100,13 @@ endfunc plat_my_core_pos
 	 * Clobber list : x0 - x4
 	 * ---------------------------------------------
 	 */
+	.globl plat_crash_console_init
 func plat_crash_console_init
 	mov_imm	x0, CRASH_CONSOLE_BASE
 	mov_imm	x1, CRASH_CONSOLE_CLK
 	mov_imm	x2, CRASH_CONSOLE_BAUD_RATE
 	mov w3, #0x0
-	b	console_core_init
-
+	b	console_16550_core_init
 endfunc plat_crash_console_init
 
 	/* ---------------------------------------------
@@ -116,7 +116,22 @@ endfunc plat_crash_console_init
 	 * Clobber list : x1, x2
 	 * ---------------------------------------------
 	 */
+	.globl plat_crash_console_putc
 func plat_crash_console_putc
 	mov_imm	x1, CRASH_CONSOLE_BASE
-	b	console_core_putc
+	b	console_16550_core_putc
 endfunc plat_crash_console_putc
+
+	/* ---------------------------------------------
+	 * int plat_crash_console_flush()
+	 * Function to force a write of all buffered
+	 * data that hasn't been output.
+	 * Out : return -1 on error else return 0.
+	 * Clobber list : x0, x1
+	 * ---------------------------------------------
+	 */
+	.globl plat_crash_console_flush
+func plat_crash_console_flush
+	mov_imm	x0, CRASH_CONSOLE_BASE
+	b	console_16550_core_flush
+endfunc plat_crash_console_flush

--- a/plat/xilinx/zynqmp/aarch64/zynqmp_helpers.S
+++ b/plat/xilinx/zynqmp/aarch64/zynqmp_helpers.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,6 +10,12 @@
 
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_is_my_cpu_primary
+	.globl	zynqmp_calc_core_pos
+	.globl	plat_my_core_pos
+	.globl	plat_crash_console_init
+	.globl	plat_crash_console_putc
+	.globl	plat_crash_console_flush
+	.globl	platform_mem_init
 
 	/* -----------------------------------------------------
 	 * void plat_secondary_cold_boot_setup (void);
@@ -47,3 +53,76 @@ func plat_is_my_cpu_primary
 	cset	x0, eq
 	ret	x9
 endfunc plat_is_my_cpu_primary
+
+	/* -----------------------------------------------------
+	 *  unsigned int plat_my_core_pos(void)
+	 *  This function uses the zynqmp_calc_core_pos()
+	 *  definition to get the index of the calling CPU.
+	 * -----------------------------------------------------
+	 */
+func plat_my_core_pos
+	mrs	x0, mpidr_el1
+	b	zynqmp_calc_core_pos
+endfunc plat_my_core_pos
+
+	/* -----------------------------------------------------
+	 *  unsigned int zynqmp_calc_core_pos(u_register_t mpidr)
+	 *  Helper function to calculate the core position.
+	 *  With this function: CorePos = (ClusterId * 4) +
+	 *  				  CoreId
+	 * -----------------------------------------------------
+	 */
+func zynqmp_calc_core_pos
+	and	x1, x0, #MPIDR_CPU_MASK
+	and	x0, x0, #MPIDR_CLUSTER_MASK
+	add	x0, x1, x0, LSR #6
+	ret
+endfunc zynqmp_calc_core_pos
+
+	/* ---------------------------------------------
+	 * int plat_crash_console_init(void)
+	 * Function to initialize the crash console
+	 * without a C Runtime to print crash report.
+	 * Clobber list : x0 - x4
+	 * ---------------------------------------------
+	 */
+func plat_crash_console_init
+	mov_imm	x0, ZYNQMP_CRASH_UART_BASE
+	mov_imm	x1, ZYNQMP_CRASH_UART_CLK_IN_HZ
+	mov_imm	x2, ZYNQMP_UART_BAUDRATE
+	b	console_core_init
+endfunc plat_crash_console_init
+
+	/* ---------------------------------------------
+	 * int plat_crash_console_putc(int c)
+	 * Function to print a character on the crash
+	 * console without a C Runtime.
+	 * Clobber list : x1, x2
+	 * ---------------------------------------------
+	 */
+func plat_crash_console_putc
+	mov_imm	x1, ZYNQMP_CRASH_UART_BASE
+	b	console_core_putc
+endfunc plat_crash_console_putc
+
+	/* ---------------------------------------------
+	 * int plat_crash_console_flush()
+	 * Function to force a write of all buffered
+	 * data that hasn't been output.
+	 * Out : return -1 on error else return 0.
+	 * Clobber list : r0
+	 * ---------------------------------------------
+	 */
+func plat_crash_console_flush
+	mov_imm	x0, ZYNQMP_CRASH_UART_BASE
+	b	console_core_flush
+endfunc plat_crash_console_flush
+
+	/* ---------------------------------------------------------------------
+	 * We don't need to carry out any memory initialization on ARM
+	 * platforms. The Secure RAM is accessible straight away.
+	 * ---------------------------------------------------------------------
+	 */
+func platform_mem_init
+	ret
+endfunc platform_mem_init

--- a/plat/xilinx/zynqmp/plat_zynqmp.c
+++ b/plat/xilinx/zynqmp/plat_zynqmp.c
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2015-2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <plat_arm.h>
+#include <platform.h>
+#include "zynqmp_private.h"
 
 int plat_core_pos_by_mpidr(u_register_t mpidr)
 {
@@ -14,5 +15,5 @@ int plat_core_pos_by_mpidr(u_register_t mpidr)
 	if ((mpidr & MPIDR_CPU_MASK) >= PLATFORM_CORE_COUNT)
 		return -1;
 
-	return plat_arm_calc_core_pos(mpidr);
+	return zynqmp_calc_core_pos(mpidr);
 }

--- a/plat/xilinx/zynqmp/platform.mk
+++ b/plat/xilinx/zynqmp/platform.mk
@@ -64,7 +64,6 @@ PLAT_BL_COMMON_SOURCES	:=	lib/xlat_tables/xlat_tables_common.c		\
 				drivers/arm/gic/v2/gicv2_helpers.c		\
 				drivers/cadence/uart/aarch64/cdns_console.S	\
 				drivers/console/aarch64/console.S		\
-				plat/arm/common/aarch64/arm_helpers.S		\
 				plat/arm/common/arm_cci.c			\
 				plat/arm/common/arm_common.c			\
 				plat/arm/common/arm_gicv2.c			\

--- a/plat/xilinx/zynqmp/zynqmp_def.h
+++ b/plat/xilinx/zynqmp/zynqmp_def.h
@@ -145,13 +145,11 @@
 # error "invalid ZYNQMP_CONSOLE"
 #endif
 
-#define PLAT_ARM_CRASH_UART_BASE	ZYNQMP_UART_BASE
+#define ZYNQMP_CRASH_UART_BASE		ZYNQMP_UART_BASE
 /* impossible to call C routine how it is done now - hardcode any value */
-#define	PLAT_ARM_CRASH_UART_CLK_IN_HZ	100000000 /* FIXME */
-
+#define ZYNQMP_CRASH_UART_CLK_IN_HZ	100000000 /* FIXME */
 /* Must be non zero */
-#define ZYNQMP_UART_BAUDRATE	115200
-#define ARM_CONSOLE_BAUDRATE	ZYNQMP_UART_BAUDRATE
+#define ZYNQMP_UART_BAUDRATE		115200
 
 /* Silicon version detection */
 #define ZYNQMP_SILICON_VER_MASK		0xF000

--- a/plat/xilinx/zynqmp/zynqmp_private.h
+++ b/plat/xilinx/zynqmp/zynqmp_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2018, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -9,8 +9,11 @@
 
 #include <bl_common.h>
 #include <interrupt_mgmt.h>
+#include <stdint.h>
 
 void zynqmp_config_setup(void);
+
+unsigned int zynqmp_calc_core_pos(u_register_t mpidr);
 
 /* ZynqMP specific functions */
 unsigned int zynqmp_get_uart_clk(void);


### PR DESCRIPTION
The default behaviour of the plat_crash_console_xxx functions isn't obvious to someone that hasn't read all the documentation. As they are not mandatory, it is unlikely that the code will be checked when doing a platform port, which may mean that some platforms may not have crash console support at all.

The idea of this patch is to force platform maintainers to decide how the crash console has to behave so that the final behaviour isn't unexpected.

This PR also fixes all upstream platforms that need it.