### PR TITLE
ti: k3: common: Remove use of ARM platform code

### DIFF
--- a/plat/ti/k3/common/k3_bl31_setup.c
+++ b/plat/ti/k3/common/k3_bl31_setup.c
@@ -10,14 +10,14 @@
 #include <bl_common.h>
 #include <debug.h>
 #include <k3_console.h>
-#include <plat_arm.h>
-#include <platform_def.h>
 #include <k3_gicv3.h>
+#include <platform_def.h>
 #include <string.h>
 #include <ti_sci.h>
+#include <xlat_tables_v2.h>
 
 /* Table of regions to map using the MMU */
-const mmap_region_t plat_arm_mmap[] = {
+const mmap_region_t plat_k3_mmap[] = {
 	MAP_REGION_FLAT(SHARED_RAM_BASE, SHARED_RAM_SIZE, MT_DEVICE | MT_RW | MT_SECURE),
 	MAP_REGION_FLAT(K3_USART_BASE_ADDRESS, K3_USART_SIZE, MT_DEVICE | MT_RW | MT_SECURE),
 	MAP_REGION_FLAT(K3_GICD_BASE, K3_GICD_SIZE, MT_DEVICE | MT_RW | MT_SECURE),
@@ -97,7 +97,6 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 
 void bl31_plat_arch_setup(void)
 {
-
 	const mmap_region_t bl_regions[] = {
 		MAP_REGION_FLAT(BL31_BASE, BL31_END - BL31_BASE,
 				MT_MEMORY | MT_RW | MT_SECURE),
@@ -108,7 +107,7 @@ void bl31_plat_arch_setup(void)
 		{0}
 	};
 
-	setup_page_tables(bl_regions, plat_arm_get_mmap());
+	setup_page_tables(bl_regions, plat_k3_mmap);
 	enable_mmu_el3(0);
 }
 

--- a/plat/ti/k3/common/plat_common.mk
+++ b/plat/ti/k3/common/plat_common.mk
@@ -35,8 +35,6 @@ include lib/xlat_tables_v2/xlat_tables.mk
 
 PLAT_INCLUDES		+=	\
 				-I${PLAT_PATH}/include			\
-				-Iinclude/plat/arm/common/		\
-				-Iinclude/plat/arm/common/aarch64/	\
 				-I${PLAT_PATH}/common/drivers/sec_proxy	\
 				-I${PLAT_PATH}/common/drivers/ti_sci	\
 
@@ -63,7 +61,6 @@ K3_TI_SCI_SOURCES	+=	\
 				${PLAT_PATH}/common/drivers/ti_sci/ti_sci.c \
 
 PLAT_BL_COMMON_SOURCES	+=	\
-				plat/arm/common/arm_common.c		\
 				lib/cpus/aarch64/cortex_a53.S		\
 				${XLAT_TABLES_LIB_SRCS}			\
 				${K3_CONSOLE_SOURCES}			\


### PR DESCRIPTION
A recent patch[0] has made setting up page tables into generic
code, complete the conversion for TI platforms by removing the
use of plat_arm_get_mmap() and using the mmap table directly.

[0] 0916c38deca4 ("Convert arm_setup_page_tables into a generic helper")

Signed-off-by: Andrew F. Davis <afd@ti.com>