### PR TITLE
rpi3: add RPI3_RUNTIME_UART build option

### DIFF
--- a/docs/plat/rpi3.rst
+++ b/docs/plat/rpi3.rst
@@ -231,6 +231,10 @@ The following build options are supported:
   ``RPI3_DIRECT_LINUX_BOOT=1``. This option allows to specify the location of a
   DTB in memory.
 
+- ``RPI3_RUNTIME_UART``: Indicates whether the UART should be used at runtime
+  or disabled. ``-1`` (default) disables the runtime UART. Any other value
+  enables the default UART (currently UART1) for runtime messages.
+
 - ``BL32``: This port can load and run OP-TEE. The OP-TEE image is optional.
   Please use the code from `here <https://github.com/OP-TEE/optee_os>`__.
   Build the Trusted Firmware with option ``BL32=tee-header_v2.bin

--- a/plat/rpi3/platform.mk
+++ b/plat/rpi3/platform.mk
@@ -109,6 +109,10 @@ RPI3_BL33_IN_AARCH32		:= 0
 # Assume that BL33 isn't the Linux kernel by default
 RPI3_DIRECT_LINUX_BOOT		:= 0
 
+# UART to use at runtime. -1 means the runtime UART is disabled.
+# Any other value means the default UART will be used.
+RPI3_RUNTIME_UART               := -1
+
 # BL32 location
 RPI3_BL32_RAM_LOCATION	:= tdram
 ifeq (${RPI3_BL32_RAM_LOCATION}, tsram)
@@ -126,6 +130,7 @@ $(eval $(call add_define,RPI3_BL32_RAM_LOCATION_ID))
 $(eval $(call add_define,RPI3_BL33_IN_AARCH32))
 $(eval $(call add_define,RPI3_DIRECT_LINUX_BOOT))
 $(eval $(call add_define,RPI3_PRELOADED_DTB_BASE))
+$(eval $(call add_define,RPI3_RUNTIME_UART))
 
 # Verify build config
 # -------------------

--- a/plat/rpi3/rpi3_common.c
+++ b/plat/rpi3/rpi3_common.c
@@ -96,6 +96,10 @@ static console_16550_t rpi3_console;
 
 void rpi3_console_init(void)
 {
+	int console_scope = CONSOLE_FLAG_BOOT;
+#if RPI3_RUNTIME_UART != -1
+	console_scope |= CONSOLE_FLAG_RUNTIME;
+#endif
 	int rc = console_16550_register(PLAT_RPI3_UART_BASE,
 					PLAT_RPI3_UART_CLK_IN_HZ,
 					PLAT_RPI3_UART_BAUDRATE,
@@ -109,8 +113,7 @@ void rpi3_console_init(void)
 		panic();
 	}
 
-	console_set_scope(&rpi3_console.console,
-			  CONSOLE_FLAG_BOOT | CONSOLE_FLAG_RUNTIME);
+	console_set_scope(&rpi3_console.console, console_scope);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Some OSes (e.g. Ubuntu 18.04 LTS on Raspberry Pi 3) may disable the
runtime UART in a manner that prevents the system from rebooting if
ATF tries to send runtime messages there.

Also, we don't want the firmware to share the UART with normal
world, as this can be a DoS attack vector into the secure world.

This patch fixes these 2 issues by introducing new build option
RPI3_RUNTIME_UART, that disables the runtime UART by default.

Fixes ARM-software/tf-issues#647

Signed-off-by: Pete Batard <pete@akeo.ie>