### PR TITLE
hikey: increase delay after eMMC initialized

### DIFF
--- a/plat/hisilicon/hikey/hikey_bl2_setup.c
+++ b/plat/hisilicon/hikey/hikey_bl2_setup.c
@@ -336,7 +336,7 @@ void bl2_platform_setup(void)
 	params.flags = MMC_FLAG_CMD23;
 	info.mmc_dev_type = MMC_IS_EMMC;
 	dw_mmc_init(&params, &info);
-	mdelay(5);
+	mdelay(20);
 
 	hikey_io_setup();
 }


### PR DESCRIPTION
Some eMMC chips require a longer delay, otherwise we run into a receive timeout when attempting to read FIP image. After testing different chips, 20ms appears to work reliably. I have tested Sandisk SDINADF4-32G and Samsung KLMBG4GEAC.