### PR TITLE
meson: console: Add missing define to fix build

### DIFF
--- a/drivers/meson/console/aarch64/meson_console.S
+++ b/drivers/meson/console/aarch64/meson_console.S
@@ -6,6 +6,7 @@
 
 #include <asm_macros.S>
 #include <assert_macros.S>
+#define USE_FINISH_CONSOLE_REG_2
 #include <console_macros.S>
 #include <meson_console.h>
 


### PR DESCRIPTION
It isn't possible to build this driver without adding this define.