### PR TITLE
plat: juno: fix build for !CSS_USE_SCMI_DRIVER

### DIFF
--- a/plat/arm/board/juno/juno_topology.c
+++ b/plat/arm/board/juno/juno_topology.c
@@ -12,6 +12,7 @@
 #include "../../css/drivers/scmi/scmi.h"
 #include "../../css/drivers/mhu/css_mhu_doorbell.h"
 
+#if CSS_USE_SCMI_SDS_DRIVER
 static scmi_channel_plat_info_t juno_scmi_plat_info = {
 		.scmi_mbx_mem = CSS_SCMI_PAYLOAD_BASE,
 		.db_reg_addr = PLAT_CSS_MHU_BASE + CSS_SCMI_MHU_DB_REG_OFF,
@@ -25,6 +26,7 @@ scmi_channel_plat_info_t *plat_css_get_scmi_info()
 	return &juno_scmi_plat_info;
 }
 
+#endif
 /*
  * On Juno, the system power level is the highest power level.
  * The first entry in the power domain descriptor specifies the


### PR DESCRIPTION
When CSS_USE_SCMI_DRIVER is not defined or set to 0, we get the
following build error.

plat/arm/board/juno/juno_topology.c:16:19: error: ‘CSS_SCMI_PAYLOAD_BASE’ undeclared here (not in a function)
   .scmi_mbx_mem = CSS_SCMI_PAYLOAD_BASE,
                   ^~~~~~~~~~~~~~~~~~~~~
plat/arm/board/juno/juno_topology.c:17:38: error: ‘CSS_SCMI_MHU_DB_REG_OFF’ undeclared here (not in a function)
   .db_reg_addr = PLAT_CSS_MHU_BASE + CSS_SCMI_MHU_DB_REG_OFF,
                                      ^~~~~~~~~~~~~~~~~~~~~~~
                                      CSS_CPU_PWR_STATE_OFF

Fix the error in order to get function legacy SCPI support functional.

Change-Id: I00cb80db9968aa0be546e33a3a682a2db87719be
Signed-off-by: Sudeep Holla <sudeep.holla@arm.com>