### PR TITLE
Synchronise arch.h and arch_helpers.h with TF-A-Tests

### DIFF
--- a/include/lib/aarch32/arch_helpers.h
+++ b/include/lib/aarch32/arch_helpers.h
@@ -101,46 +101,23 @@ static inline void write_ ## _name(const u_register_t v)		\
  * Macros to create inline functions for tlbi operations
  *********************************************************************/
 
-#if ERRATA_A57_813419
-/*
- * Define function for TLBI instruction with type specifier that
- * implements the workaround for errata 813419 of Cortex-A57
- */
-#define _DEFINE_TLBIOP_FUNC(_op, coproc, opc1, CRn, CRm, opc2)		\
-static inline void tlbi##_op(void)					\
-{									\
-	u_register_t v = 0;						\
-	__asm__ volatile ("mcr "#coproc","#opc1",%0,"#CRn","#CRm","#opc2 : : "r" (v));\
-	__asm__ volatile ("dsb ish");\
-	__asm__ volatile ("mcr "#coproc","#opc1",%0,"#CRn","#CRm","#opc2 : : "r" (v));\
-}
-
-#define _DEFINE_TLBIOP_PARAM_FUNC(_op, coproc, opc1, CRn, CRm, opc2)	\
-static inline void tlbi##_op(u_register_t v)				\
-{									\
-	__asm__ volatile ("mcr "#coproc","#opc1",%0,"#CRn","#CRm","#opc2 : : "r" (v));\
-	__asm__ volatile ("dsb ish");\
-	__asm__ volatile ("mcr "#coproc","#opc1",%0,"#CRn","#CRm","#opc2 : : "r" (v));\
-}
-#else
 #define _DEFINE_TLBIOP_FUNC(_op, coproc, opc1, CRn, CRm, opc2)		\
 static inline void tlbi##_op(void)					\
 {									\
 	u_register_t v = 0;						\
 	__asm__ volatile ("mcr "#coproc","#opc1",%0,"#CRn","#CRm","#opc2 : : "r" (v));\
 }
-
-#define _DEFINE_TLBIOP_PARAM_FUNC(_op, coproc, opc1, CRn, CRm, opc2)	\
-static inline void tlbi##_op(u_register_t v)				\
-{									\
-	__asm__ volatile ("mcr "#coproc","#opc1",%0,"#CRn","#CRm","#opc2 : : "r" (v));\
-}
-#endif /* ERRATA_A57_813419 */
 
 #define _DEFINE_BPIOP_FUNC(_op, coproc, opc1, CRn, CRm, opc2)		\
 static inline void bpi##_op(void)					\
 {									\
 	u_register_t v = 0;						\
+	__asm__ volatile ("mcr "#coproc","#opc1",%0,"#CRn","#CRm","#opc2 : : "r" (v));\
+}
+
+#define _DEFINE_TLBIOP_PARAM_FUNC(_op, coproc, opc1, CRn, CRm, opc2)	\
+static inline void tlbi##_op(u_register_t v)				\
+{									\
 	__asm__ volatile ("mcr "#coproc","#opc1",%0,"#CRn","#CRm","#opc2 : : "r" (v));\
 }
 

--- a/include/lib/aarch32/arch_helpers.h
+++ b/include/lib/aarch32/arch_helpers.h
@@ -7,7 +7,7 @@
 #ifndef ARCH_HELPERS_H
 #define ARCH_HELPERS_H
 
-#include <arch.h>	/* for additional register definitions */
+#include <arch.h>
 #include <cdefs.h>
 #include <stdint.h>
 #include <string.h>
@@ -33,13 +33,8 @@ static inline u_register_t read_ ## _name(void)				\
 
 /*
  *  The undocumented %Q and %R extended asm are used to implemented the below
- *  64 bit `mrrc` and `mcrr` instructions. It works only on Little Endian
- *  systems for GCC versions < 4.6. Above GCC 4.6, both Little Endian and
- *  Big Endian systems generate the right instruction encoding.
+ *  64 bit `mrrc` and `mcrr` instructions.
  */
-#if !(__clang__ || __GNUC__ > (4) || __GNUC__ == (4) && __GNUC_MINOR__ >= (6))
-#error "clang or GCC 4.6 or above is required to build AArch32 Trusted Firmware"
-#endif
 
 #define _DEFINE_COPROCR_WRITE_FUNC_64(_name, coproc, opc1, CRm)		\
 static inline void write64_## _name(uint64_t v)				\
@@ -78,6 +73,10 @@ static inline void write_ ## _name(const u_register_t v)		\
 #define DEFINE_COPROCR_READ_FUNC(_name, ...) 				\
 	_DEFINE_COPROCR_READ_FUNC(_name, __VA_ARGS__)
 
+/* Define write function for coproc register */
+#define DEFINE_COPROCR_WRITE_FUNC(_name, ...) 				\
+	_DEFINE_COPROCR_WRITE_FUNC(_name, __VA_ARGS__)
+
 /* Define read & write function for coproc register */
 #define DEFINE_COPROCR_RW_FUNCS(_name, ...) 				\
 	_DEFINE_COPROCR_READ_FUNC(_name, __VA_ARGS__)			\
@@ -86,6 +85,10 @@ static inline void write_ ## _name(const u_register_t v)		\
 /* Define 64 bit read function for coproc register */
 #define DEFINE_COPROCR_READ_FUNC_64(_name, ...) 			\
 	_DEFINE_COPROCR_READ_FUNC_64(_name, __VA_ARGS__)
+
+/* Define 64 bit write function for coproc register */
+#define DEFINE_COPROCR_WRITE_FUNC_64(_name, ...) 			\
+	_DEFINE_COPROCR_WRITE_FUNC_64(_name, __VA_ARGS__)
 
 /* Define 64 bit read & write function for coproc register */
 #define DEFINE_COPROCR_RW_FUNCS_64(_name, ...) 				\
@@ -227,10 +230,13 @@ DEFINE_COPROCR_RW_FUNCS(cntfrq, CNTFRQ)
 DEFINE_COPROCR_RW_FUNCS(cnthctl, CNTHCTL)
 DEFINE_COPROCR_RW_FUNCS(mair0, MAIR0)
 DEFINE_COPROCR_RW_FUNCS(mair1, MAIR1)
+DEFINE_COPROCR_RW_FUNCS(hmair0, HMAIR0)
 DEFINE_COPROCR_RW_FUNCS(ttbcr, TTBCR)
+DEFINE_COPROCR_RW_FUNCS(htcr, HTCR)
 DEFINE_COPROCR_RW_FUNCS(ttbr0, TTBR0)
 DEFINE_COPROCR_RW_FUNCS_64(ttbr0, TTBR0_64)
 DEFINE_COPROCR_RW_FUNCS(ttbr1, TTBR1)
+DEFINE_COPROCR_RW_FUNCS_64(httbr, HTTBR_64)
 DEFINE_COPROCR_RW_FUNCS(vpidr, VPIDR)
 DEFINE_COPROCR_RW_FUNCS(vmpidr, VMPIDR)
 DEFINE_COPROCR_RW_FUNCS_64(vttbr, VTTBR_64)
@@ -238,6 +244,9 @@ DEFINE_COPROCR_RW_FUNCS_64(ttbr1, TTBR1_64)
 DEFINE_COPROCR_RW_FUNCS_64(cntvoff, CNTVOFF_64)
 DEFINE_COPROCR_RW_FUNCS(csselr, CSSELR)
 DEFINE_COPROCR_RW_FUNCS(hstr, HSTR)
+DEFINE_COPROCR_RW_FUNCS(cnthp_ctl_el2, CNTHP_CTL)
+DEFINE_COPROCR_RW_FUNCS(cnthp_tval_el2, CNTHP_TVAL)
+DEFINE_COPROCR_RW_FUNCS_64(cnthp_cval_el2, CNTHP_CVAL_64)
 
 DEFINE_COPROCR_RW_FUNCS(icc_sre_el1, ICC_SRE)
 DEFINE_COPROCR_RW_FUNCS(icc_sre_el2, ICC_HSRE)
@@ -245,6 +254,7 @@ DEFINE_COPROCR_RW_FUNCS(icc_sre_el3, ICC_MSRE)
 DEFINE_COPROCR_RW_FUNCS(icc_pmr_el1, ICC_PMR)
 DEFINE_COPROCR_RW_FUNCS(icc_rpr_el1, ICC_RPR)
 DEFINE_COPROCR_RW_FUNCS(icc_igrpen1_el3, ICC_MGRPEN1)
+DEFINE_COPROCR_RW_FUNCS(icc_igrpen1_el1, ICC_IGRPEN1)
 DEFINE_COPROCR_RW_FUNCS(icc_igrpen0_el1, ICC_IGRPEN0)
 DEFINE_COPROCR_RW_FUNCS(icc_hppir0_el1, ICC_HPPIR0)
 DEFINE_COPROCR_RW_FUNCS(icc_hppir1_el1, ICC_HPPIR1)
@@ -253,13 +263,17 @@ DEFINE_COPROCR_RW_FUNCS(icc_iar1_el1, ICC_IAR1)
 DEFINE_COPROCR_RW_FUNCS(icc_eoir0_el1, ICC_EOIR0)
 DEFINE_COPROCR_RW_FUNCS(icc_eoir1_el1, ICC_EOIR1)
 DEFINE_COPROCR_RW_FUNCS_64(icc_sgi0r_el1, ICC_SGI0R_EL1_64)
+DEFINE_COPROCR_WRITE_FUNC_64(icc_sgi1r, ICC_SGI1R_EL1_64)
 
 DEFINE_COPROCR_RW_FUNCS(hdcr, HDCR)
 DEFINE_COPROCR_RW_FUNCS(cnthp_ctl, CNTHP_CTL)
 DEFINE_COPROCR_READ_FUNC(pmcr, PMCR)
 
-DEFINE_COPROCR_RW_FUNCS(ats1cpr, ATS1CPR)
-DEFINE_COPROCR_RW_FUNCS(ats1hr, ATS1HR)
+/*
+ * Address translation
+ */
+DEFINE_COPROCR_WRITE_FUNC(ats1cpr, ATS1CPR)
+DEFINE_COPROCR_WRITE_FUNC(ats1hr, ATS1HR)
 DEFINE_COPROCR_RW_FUNCS_64(par, PAR_64)
 
 DEFINE_COPROCR_RW_FUNCS(nsacr, NSACR)
@@ -317,9 +331,7 @@ DEFINE_DCOP_PARAM_FUNC(cvac, DCCMVAC)
 #define IS_IN_SVC()	(GET_M32(read_cpsr()) == MODE32_svc)
 #define IS_IN_MON()	(GET_M32(read_cpsr()) == MODE32_mon)
 #define IS_IN_EL2()	IS_IN_HYP()
- /*
-  * If EL3 is AArch32, then secure PL1 and monitor mode correspond to EL3
-  */
+/* If EL3 is AArch32, then secure PL1 and monitor mode correspond to EL3 */
 #define IS_IN_EL3() \
 	((GET_M32(read_cpsr()) == MODE32_mon) ||	\
 		(IS_IN_SECURE() && (GET_M32(read_cpsr()) != MODE32_usr)))
@@ -355,7 +367,15 @@ static inline unsigned int get_current_el(void)
 
 #define read_ctr_el0()		read_ctr()
 
-#define write_icc_sgi0r_el1(_v) \
-		write64_icc_sgi0r_el1(_v)
+#define write_icc_sgi0r_el1(_v)	write64_icc_sgi0r_el1(_v)
+
+#define read_daif()		read_cpsr()
+#define write_daif(flags)	write_cpsr(flags)
+
+#define read_cnthp_cval_el2()	read64_cnthp_cval_el2()
+#define write_cnthp_cval_el2(v)	write64_cnthp_cval_el2(v)
+
+#define read_amcntenset0_el0()	read_amcntenset0()
+#define read_amcntenset1_el0()	read_amcntenset1()
 
 #endif /* ARCH_HELPERS_H */

--- a/include/lib/aarch64/arch.h
+++ b/include/lib/aarch64/arch.h
@@ -35,12 +35,14 @@
 #define MPIDR_AFF1_SHIFT	U(8)
 #define MPIDR_AFF2_SHIFT	U(16)
 #define MPIDR_AFF3_SHIFT	U(32)
+#define MPIDR_AFF_SHIFT(_n)	MPIDR_AFF##_n##_SHIFT
 #define MPIDR_AFFINITY_MASK	ULL(0xff00ffffff)
 #define MPIDR_AFFLVL_SHIFT	U(3)
-#define MPIDR_AFFLVL0		U(0x0)
-#define MPIDR_AFFLVL1		U(0x1)
-#define MPIDR_AFFLVL2		U(0x2)
-#define MPIDR_AFFLVL3		U(0x3)
+#define MPIDR_AFFLVL0		ULL(0x0)
+#define MPIDR_AFFLVL1		ULL(0x1)
+#define MPIDR_AFFLVL2		ULL(0x2)
+#define MPIDR_AFFLVL3		ULL(0x3)
+#define MPIDR_AFFLVL(_n)	MPIDR_AFFLVL##_n
 #define MPIDR_AFFLVL0_VAL(mpidr) \
 		(((mpidr) >> MPIDR_AFF0_SHIFT) & MPIDR_AFFLVL_MASK)
 #define MPIDR_AFFLVL1_VAL(mpidr) \
@@ -56,28 +58,42 @@
  */
 #define MPIDR_MAX_AFFLVL	U(2)
 
-/* Constant to highlight the assumption that MPIDR allocation starts from 0 */
-#define FIRST_MPIDR		ULL(0)
+#define MPID_MASK		(MPIDR_MT_MASK				 | \
+				 (MPIDR_AFFLVL_MASK << MPIDR_AFF3_SHIFT) | \
+				 (MPIDR_AFFLVL_MASK << MPIDR_AFF2_SHIFT) | \
+				 (MPIDR_AFFLVL_MASK << MPIDR_AFF1_SHIFT) | \
+				 (MPIDR_AFFLVL_MASK << MPIDR_AFF0_SHIFT))
+
+#define MPIDR_AFF_ID(mpid, n)					\
+	(((mpid) >> MPIDR_AFF_SHIFT(n)) & MPIDR_AFFLVL_MASK)
+
+/*
+ * An invalid MPID. This value can be used by functions that return an MPID to
+ * indicate an error.
+ */
+#define INVALID_MPID		U(0xFFFFFFFF)
 
 /*******************************************************************************
  * Definitions for CPU system register interface to GICv3
  ******************************************************************************/
-#define ICC_SRE_EL1     S3_0_C12_C12_5
-#define ICC_SRE_EL2     S3_4_C12_C9_5
-#define ICC_SRE_EL3     S3_6_C12_C12_5
-#define ICC_CTLR_EL1    S3_0_C12_C12_4
-#define ICC_CTLR_EL3    S3_6_C12_C12_4
-#define ICC_PMR_EL1     S3_0_C4_C6_0
-#define ICC_RPR_EL1     S3_0_C12_C11_3
-#define ICC_IGRPEN1_EL3 S3_6_c12_c12_7
-#define ICC_IGRPEN0_EL1 S3_0_c12_c12_6
-#define ICC_HPPIR0_EL1  S3_0_c12_c8_2
-#define ICC_HPPIR1_EL1  S3_0_c12_c12_2
-#define ICC_IAR0_EL1    S3_0_c12_c8_0
-#define ICC_IAR1_EL1    S3_0_c12_c12_0
-#define ICC_EOIR0_EL1   S3_0_c12_c8_1
-#define ICC_EOIR1_EL1   S3_0_c12_c12_1
-#define ICC_SGI0R_EL1	S3_0_c12_c11_7
+#define ICC_IGRPEN1_EL1		S3_0_C12_C12_7
+#define ICC_SGI1R		S3_0_C12_C11_5
+#define ICC_SRE_EL1		S3_0_C12_C12_5
+#define ICC_SRE_EL2		S3_4_C12_C9_5
+#define ICC_SRE_EL3		S3_6_C12_C12_5
+#define ICC_CTLR_EL1		S3_0_C12_C12_4
+#define ICC_CTLR_EL3		S3_6_C12_C12_4
+#define ICC_PMR_EL1		S3_0_C4_C6_0
+#define ICC_RPR_EL1		S3_0_C12_C11_3
+#define ICC_IGRPEN1_EL3		S3_6_c12_c12_7
+#define ICC_IGRPEN0_EL1		S3_0_c12_c12_6
+#define ICC_HPPIR0_EL1		S3_0_c12_c8_2
+#define ICC_HPPIR1_EL1		S3_0_c12_c12_2
+#define ICC_IAR0_EL1		S3_0_c12_c8_0
+#define ICC_IAR1_EL1		S3_0_c12_c12_0
+#define ICC_EOIR0_EL1		S3_0_c12_c8_1
+#define ICC_EOIR1_EL1		S3_0_c12_c12_1
+#define ICC_SGI0R_EL1		S3_0_c12_c11_7
 
 /*******************************************************************************
  * Generic timer memory mapped registers & offsets
@@ -139,6 +155,25 @@
 /* ID_AA64MMFR0_EL1 definitions */
 #define ID_AA64MMFR0_EL1_PARANGE_SHIFT	U(0)
 #define ID_AA64MMFR0_EL1_PARANGE_MASK	ULL(0xf)
+
+/* ID_AA64ISAR1_EL1 definitions */
+#define ID_AA64ISAR1_GPI_SHIFT	U(28)
+#define ID_AA64ISAR1_GPI_WIDTH	U(4)
+#define ID_AA64ISAR1_GPA_SHIFT	U(24)
+#define ID_AA64ISAR1_GPA_WIDTH	U(4)
+#define ID_AA64ISAR1_API_SHIFT	U(8)
+#define ID_AA64ISAR1_API_WIDTH	U(4)
+#define ID_AA64ISAR1_APA_SHIFT	U(4)
+#define ID_AA64ISAR1_APA_WIDTH	U(4)
+
+#define ID_AA64ISAR1_GPI_MASK \
+	(((ULL(1) << ID_AA64ISAR1_GPI_WIDTH) - ULL(1)) << ID_AA64ISAR1_GPI_SHIFT)
+#define ID_AA64ISAR1_GPA_MASK \
+	(((ULL(1) << ID_AA64ISAR1_GPA_WIDTH) - ULL(1)) << ID_AA64ISAR1_GPA_SHIFT)
+#define ID_AA64ISAR1_API_MASK \
+	(((ULL(1) << ID_AA64ISAR1_API_WIDTH) - ULL(1)) << ID_AA64ISAR1_API_SHIFT)
+#define ID_AA64ISAR1_APA_MASK \
+	(((ULL(1) << ID_AA64ISAR1_APA_WIDTH) - ULL(1)) << ID_AA64ISAR1_APA_SHIFT)
 
 #define PARANGE_0000	U(32)
 #define PARANGE_0001	U(36)
@@ -278,6 +313,7 @@
 /* HCR definitions */
 #define HCR_API_BIT		(ULL(1) << 41)
 #define HCR_APK_BIT		(ULL(1) << 40)
+#define HCR_TGE_BIT		(ULL(1) << 27)
 #define HCR_RW_SHIFT		U(31)
 #define HCR_RW_BIT		(ULL(1) << HCR_RW_SHIFT)
 #define HCR_AMO_BIT		(ULL(1) << 5)
@@ -351,6 +387,8 @@
 #define DISABLE_ALL_EXCEPTIONS \
 		(DAIF_FIQ_BIT | DAIF_IRQ_BIT | DAIF_ABT_BIT | DAIF_DBG_BIT)
 
+#define DISABLE_INTERRUPTS	(DAIF_FIQ_BIT | DAIF_IRQ_BIT)
+
 /*
  * RMR_EL3 definitions
  */
@@ -360,12 +398,12 @@
 /*
  * HI-VECTOR address for AArch32 state
  */
-#define HI_VECTOR_BASE	U(0xFFFF0000)
+#define HI_VECTOR_BASE		U(0xFFFF0000)
 
 /*
  * TCR defintions
  */
-#define TCR_EL3_RES1		((U(1) << 31) | (U(1) << 23))
+#define TCR_EL3_RES1		((ULL(1) << 31) | (ULL(1) << 23))
 #define TCR_EL2_RES1		((ULL(1) << 31) | (ULL(1) << 23))
 #define TCR_EL1_IPS_SHIFT	U(32)
 #define TCR_EL2_PS_SHIFT	U(16)
@@ -571,10 +609,17 @@
 #define CNTACR_RWPT_SHIFT	U(0x5)
 
 /*******************************************************************************
- * Definitions of register offsets in the CNTBaseN Frame of the
+ * Definitions of register offsets and fields in the CNTBaseN Frame of the
  * system level implementation of the Generic Timer.
  ******************************************************************************/
-#define CNTBASE_CNTFRQ		U(0x10)
+/* Physical Count register. */
+#define CNTPCT_LO		U(0x0)
+/* Counter Frequency register. */
+#define CNTBASEN_CNTFRQ		U(0x10)
+/* Physical Timer CompareValue register. */
+#define CNTP_CVAL_LO		U(0x20)
+/* Physical Timer Control register. */
+#define CNTP_CTL		U(0x2c)
 
 /* PMCR_EL0 definitions */
 #define PMCR_EL0_RESET_VAL	U(0x0)
@@ -753,7 +798,22 @@
 #define ERXCTLR_EL1		S3_0_C5_C4_1
 #define ERXSTATUS_EL1		S3_0_C5_C4_2
 #define ERXADDR_EL1		S3_0_C5_C4_3
+#define ERXPFGF_EL1		S3_0_C5_C4_4
+#define ERXPFGCTL_EL1		S3_0_C5_C4_5
+#define ERXPFGCDN_EL1		S3_0_C5_C4_6
 #define ERXMISC0_EL1		S3_0_C5_C5_0
 #define ERXMISC1_EL1		S3_0_C5_C5_1
+
+#define ERXCTLR_ED_BIT		(U(1) << 0)
+#define ERXCTLR_UE_BIT		(U(1) << 4)
+
+#define ERXPFGCTL_UC_BIT	(U(1) << 1)
+#define ERXPFGCTL_UEU_BIT	(U(1) << 2)
+#define ERXPFGCTL_CDEN_BIT	(U(1) << 31)
+
+/*******************************************************************************
+ * Armv8.3 Pointer Authentication Registers
+ *******************************************************************************/
+#define APGAKeyLo_EL1		S3_0_C2_C3_0
 
 #endif /* ARCH_H */

--- a/include/lib/aarch64/arch_helpers.h
+++ b/include/lib/aarch64/arch_helpers.h
@@ -7,8 +7,8 @@
 #ifndef ARCH_HELPERS_H
 #define ARCH_HELPERS_H
 
-#include <arch.h>	/* for additional register definitions */
-#include <cdefs.h>	/* For __dead2 */
+#include <arch.h>
+#include <cdefs.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <string.h>
@@ -179,11 +179,13 @@ void disable_mmu_icache_el3(void);
 #define write_daifclr(val) SYSREG_WRITE_CONST(daifclr, val)
 #define write_daifset(val) SYSREG_WRITE_CONST(daifset, val)
 
-DEFINE_SYSREG_READ_FUNC(par_el1)
+DEFINE_SYSREG_RW_FUNCS(par_el1)
 DEFINE_SYSREG_READ_FUNC(id_pfr1_el1)
+DEFINE_SYSREG_READ_FUNC(id_aa64isar1_el1)
 DEFINE_SYSREG_READ_FUNC(id_aa64pfr0_el1)
 DEFINE_SYSREG_READ_FUNC(id_aa64dfr0_el1)
 DEFINE_SYSREG_READ_FUNC(CurrentEl)
+DEFINE_SYSREG_READ_FUNC(ctr_el0)
 DEFINE_SYSREG_RW_FUNCS(daif)
 DEFINE_SYSREG_RW_FUNCS(spsr_el1)
 DEFINE_SYSREG_RW_FUNCS(spsr_el2)
@@ -202,13 +204,19 @@ DEFINE_SYSOP_TYPE_FUNC(dmb, ld)
 DEFINE_SYSOP_TYPE_FUNC(dsb, ish)
 DEFINE_SYSOP_TYPE_FUNC(dsb, nsh)
 DEFINE_SYSOP_TYPE_FUNC(dsb, ishst)
-DEFINE_SYSOP_TYPE_FUNC(dmb, ish)
+DEFINE_SYSOP_TYPE_FUNC(dmb, oshld)
+DEFINE_SYSOP_TYPE_FUNC(dmb, oshst)
+DEFINE_SYSOP_TYPE_FUNC(dmb, osh)
+DEFINE_SYSOP_TYPE_FUNC(dmb, nshld)
+DEFINE_SYSOP_TYPE_FUNC(dmb, nshst)
+DEFINE_SYSOP_TYPE_FUNC(dmb, nsh)
+DEFINE_SYSOP_TYPE_FUNC(dmb, ishld)
 DEFINE_SYSOP_TYPE_FUNC(dmb, ishst)
+DEFINE_SYSOP_TYPE_FUNC(dmb, ish)
 DEFINE_SYSOP_FUNC(isb)
 
 uint32_t get_afflvl_shift(uint32_t);
 uint32_t mpidr_mask_lower_afflvls(uint64_t, uint32_t);
-
 
 void __dead2 eret(uint64_t x0, uint64_t x1, uint64_t x2, uint64_t x3,
 		  uint64_t x4, uint64_t x5, uint64_t x6, uint64_t x7);
@@ -286,9 +294,15 @@ DEFINE_SYSREG_RW_FUNCS(cptr_el3)
 
 DEFINE_SYSREG_RW_FUNCS(cpacr_el1)
 DEFINE_SYSREG_RW_FUNCS(cntfrq_el0)
+DEFINE_SYSREG_RW_FUNCS(cnthp_ctl_el2)
+DEFINE_SYSREG_RW_FUNCS(cnthp_tval_el2)
+DEFINE_SYSREG_RW_FUNCS(cnthp_cval_el2)
 DEFINE_SYSREG_RW_FUNCS(cntps_ctl_el1)
 DEFINE_SYSREG_RW_FUNCS(cntps_tval_el1)
 DEFINE_SYSREG_RW_FUNCS(cntps_cval_el1)
+DEFINE_SYSREG_RW_FUNCS(cntp_ctl_el0)
+DEFINE_SYSREG_RW_FUNCS(cntp_tval_el0)
+DEFINE_SYSREG_RW_FUNCS(cntp_cval_el0)
 DEFINE_SYSREG_READ_FUNC(cntpct_el0)
 DEFINE_SYSREG_RW_FUNCS(cnthctl_el2)
 
@@ -298,17 +312,15 @@ DEFINE_SYSREG_RW_FUNCS(cntvoff_el2)
 
 DEFINE_SYSREG_RW_FUNCS(vpidr_el2)
 DEFINE_SYSREG_RW_FUNCS(vmpidr_el2)
-DEFINE_SYSREG_RW_FUNCS(cntp_ctl_el0)
 
 DEFINE_SYSREG_READ_FUNC(isr_el1)
-
-DEFINE_SYSREG_READ_FUNC(ctr_el0)
 
 DEFINE_SYSREG_RW_FUNCS(mdcr_el2)
 DEFINE_SYSREG_RW_FUNCS(mdcr_el3)
 DEFINE_SYSREG_RW_FUNCS(hstr_el2)
-DEFINE_SYSREG_RW_FUNCS(cnthp_ctl_el2)
 DEFINE_SYSREG_RW_FUNCS(pmcr_el0)
+
+/* GICv3 System Registers */
 
 DEFINE_RENAME_SYSREG_RW_FUNCS(icc_sre_el1, ICC_SRE_EL1)
 DEFINE_RENAME_SYSREG_RW_FUNCS(icc_sre_el2, ICC_SRE_EL2)
@@ -316,6 +328,7 @@ DEFINE_RENAME_SYSREG_RW_FUNCS(icc_sre_el3, ICC_SRE_EL3)
 DEFINE_RENAME_SYSREG_RW_FUNCS(icc_pmr_el1, ICC_PMR_EL1)
 DEFINE_RENAME_SYSREG_READ_FUNC(icc_rpr_el1, ICC_RPR_EL1)
 DEFINE_RENAME_SYSREG_RW_FUNCS(icc_igrpen1_el3, ICC_IGRPEN1_EL3)
+DEFINE_RENAME_SYSREG_RW_FUNCS(icc_igrpen1_el1, ICC_IGRPEN1_EL1)
 DEFINE_RENAME_SYSREG_RW_FUNCS(icc_igrpen0_el1, ICC_IGRPEN0_EL1)
 DEFINE_RENAME_SYSREG_READ_FUNC(icc_hppir0_el1, ICC_HPPIR0_EL1)
 DEFINE_RENAME_SYSREG_READ_FUNC(icc_hppir1_el1, ICC_HPPIR1_EL1)
@@ -324,6 +337,7 @@ DEFINE_RENAME_SYSREG_READ_FUNC(icc_iar1_el1, ICC_IAR1_EL1)
 DEFINE_RENAME_SYSREG_WRITE_FUNC(icc_eoir0_el1, ICC_EOIR0_EL1)
 DEFINE_RENAME_SYSREG_WRITE_FUNC(icc_eoir1_el1, ICC_EOIR1_EL1)
 DEFINE_RENAME_SYSREG_WRITE_FUNC(icc_sgi0r_el1, ICC_SGI0R_EL1)
+DEFINE_RENAME_SYSREG_RW_FUNCS(icc_sgi1r, ICC_SGI1R)
 
 DEFINE_RENAME_SYSREG_RW_FUNCS(amcgcr_el0, AMCGCR_EL0)
 DEFINE_RENAME_SYSREG_RW_FUNCS(amcntenclr0_el0, AMCNTENCLR0_EL0)
@@ -351,11 +365,14 @@ DEFINE_RENAME_SYSREG_READ_FUNC(erxaddr_el1, ERXADDR_EL1)
 DEFINE_RENAME_SYSREG_READ_FUNC(erxmisc0_el1, ERXMISC0_EL1)
 DEFINE_RENAME_SYSREG_READ_FUNC(erxmisc1_el1, ERXMISC1_EL1)
 
+/* Armv8.3 Pointer Authentication Registers */
+DEFINE_RENAME_SYSREG_RW_FUNCS(apgakeylo_el1, APGAKeyLo_EL1)
+
 #define IS_IN_EL(x) \
 	(GET_EL(read_CurrentEl()) == MODE_EL##x)
 
 #define IS_IN_EL1() IS_IN_EL(1)
-#define IS_IN_EL3() IS_IN_EL(3)
+#define IS_IN_EL2() IS_IN_EL(2)
 #define IS_IN_EL3() IS_IN_EL(3)
 
 static inline unsigned int get_current_el(void)

--- a/include/lib/utils_def.h
+++ b/include/lib/utils_def.h
@@ -160,5 +160,6 @@
  */
 #define ASSERT_SYM_PTR_ALIGN(sym) assert(((size_t)(sym) % __alignof__(*(sym))) == 0)
 
+#define COMPILER_BARRIER() __asm__ volatile ("" ::: "memory")
 
 #endif /* UTILS_DEF_H */

--- a/plat/arm/common/arm_common.c
+++ b/plat/arm/common/arm_common.c
@@ -128,10 +128,10 @@ void arm_configure_sys_timer(void)
 	/*
 	 * Initialize CNTFRQ register in Non-secure CNTBase frame.
 	 * This is only required for Juno, because it doesn't follow ARM ARM
-	 * in that the value updated in CNTFRQ is not reflected in CNTBASE_CNTFRQ.
-	 * Hence update the value manually.
+	 * in that the value updated in CNTFRQ is not reflected in
+	 * CNTBASEN_CNTFRQ. Hence update the value manually.
 	 */
-	mmio_write_32(ARM_SYS_CNT_BASE_NS + CNTBASE_CNTFRQ, freq_val);
+	mmio_write_32(ARM_SYS_CNT_BASE_NS + CNTBASEN_CNTFRQ, freq_val);
 #endif
 }
 #endif /* ARM_SYS_TIMCTL_BASE */


### PR DESCRIPTION
The headers forked at some point in the past and have diverged a lot. In order to make it easier to share code between TF-A-Tests and TF-A, this patch synchronises most of the definitions in the mentioned headers.

This is not a complete sync, it has to be followed by more cleanup.

This patch also removes the read helpers for the AArch32 instructions ``ats1cpr`` and ``ats1hr`` (they are write-only).

This PR depends on https://github.com/ARM-software/arm-trusted-firmware/pull/1694