### PR TITLE
rcar-gen3: lock RPC hyper-flash access

### DIFF
--- a/plat/renesas/rcar/bl2_secure_setting.c
+++ b/plat/renesas/rcar/bl2_secure_setting.c
@@ -66,7 +66,9 @@ static const struct {
 	    /*      {SEC_SEL12,             0xFFFFFFFFU},                   */
 	    /* Bit22: RPC slave ports.                                      */
 	    /*        0: registers accessed from secure resource only.      */
-	    /* {SEC_SEL13,          0xFFBFFFFFU},*/
+#if (RCAR_RPC_HYPERFLASH_LOCKED == 1)
+	    {SEC_SEL13,          0xFFBFFFFFU},
+#endif
 	    /* Bit27: System Timer (SCMT) slave ports                       */
 	    /*        0: registers accessed from secure resource only       */
 	    /* Bit26: System Watchdog Timer (SWDT) slave ports              */
@@ -183,8 +185,10 @@ static const struct {
 	/** Security group 1 attribute setting for slave ports 13	*/
 	    /* Bit22: RPC slave ports.                                      */
 	    /*        SecurityGroup3                                        */
-	    /* {SEC_GRP0COND13,     0x00400000U}, */
-	    /* {SEC_GRP1COND13,     0x00400000U}, */
+#if (RCAR_RPC_HYPERFLASH_LOCKED == 1)
+	    {SEC_GRP0COND13,     0x00400000U},
+	    {SEC_GRP1COND13,     0x00400000U},
+#endif
 	/** Security group 0 attribute setting for slave ports 14	*/
 	/** Security group 1 attribute setting for slave ports 14	*/
 	    /* Bit26: System Timer (SCMT) slave ports                       */

--- a/plat/renesas/rcar/platform.mk
+++ b/plat/renesas/rcar/platform.mk
@@ -137,6 +137,13 @@ else
   $(eval $(call add_define,RCAR_LSI))
 endif
 
+# lock RPC HYPERFLASH access by default
+# unlock to repogram the ATF firmware from u-boot
+ifndef RCAR_RPC_HYPERFLASH_LOCKED
+RCAR_RPC_HYPERFLASH_LOCKED := 1
+endif
+$(eval $(call add_define,RCAR_RPC_HYPERFLASH_LOCKED))
+
 # Process RCAR_SECURE_BOOT flag
 ifndef RCAR_SECURE_BOOT
 RCAR_SECURE_BOOT := 1


### PR DESCRIPTION
This feature was enabled to allow u-boot reprograming the ATF firmware
using a FIP image instead of having to toggle numerous DIP switches on
the board.

The code being disabled with this commit should only be re-enabled for
debugging (_never_ on a product release)

Signed-off-by: Jorge Ramirez-Ortiz <jorge.ramirez.ortiz@gmail.com>