### PR TITLE
plat/arm/scmi: introduce plat_css_get_scmi_info API

### DIFF
--- a/plat/arm/board/juno/juno_topology.c
+++ b/plat/arm/board/juno/juno_topology.c
@@ -9,6 +9,21 @@
 #include <plat_arm.h>
 #include <platform.h>
 #include "juno_def.h"
+#include "../../css/drivers/scmi/scmi.h"
+#include "../../css/drivers/mhu/css_mhu_doorbell.h"
+
+static scmi_channel_plat_info_t juno_scmi_plat_info = {
+		.scmi_mbx_mem = CSS_SCMI_PAYLOAD_BASE,
+		.db_reg_addr = PLAT_CSS_MHU_BASE + CSS_SCMI_MHU_DB_REG_OFF,
+		.db_preserve_mask = 0xfffffffe,
+		.db_modify_mask = 0x1,
+		.ring_doorbell = &mhu_ring_doorbell,
+};
+
+scmi_channel_plat_info_t *plat_css_get_scmi_info()
+{
+	return &juno_scmi_plat_info;
+}
 
 /*
  * On Juno, the system power level is the highest power level.

--- a/plat/arm/css/drivers/scmi/scmi.h
+++ b/plat/arm/css/drivers/scmi/scmi.h
@@ -159,4 +159,7 @@ int scmi_sys_pwr_state_get(void *p, uint32_t *system_state);
 int scmi_ap_core_set_reset_addr(void *p, uint64_t reset_addr, uint32_t attr);
 int scmi_ap_core_get_reset_addr(void *p, uint64_t *reset_addr, uint32_t *attr);
 
+/* API to get the platform specific SCMI channel information. */
+scmi_channel_plat_info_t *plat_css_get_scmi_info();
+
 #endif	/* __CSS_SCMI_H__ */

--- a/plat/arm/css/drivers/scp/css_pm_scmi.c
+++ b/plat/arm/css/drivers/scp/css_pm_scmi.c
@@ -13,7 +13,6 @@
 #include <platform.h>
 #include <string.h>
 #include "../scmi/scmi.h"
-#include "../mhu/css_mhu_doorbell.h"
 #include "css_scp.h"
 
 /*
@@ -298,14 +297,6 @@ void __dead2 css_scp_sys_reboot(void)
 	css_scp_system_off(SCMI_SYS_PWR_COLD_RESET);
 }
 
-static scmi_channel_plat_info_t plat_css_scmi_plat_info = {
-		.scmi_mbx_mem = CSS_SCMI_PAYLOAD_BASE,
-		.db_reg_addr = PLAT_CSS_MHU_BASE + CSS_SCMI_MHU_DB_REG_OFF,
-		.db_preserve_mask = 0xfffffffe,
-		.db_modify_mask = 0x1,
-		.ring_doorbell = &mhu_ring_doorbell,
-};
-
 static int scmi_ap_core_init(scmi_channel_t *ch)
 {
 #if PROGRAMMABLE_RESET_ADDRESS
@@ -330,7 +321,7 @@ static int scmi_ap_core_init(scmi_channel_t *ch)
 
 void __init plat_arm_pwrc_setup(void)
 {
-	channel.info = &plat_css_scmi_plat_info;
+	channel.info = plat_css_get_scmi_info();
 	channel.lock = ARM_SCMI_LOCK_GET_INSTANCE;
 	scmi_handle = scmi_init(&channel);
 	if (scmi_handle == NULL) {

--- a/plat/arm/css/sgi/sgi_bl31_setup.c
+++ b/plat/arm/css/sgi/sgi_bl31_setup.c
@@ -9,6 +9,21 @@
 #include <plat_arm.h>
 #include <sgi_plat_config.h>
 #include <sgi_ras.h>
+#include "../../css/drivers/scmi/scmi.h"
+#include "../../css/drivers/mhu/css_mhu_doorbell.h"
+
+static scmi_channel_plat_info_t sgi575_scmi_plat_info = {
+		.scmi_mbx_mem = CSS_SCMI_PAYLOAD_BASE,
+		.db_reg_addr = PLAT_CSS_MHU_BASE + CSS_SCMI_MHU_DB_REG_OFF,
+		.db_preserve_mask = 0xfffffffe,
+		.db_modify_mask = 0x1,
+		.ring_doorbell = &mhu_ring_doorbell,
+};
+
+scmi_channel_plat_info_t *plat_css_get_scmi_info()
+{
+	return &sgi575_scmi_plat_info;
+}
 
 void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 				u_register_t arg2, u_register_t arg3)

--- a/plat/arm/css/sgm/sgm_bl31_setup.c
+++ b/plat/arm/css/sgm/sgm_bl31_setup.c
@@ -8,6 +8,21 @@
 #include <debug.h>
 #include <plat_arm.h>
 #include <sgm_plat_config.h>
+#include "../../css/drivers/scmi/scmi.h"
+#include "../../css/drivers/mhu/css_mhu_doorbell.h"
+
+static scmi_channel_plat_info_t sgm775_scmi_plat_info = {
+		.scmi_mbx_mem = CSS_SCMI_PAYLOAD_BASE,
+		.db_reg_addr = PLAT_CSS_MHU_BASE + CSS_SCMI_MHU_DB_REG_OFF,
+		.db_preserve_mask = 0xfffffffe,
+		.db_modify_mask = 0x1,
+		.ring_doorbell = &mhu_ring_doorbell,
+};
+
+scmi_channel_plat_info_t *plat_css_get_scmi_info()
+{
+	return &sgm775_scmi_plat_info;
+}
 
 void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 				u_register_t arg2, u_register_t arg3)


### PR DESCRIPTION
The default values of 'plat_css_scmi_plat_info' is not applicable for
all the platforms. There should be a provision to let platform code to
register a platform specific instance of scmi_channel_plat_info_t.

Add a new API 'plat_css_get_scmi_info' which lets the platform to
register a platform specific instance of scmi_channel_plat_info_t and
remove the default values.

In addition to this, the existing 'plat_css_scmi_plat_info' structure
is removed from the common code and instantiated for the platforms that
need it. This allows for a consistent provisioning of the SCMI channel
information across all the existing and upcoming platforms.

Change-Id: I4fb65d7f2f165b78697b4677f1e8d81edebeac06
Signed-off-by: Chandni Cherukuri <chandni.cherukuri@arm.com>