### PR TITLE
Initial Spectre V1 mitigations (CVE-2017-5753).

### DIFF
--- a/include/lib/utils_def.h
+++ b/include/lib/utils_def.h
@@ -162,4 +162,11 @@
 
 #define COMPILER_BARRIER() __asm__ volatile ("" ::: "memory")
 
+/* Compiler builtin of GCC >= 9 and planned in llvm */
+#ifdef __HAVE_SPECULATION_SAFE_VALUE
+# define SPECULATION_SAFE_VALUE(var) __builtin_speculation_safe_value(var)
+#else
+# define SPECULATION_SAFE_VALUE(var) var
+#endif
+
 #endif /* UTILS_DEF_H */

--- a/lib/psci/psci_stat.c
+++ b/lib/psci/psci_stat.c
@@ -206,9 +206,9 @@ static int psci_get_stat(u_register_t target_cpu, unsigned int power_state,
 
 	if (pwrlvl > PSCI_CPU_PWR_LVL) {
 		/* Get the power domain index */
-		parent_idx = psci_cpu_pd_nodes[target_idx].parent_node;
+		parent_idx = SPECULATION_SAFE_VALUE(psci_cpu_pd_nodes[target_idx].parent_node);
 		for (lvl = PSCI_CPU_PWR_LVL + 1U; lvl < pwrlvl; lvl++)
-			parent_idx = psci_non_cpu_pd_nodes[parent_idx].parent_node;
+			parent_idx = SPECULATION_SAFE_VALUE(psci_non_cpu_pd_nodes[parent_idx].parent_node);
 
 		/* Get the non cpu power domain stats */
 		*psci_stat = psci_non_cpu_stat[parent_idx][stat_idx];


### PR DESCRIPTION
Initial Spectre Variant 1 mitigations (CVE-2017-5753).
A potential speculative data leak was found in PSCI code, this depends
on a non-robust implementation of the `plat_get_core_pos_by_mpidr()`
function. This is considered very low-risk. This patch adds a macro to
mitigate this. Note not all code paths could be analyzed with current
tools.

Add a macro which makes a variable 'speculation safe', using the
 __builtin_speculation_safe_value function of GCC and llvm. This will be
available in GCC 9, and is planned for llvm, but is not currently in
mainline GCC or llvm. In order to implement this mitigation the compiler
must support this builtin. Support is indicated by the
__HAVE_SPECULATION_SAFE_VALUE flag.

The -mtrack-speculation option maintains a 'tracker' register, which
determines if the processor is in false speculation at any point. This
adds instructions and increases code size, but avoids the performance
impact of a hard barrier.

Without the -mtrack-speculation option, __builtin_speculation_safe_value
expands to a

    ISB
    DSB SY

sequence after a conditional branch, before the
speculation safe variable is used. With -mtrack-speculation a

    CSEL tracker, tracker, XZR, [cond];
    AND safeval,tracker;
    CSDB

sequence is added instead, clearing the vulnerable variable by
AND'ing it with the tracker register, which is zero during speculative
execution. [cond] are the status flags which will only be true during
speculative execution. For more information on
__builtin_speculation_safe_value and the -mtrack-speculation option see
https://developer.arm.com/support/arm-security-updates/speculative-processor-vulnerability/compiler-support-for-mitigations

The -mtracking option was not added, as the performance impact of the
mitigation is low, and there is only one occurence.

Change-Id: Ic9e66d1f4a5155e42e3e4055594974c230bfba3c
Signed-off-by: Joel Hutton <Joel.Hutton@Arm.com>