### PR TITLE
rpi3: add RPI3_USE_UEFI_MAP build option

### DIFF
--- a/docs/plat/rpi3.rst
+++ b/docs/plat/rpi3.rst
@@ -235,6 +235,41 @@ The following build options are supported:
   or disabled. ``-1`` (default) disables the runtime UART. Any other value
   enables the default UART (currently UART1) for runtime messages.
 
+- ``RPI3_USE_UEFI_MAP``: Set to 1 to build ATF with the altername memory
+   mapping required for an UEFI firmware payload. These changes are needed
+   to be able to run Windows on ARM64. This option, which is disabled by
+   default, results in the following memory mappings:
+
+::
+
+    0x00000000 +-----------------+
+               |       ROM       | BL1
+    0x00010000 +-----------------+
+               |       DTB       | (Loaded by the VideoCore)
+    0x00020000 +-----------------+
+               |       FIP       |
+    0x00030000 +-----------------+
+               |                 |
+               |  UEFI PAYLOAD   |
+               |                 |
+    0x00200000 +-----------------+
+               |   Secure SRAM   | BL2, BL31
+    0x00300000 +-----------------+
+               |   Secure DRAM   | BL32 (Secure payload)
+    0x00400000 +-----------------+
+               |                 |
+               |                 |
+               | Non-secure DRAM | BL33
+               |                 |
+               |                 |
+    0x01000000 +-----------------+
+               |                 |
+               |       ...       |
+               |                 |
+    0x3F000000 +-----------------+
+               |       I/O       |
+
+
 - ``BL32``: This port can load and run OP-TEE. The OP-TEE image is optional.
   Please use the code from `here <https://github.com/OP-TEE/optee_os>`__.
   Build the Trusted Firmware with option ``BL32=tee-header_v2.bin

--- a/plat/rpi3/include/platform_def.h
+++ b/plat/rpi3/include/platform_def.h
@@ -63,6 +63,25 @@
  * secure DRAM. Note that this is all actually DRAM with different names,
  * there is no Secure RAM in the Raspberry Pi 3.
  */
+#if RPI3_USE_UEFI_MAP
+#define SEC_ROM_BASE			ULL(0x00000000)
+#define SEC_ROM_SIZE			ULL(0x00010000)
+
+/* FIP placed after ROM to append it to BL1 with very little padding. */
+#define PLAT_RPI3_FIP_BASE		ULL(0x00020000)
+#define PLAT_RPI3_FIP_MAX_SIZE		ULL(0x00010000)
+
+/* Reserve 2M of secure SRAM and DRAM, starting at 2M */
+#define SEC_SRAM_BASE			ULL(0x00200000)
+#define SEC_SRAM_SIZE			ULL(0x00100000)
+
+#define SEC_DRAM0_BASE			ULL(0x00300000)
+#define SEC_DRAM0_SIZE			ULL(0x00100000)
+
+/* Windows on ARM requires some RAM at 4M */
+#define NS_DRAM0_BASE			ULL(0x00400000)
+#define NS_DRAM0_SIZE			ULL(0x00C00000)
+#else
 #define SEC_ROM_BASE			ULL(0x00000000)
 #define SEC_ROM_SIZE			ULL(0x00020000)
 
@@ -80,6 +99,7 @@
 
 #define NS_DRAM0_BASE			ULL(0x11000000)
 #define NS_DRAM0_SIZE			ULL(0x01000000)
+#endif /* RPI3_USE_UEFI_MAP */
 
 /*
  * BL33 entrypoint.

--- a/plat/rpi3/platform.mk
+++ b/plat/rpi3/platform.mk
@@ -111,7 +111,10 @@ RPI3_DIRECT_LINUX_BOOT		:= 0
 
 # UART to use at runtime. -1 means the runtime UART is disabled.
 # Any other value means the default UART will be used.
-RPI3_RUNTIME_UART               := -1
+RPI3_RUNTIME_UART		:= -1
+
+# Use normal memory mapping for ROM, FIP, SRAM and DRAM
+RPI3_USE_UEFI_MAP		:= 0
 
 # BL32 location
 RPI3_BL32_RAM_LOCATION	:= tdram
@@ -131,6 +134,7 @@ $(eval $(call add_define,RPI3_BL33_IN_AARCH32))
 $(eval $(call add_define,RPI3_DIRECT_LINUX_BOOT))
 $(eval $(call add_define,RPI3_PRELOADED_DTB_BASE))
 $(eval $(call add_define,RPI3_RUNTIME_UART))
+$(eval $(call add_define,RPI3_USE_UEFI_MAP))
 
 # Verify build config
 # -------------------


### PR DESCRIPTION
The default Raspberry Pi 3 memory mapping for ATF is geared towards
the use of uboot + Linux. This creates issues when trying to use
ATF with an UEFI payload and Windows on ARM64.

We therefore introduce new build option RPI3_USE_UEFI_MAP, that
enables the build process to use an alternate memory mapping that
is compatible with UEFI + Windows (as well as UEFI + Linux).

Fixes ARM-software/tf-issues#649

Signed-off-by: Pete Batard <pete@akeo.ie>