### PR TITLE
romlib: Add juno support for romlib

### DIFF
--- a/lib/romlib/gen_combined_bl1_romlib.sh
+++ b/lib/romlib/gen_combined_bl1_romlib.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+set -e
+
+output="bl1_romlib.bin"
+
+# Set trap for removing temporary file
+trap 'r=$?;rm -f $bin_path/$$.tmp;exit $r' EXIT HUP QUIT INT TERM
+
+# Read input parameters
+for i
+do
+	case $i in
+	-o)
+		output=$2
+		shift 2
+		;;
+	--)
+		shift
+		break
+		;;
+	-*)
+		echo usage: gen_combined_bl1_romlib.sh [-o output] path_to_build_directory >&2
+		;;
+	esac
+done
+
+
+bin_path=$1
+romlib_path=$1/romlib
+bl1_file="$1/bl1/bl1.elf"
+romlib_file="$1/romlib/romlib.elf"
+bl1_end=""
+romlib_begin=""
+
+# Get address of __BL1_ROM_END__
+bl1_end=`nm -a "$bl1_file" |
+awk '$3 == "__BL1_ROM_END__" {print "0x"$1}'`
+
+# Get start address of romlib "text" section
+romlib_begin=`nm -a "$romlib_file" |
+awk '$3 == ".text" {print "0x"$1}'`
+
+# Character "U" will be read as "55" in hex when it is
+# concatenated with bl1.bin. Generate combined BL1 and ROMLIB
+# binary with filler bytes for juno
+(cat $bin_path/bl1.bin
+ yes U | sed $(($romlib_begin - $bl1_end))q | tr -d '\n'
+ cat $bin_path/romlib/romlib.bin) > $bin_path/$$.tmp &&
+mv $bin_path/$$.tmp $bin_path/$output

--- a/plat/arm/board/juno/include/platform_def.h
+++ b/plat/arm/board/juno/include/platform_def.h
@@ -55,7 +55,8 @@
 #define PLAT_ARM_TRUSTED_SRAM_SIZE	UL(0x00040000)	/* 256 KB */
 
 /* Use the bypass address */
-#define PLAT_ARM_TRUSTED_ROM_BASE	V2M_FLASH0_BASE + BL1_ROM_BYPASS_OFFSET
+#define PLAT_ARM_TRUSTED_ROM_BASE	(V2M_FLASH0_BASE + \
+					BL1_ROM_BYPASS_OFFSET)
 
 #define NSRAM_BASE			UL(0x2e000000)
 #define NSRAM_SIZE			UL(0x00008000)	/* 32KB */
@@ -64,11 +65,22 @@
 #define PLAT_ARM_MEM_PROTEC_VA_FRAME	UL(0xc0000000)
 
 /*
+ * PLAT_ARM_MAX_ROMLIB_RW_SIZE is define to use a full page
+ */
+
+#if USE_ROMLIB
+#define PLAT_ARM_MAX_ROMLIB_RW_SIZE	UL(0x1000)
+#define PLAT_ARM_MAX_ROMLIB_RO_SIZE	UL(0xe000)
+#else
+#define PLAT_ARM_MAX_ROMLIB_RW_SIZE	UL(0)
+#define PLAT_ARM_MAX_ROMLIB_RO_SIZE	UL(0)
+#endif
+
+/*
  * Actual ROM size on Juno is 64 KB, but TBB currently requires at least 80 KB
  * in debug mode. We can test TBB on Juno bypassing the ROM and using 128 KB of
  * flash
  */
-#define PLAT_ARM_MAX_ROMLIB_RO_SIZE	0
 
 #if TRUSTED_BOARD_BOOT
 #define PLAT_ARM_TRUSTED_ROM_SIZE	UL(0x00020000)
@@ -118,15 +130,6 @@
 # define PLAT_ARM_MAX_BL1_RW_SIZE	UL(0xB000)
 #else
 # define PLAT_ARM_MAX_BL1_RW_SIZE	UL(0x6000)
-#endif
-
-/*
- * PLAT_ARM_MAX_ROMLIB_RW_SIZE is define to use a full page
- */
-#if USE_ROMLIB
-#define PLAT_ARM_MAX_ROMLIB_RW_SIZE	UL(0x1000)
-#else
-#define PLAT_ARM_MAX_ROMLIB_RW_SIZE	UL(0)
 #endif
 
 /*

--- a/plat/arm/board/juno/platform.mk
+++ b/plat/arm/board/juno/platform.mk
@@ -96,6 +96,14 @@ ifneq (${RESET_TO_BL31},0)
   Please set RESET_TO_BL31 to 0.")
 endif
 
+ifeq ($(USE_ROMLIB),1)
+all : bl1_romlib.bin
+endif
+
+bl1_romlib.bin : $(BUILD_PLAT)/bl1.bin $(BUILD_PLAT)/romlib/romlib.bin
+	@echo "Building combined BL1 and ROMLIB binary for Juno $@"
+	./lib/romlib/gen_combined_bl1_romlib.sh -o bl1_romlib.bin $(BUILD_PLAT)
+
 # Errata workarounds for Cortex-A53:
 ERRATA_A53_826319		:=	1
 ERRATA_A53_835769		:=	1


### PR DESCRIPTION
This patch builds the combined BL1 and ROMLIB
binary file with filler bytes for the right page
size alignment in Juno. The build option
USE_ROMLIB=1 generates the combined file:
bl1_romlib.bin which has to be used instead of
bl1.bin for Juno.

Change-Id: I407efbe48d3e522fa6ef855538a9587193cb1919
Signed-off-by: Sathees Balya <sathees.balya@arm.com>