### PR TITLE
Makefile: Fix verbose builds on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,12 +78,12 @@ ifeq (${V},0)
         CHECKCODE_ARGS	+=	--no-summary --terse
 else
         Q:=
-        ECHO:=@\#
+        ECHO:=$(ECHO_QUIET)
 endif
 
 ifneq ($(findstring s,$(filter-out --%,$(MAKEFLAGS))),)
         Q:=@
-        ECHO:=@\#
+        ECHO:=$(ECHO_QUIET)
 endif
 
 export Q ECHO

--- a/make_helpers/unix.mk
+++ b/make_helpers/unix.mk
@@ -1,8 +1,7 @@
 #
-# Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-#
 #
 
 # Trusted Firmware shell command definitions for a Unix style environment.
@@ -11,6 +10,7 @@ ifndef UNIX_MK
     UNIX_MK := $(lastword $(MAKEFILE_LIST))
 
     ECHO_BLANK_LINE := echo
+    ECHO_QUIET := @\#
 
     DIR_DELIM := /
     PATH_SEP := :

--- a/make_helpers/windows.mk
+++ b/make_helpers/windows.mk
@@ -1,8 +1,7 @@
 #
-# Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
-#
 #
 
 # OS specific parts for builds in a Windows_NT environment. The
@@ -14,6 +13,7 @@ ifndef WINDOWS_MK
     WINDOWS_MK := $(lastword $(MAKEFILE_LIST))
 
     ECHO_BLANK_LINE := @cmd /c echo.
+    ECHO_QUIET := @rem
     DIR_DELIM := $(strip \)
     BIN_EXT   := .exe
     PATH_SEP  := ;


### PR DESCRIPTION
Commit ee1ba6d4ddf1 ("Makefile: Support totally quiet output with -s") broke verbose (V=1) builds on Windows. This patch fixes it by adding helpers to silence echo prints in a OS-dependent way.