### PR TITLE
psci, rpi3: add CONSOLE_FLUSH_ON_POWEROFF build option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -559,6 +559,7 @@ endif
 ################################################################################
 
 $(eval $(call assert_boolean,COLD_BOOT_SINGLE_CPU))
+$(eval $(call assert_boolean,CONSOLE_FLUSH_ON_POWEROFF))
 $(eval $(call assert_boolean,CREATE_KEYS))
 $(eval $(call assert_boolean,CTX_INCLUDE_AARCH32_REGS))
 $(eval $(call assert_boolean,CTX_INCLUDE_FPREGS))
@@ -613,6 +614,7 @@ $(eval $(call assert_numeric,SMCCC_MAJOR_VERSION))
 
 $(eval $(call add_define,ARM_ARCH_MAJOR))
 $(eval $(call add_define,ARM_ARCH_MINOR))
+$(eval $(call add_define,CONSOLE_FLUSH_ON_POWEROFF))
 $(eval $(call add_define,COLD_BOOT_SINGLE_CPU))
 $(eval $(call add_define,CTX_INCLUDE_AARCH32_REGS))
 $(eval $(call add_define,CTX_INCLUDE_FPREGS))

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -305,6 +305,13 @@ Common build options
    ``plat_secondary_cold_boot_setup()`` platform porting interfaces do not need
    to be implemented in this case.
 
+-  ``CONSOLE_FLUSH_ON_POWEROFF``: This option, which is enabled by default,
+   tells the system to issue a flush of the console on power operations (reset,
+   power off). However, some combinations of OSes + hardware may have disabled
+   the UART in a manner that creates an infinite loop when flushing the serial 
+   console, thus preventing platform reboot or power down (e.g. Ubuntu 18.04 on
+   Raspberry Pi 3). Setting this option to 0 can work around that problem.
+
 -  ``CRASH_REPORTING``: A non-zero value enables a console dump of processor
    register state when an unexpected exception occurs during execution of
    BL31. This option defaults to the value of ``DEBUG`` - i.e. by default

--- a/lib/psci/psci_system_off.c
+++ b/lib/psci/psci_system_off.c
@@ -23,7 +23,9 @@ void __dead2 psci_system_off(void)
 		psci_spd_pm->svc_system_off();
 	}
 
+#if CONSOLE_FLUSH_ON_POWEROFF
 	(void) console_flush();
+#endif /* CONSOLE_FLUSH_ON_POWEROFF */
 
 	/* Call the platform specific hook */
 	psci_plat_pm_ops->system_off();
@@ -42,7 +44,9 @@ void __dead2 psci_system_reset(void)
 		psci_spd_pm->svc_system_reset();
 	}
 
+#if CONSOLE_FLUSH_ON_POWEROFF
 	(void) console_flush();
+#endif /* CONSOLE_FLUSH_ON_POWEROFF */
 
 	/* Call the platform specific hook */
 	psci_plat_pm_ops->system_reset();
@@ -75,7 +79,9 @@ u_register_t psci_system_reset2(uint32_t reset_type, u_register_t cookie)
 	if ((psci_spd_pm != NULL) && (psci_spd_pm->svc_system_reset != NULL)) {
 		psci_spd_pm->svc_system_reset();
 	}
+#if CONSOLE_FLUSH_ON_POWEROFF
 	(void) console_flush();
+#endif /* CONSOLE_FLUSH_ON_POWEROFF */
 
 	return (u_register_t)
 		psci_plat_pm_ops->system_reset2((int) is_vendor, reset_type,

--- a/make_helpers/defaults.mk
+++ b/make_helpers/defaults.mk
@@ -37,6 +37,11 @@ BL2_IN_XIP_MEM			:= 0
 # The platform Makefile is free to override this value.
 COLD_BOOT_SINGLE_CPU		:= 0
 
+# Some combinations of OSes + hardware may disable the UART in a manner that
+# prevents console flushing from completing (infinite loop), thus preventing
+# reboot or poweroff. Setting this option to 0 can work around that issue.
+CONSOLE_FLUSH_ON_POWEROFF	:= 1
+
 # Flag to compile in coreboot support code. Exclude by default. The coreboot
 # Makefile system will set this when compiling TF as part of a coreboot image.
 COREBOOT			:= 0

--- a/plat/rpi3/rpi3_pm.c
+++ b/plat/rpi3/rpi3_pm.c
@@ -155,7 +155,9 @@ static void __dead2 rpi3_watchdog_reset(void)
 {
 	uint32_t rstc;
 
+#if CONSOLE_FLUSH_ON_POWEROFF
 	console_flush();
+#endif /* CONSOLE_FLUSH_ON_POWEROFF */
 
 	dsbsy();
 	isb();


### PR DESCRIPTION
Some OSes (e.g. Ubuntu 18.04 LTS on Raspberry Pi 3) may disable
the UART after boot, in conditions that create an infinite loop
in console_flush(), thus preventing power down or reboot.

By adding a new CONSOLE_FLUSH_ON_POWEROFF option (enabled by
default), ATF can be built that avoids system freeze on reboot.

Option is added to both psci & rpi3, as both paths can be used
for OS boot on Raspberry Pi.

Fixes ARM-software/tf-issues#647

Signed-off-by: Pete Batard <pete@akeo.ie>