### PR TITLE
hikey960: initialize EDMAC and channels

### DIFF
--- a/plat/hisilicon/hikey960/hikey960_bl31_setup.c
+++ b/plat/hisilicon/hikey960/hikey960_bl31_setup.c
@@ -14,6 +14,7 @@
 #include <generic_delay_timer.h>
 #include <gicv2.h>
 #include <hi3660.h>
+#include <mmio.h>
 #include <hisi_ipc.h>
 #include <interrupt_mgmt.h>
 #include <interrupt_props.h>
@@ -143,6 +144,19 @@ void bl31_plat_arch_setup(void)
 			BL31_COHERENT_RAM_LIMIT);
 }
 
+static void hikey960_edma_init(void)
+{
+	int i;
+	uint32_t non_secure;
+
+	non_secure = EDMAC_SEC_CTRL_INTR_SEC | EDMAC_SEC_CTRL_GLOBAL_SEC;
+	mmio_write_32(EDMAC_SEC_CTRL, non_secure);
+
+	for (i = 0; i < EDMAC_CHANNEL_NUMS; i++) {
+		mmio_write_32(EDMAC_AXI_CONF(i), (1 << 6) | (1 << 18));
+	}
+}
+
 void bl31_platform_setup(void)
 {
 	/* Initialize the GIC driver, cpu and distributor interfaces */
@@ -150,6 +164,8 @@ void bl31_platform_setup(void)
 	gicv2_distif_init();
 	gicv2_pcpu_distif_init();
 	gicv2_cpuif_enable();
+
+	hikey960_edma_init();
 
 	hisi_ipc_init();
 }

--- a/plat/hisilicon/hikey960/include/hi3660.h
+++ b/plat/hisilicon/hikey960/include/hi3660.h
@@ -366,4 +366,11 @@
 /* GPIO219: PD interrupt. pull up */
 #define IOCG_AO_043_REG			(IOCG_AO_REG_BASE + 0x030)
 
+#define EDMAC_BASE				0xfdf30000
+#define EDMAC_SEC_CTRL				(EDMAC_BASE + 0x694)
+#define EDMAC_AXI_CONF(x)			(EDMAC_BASE + 0x820 + (x << 6))
+#define EDMAC_SEC_CTRL_INTR_SEC			(1 << 1)
+#define EDMAC_SEC_CTRL_GLOBAL_SEC		(1 << 0)
+#define EDMAC_CHANNEL_NUMS				16
+
 #endif /* HI3660_H */


### PR DESCRIPTION
This is needed to utilize the DMA controller on the hikey960

Signed-off-by: Ryan Grachek <ryan@edited.us>