### PR TITLE
qemu: increase PLAT_QEMU_DT_MAX_SIZE to 1 MiB

### DIFF
--- a/plat/qemu/include/platform_def.h
+++ b/plat/qemu/include/platform_def.h
@@ -223,7 +223,7 @@
  * DT related constants
  */
 #define PLAT_QEMU_DT_BASE		NS_DRAM0_BASE
-#define PLAT_QEMU_DT_MAX_SIZE		0x10000
+#define PLAT_QEMU_DT_MAX_SIZE		0x100000
 
 /*
  * System counter


### PR DESCRIPTION
Since upstream QEMU commit 14ec3cbd7c1e ("device_tree: Increase
FDT_MAX_SIZE to 1 MiB"), which is included in release v2.12.1
and later, BL2 initialization fails with the following error (-3 is
-FDT_ERR_NOSPACE):

 ERROR:   Invalid Device Tree at 0x40000000: error -3

Increase PLAT_QEMU_DT_MAX_SIZE accordingly.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>