### PR TITLE
plat/arm/sgi: Use platform specific functions to get platform ids

### DIFF
--- a/plat/arm/board/sgi575/platform.mk
+++ b/plat/arm/board/sgi575/platform.mk
@@ -14,12 +14,14 @@ SGI_CPU_SOURCES		:=	lib/cpus/aarch64/cortex_a75.S
 
 BL1_SOURCES		+=	${SGI_CPU_SOURCES}
 
-BL2_SOURCES		+=	${SGI575_BASE}/sgi575_security.c	\
+BL2_SOURCES		+=	${SGI575_BASE}/sgi575_plat.c		\
+				${SGI575_BASE}/sgi575_security.c	\
 				drivers/arm/tzc/tzc_dmc620.c		\
 				lib/utils/mem_region.c			\
 				plat/arm/common/arm_nor_psci_mem_protect.c
 
 BL31_SOURCES		+=	${SGI_CPU_SOURCES}			\
+				${SGI575_BASE}/sgi575_plat.c		\
 				drivers/cfi/v2m/v2m_flash.c		\
 				lib/utils/mem_region.c			\
 				plat/arm/common/arm_nor_psci_mem_protect.c

--- a/plat/arm/board/sgi575/sgi575_plat.c
+++ b/plat/arm/board/sgi575/sgi575_plat.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <platform.h>
+
+unsigned int plat_arm_sgi_get_platform_id(void)
+{
+	return mmio_read_32(SSC_VERSION) & SSC_VERSION_PART_NUM_MASK;
+}
+
+unsigned int plat_arm_sgi_get_config_id(void)
+{
+	return (mmio_read_32(SSC_VERSION) >> SSC_VERSION_CONFIG_SHIFT)
+			& SSC_VERSION_CONFIG_MASK;
+}

--- a/plat/arm/board/sgiclarka/platform.mk
+++ b/plat/arm/board/sgiclarka/platform.mk
@@ -14,12 +14,14 @@ SGI_CPU_SOURCES		:=	lib/cpus/aarch64/cortex_ares.S
 
 BL1_SOURCES		+=	${SGI_CPU_SOURCES}
 
-BL2_SOURCES		+=	${SGICLARKA_BASE}/sgiclarka_security.c	\
+BL2_SOURCES		+=	${SGICLARKA_BASE}/sgiclarka_plat.c	\
+				${SGICLARKA_BASE}/sgiclarka_security.c	\
 				drivers/arm/tzc/tzc_dmc620.c		\
 				lib/utils/mem_region.c			\
 				plat/arm/common/arm_nor_psci_mem_protect.c
 
 BL31_SOURCES		+=	${SGI_CPU_SOURCES}			\
+				${SGICLARKA_BASE}/sgiclarka_plat.c	\
 				drivers/cfi/v2m/v2m_flash.c		\
 				lib/utils/mem_region.c			\
 				plat/arm/common/arm_nor_psci_mem_protect.c

--- a/plat/arm/board/sgiclarka/sgiclarka_plat.c
+++ b/plat/arm/board/sgiclarka/sgiclarka_plat.c
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <platform.h>
+
+unsigned int plat_arm_sgi_get_platform_id(void)
+{
+	return mmio_read_32(SID_REG_BASE + SID_SYSTEM_ID_OFFSET)
+				& SID_SYSTEM_ID_PART_NUM_MASK;
+}
+
+unsigned int plat_arm_sgi_get_config_id(void)
+{
+	return mmio_read_32(SID_REG_BASE + SID_SYSTEM_CFG_OFFSET);
+}

--- a/plat/arm/css/sgi/include/sgi_variant.h
+++ b/plat/arm/css/sgi/include/sgi_variant.h
@@ -21,4 +21,10 @@ typedef struct sgi_platform_info {
 
 extern sgi_platform_info_t sgi_plat_info;
 
+/* returns the part number of the platform*/
+unsigned int plat_arm_sgi_get_platform_id(void);
+
+/* returns the configuration id of the platform */
+unsigned int plat_arm_sgi_get_config_id(void);
+
 #endif /* SGI_VARIANT_H */

--- a/plat/arm/css/sgi/sgi_bl31_setup.c
+++ b/plat/arm/css/sgi/sgi_bl31_setup.c
@@ -42,53 +42,11 @@ scmi_channel_plat_info_t *plat_css_get_scmi_info()
 		panic();
 };
 
-/*******************************************************************************
- * This function sets the sgi_platform_id and sgi_config_id
- ******************************************************************************/
-int sgi_identify_platform(unsigned long hw_config)
-{
-	void *fdt;
-	int nodeoffset;
-	const unsigned int *property;
-
-	fdt = (void *)hw_config;
-
-	/* Check the validity of the fdt */
-	assert(fdt_check_header(fdt) == 0);
-
-	nodeoffset = fdt_subnode_offset(fdt, 0, "system-id");
-	if (nodeoffset < 0) {
-		ERROR("Failed to get system-id node offset\n");
-		return -1;
-	}
-
-	property = fdt_getprop(fdt, nodeoffset, "platform-id", NULL);
-	if (property == NULL) {
-		ERROR("Failed to get platform-id property\n");
-		return -1;
-	}
-
-	sgi_plat_info.platform_id = fdt32_to_cpu(*property);
-
-	property = fdt_getprop(fdt, nodeoffset, "config-id", NULL);
-	if (property == NULL) {
-		ERROR("Failed to get config-id property\n");
-		return -1;
-	}
-
-	sgi_plat_info.config_id = fdt32_to_cpu(*property);
-
-	return 0;
-}
-
 void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 				u_register_t arg2, u_register_t arg3)
 {
-	int ret;
-
-	ret = sgi_identify_platform(arg2);
-	if (ret == -1)
-		panic();
+	sgi_plat_info.platform_id = plat_arm_sgi_get_platform_id();
+	sgi_plat_info.config_id = plat_arm_sgi_get_config_id();
 
 	arm_bl31_early_platform_setup((void *)arg0, arg1, arg2, (void *)arg3);
 }


### PR DESCRIPTION
Add two new functions 'plat_arm_sgi_get_platform_id' and
'plat_arm_sgi_get_config_id' which will be implemented by all the
SGI platforms. These functions can be used to determine the part
number and configuration id of the SGI platforms.

In BL2, these functions are used to populate the 'system-id' node.
In BL31, these functions are used to populate the 'sgi_plat_info_t'
structure with the part number and configuration id of the platform.

Change-Id: I3bacda933527724a3b4074ad4ed5b53a81ea4689
Signed-off-by: Chandni Cherukuri <chandni.cherukuri@arm.com>