### PR TITLE
AArch64: Enable lower ELs to use pointer authentication

### DIFF
--- a/docs/firmware-design.rst
+++ b/docs/firmware-design.rst
@@ -2532,6 +2532,12 @@ This Architecture Extension is targeted when ``ARM_ARCH_MAJOR`` == 8 and
    translation table entries for a given stage of translation for a particular
    translation regime.
 
+Armv8.3-A
+~~~~~~~~~
+
+-  Pointer Authentication features of Armv8.3-A are unconditionally enabled so
+   that lower ELs are allowed to use them without causing a trap to EL3.
+
 Armv7-A
 ~~~~~~~
 

--- a/include/common/aarch64/el3_common_macros.S
+++ b/include/common/aarch64/el3_common_macros.S
@@ -70,9 +70,14 @@
 	 *
 	 * SCR_EL3.EA: Set to one to route External Aborts and SError Interrupts
 	 *  to EL3 when executing at any EL.
+	 *
+	 * SCR_EL3.{API,APK}: For Armv8.3 pointer authentication feature,
+	 * disable traps to EL3 when accessing key registers or using pointer
+	 * authentication instructions from lower ELs.
 	 * ---------------------------------------------------------------------
 	 */
-	mov	x0, #((SCR_RESET_VAL | SCR_EA_BIT | SCR_SIF_BIT) \
+	mov_imm	x0, ((SCR_RESET_VAL | SCR_EA_BIT | SCR_SIF_BIT | \
+				SCR_API_BIT | SCR_APK_BIT) \
 			& ~(SCR_TWE_BIT | SCR_TWI_BIT | SCR_SMD_BIT))
 	msr	scr_el3, x0
 

--- a/include/lib/aarch64/arch.h
+++ b/include/lib/aarch64/arch.h
@@ -218,6 +218,8 @@
 /* SCR definitions */
 #define SCR_RES1_BITS		((U(1) << 4) | (U(1) << 5))
 #define SCR_FIEN_BIT		(U(1) << 21)
+#define SCR_API_BIT		(U(1) << 17)
+#define SCR_APK_BIT		(U(1) << 16)
 #define SCR_TWE_BIT		(U(1) << 13)
 #define SCR_TWI_BIT		(U(1) << 12)
 #define SCR_ST_BIT		(U(1) << 11)
@@ -274,6 +276,8 @@
 #define VTTBR_BADDR_SHIFT	U(0)
 
 /* HCR definitions */
+#define HCR_API_BIT		(ULL(1) << 41)
+#define HCR_APK_BIT		(ULL(1) << 40)
 #define HCR_RW_SHIFT		U(31)
 #define HCR_RW_BIT		(ULL(1) << HCR_RW_SHIFT)
 #define HCR_AMO_BIT		(ULL(1) << 5)


### PR DESCRIPTION
Pointer authentication is an Armv8.3 feature that introduces
instructions that can be used to authenticate and verify pointers.

Pointer authentication instructions are allowed to be accessed from all
ELs but only when EL3 explicitly allows for it; otherwise, their usage
will trap to EL3. Since EL3 doesn't have trap handling in place, this
patch unconditionally disables all related traps to EL3 to avoid
potential misconfiguration leading to an unhandled EL3 exception.

Fixes ARM-software/tf-issues#629

Change-Id: I9bd2efe0dc714196f503713b721ffbf05672c14d
Signed-off-by: Jeenu Viswambharan <jeenu.viswambharan@arm.com>