### PR TITLE
Add possibility to add compilation warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,8 +226,12 @@ else ifeq (${W},3)
 WARNINGS := $(WARNING1) $(WARNING2) $(WARNING3)
 endif
 
+ifneq (${E},0)
+ERRORS := -Werror
+endif
+
 CPPFLAGS		=	${DEFINES} ${INCLUDES} ${MBEDTLS_INC} -nostdinc		\
-				-Wmissing-include-dirs -Werror $(WARNINGS)
+				-Wmissing-include-dirs $(ERRORS) $(WARNINGS)
 ASFLAGS			+=	$(CPPFLAGS) $(ASFLAGS_$(ARCH))			\
 				-D__ASSEMBLY__ -ffreestanding 			\
 				-Wa,--fatal-warnings

--- a/Makefile
+++ b/Makefile
@@ -188,8 +188,46 @@ TF_CFLAGS_aarch64	+=	-mgeneral-regs-only -mstrict-align
 ASFLAGS_aarch32		=	$(march32-directive)
 ASFLAGS_aarch64		=	-march=armv8-a
 
+WARNING1 := -Wextra
+WARNING1 += -Wunused -Wno-unused-parameter
+WARNING1 += -Wmissing-declarations
+WARNING1 += -Wmissing-format-attribute
+WARNING1 += -Wmissing-prototypes
+WARNING1 += -Wold-style-definition
+WARNING1 += -Wunused-but-set-variable
+WARNING1 += -Wunused-const-variable
+
+WARNING2 := -Waggregate-return
+WARNING2 += -Wcast-align
+WARNING2 += -Wdisabled-optimization
+WARNING2 += -Wnested-externs
+WARNING2 += -Wshadow
+WARNING2 += -Wlogical-op
+WARNING2 += -Wmissing-field-initializers
+WARNING2 += -Wsign-compare
+WARNING2 += -Wmaybe-uninitialized
+
+WARNING3 := -Wbad-function-cast
+WARNING3 += -Wcast-qual
+WARNING3 += -Wconversion
+WARNING3 += -Wpacked
+WARNING3 += -Wpadded
+WARNING3 += -Wpointer-arith
+WARNING3 += -Wredundant-decls
+WARNING3 += -Wswitch-default
+WARNING3 += -Wpacked-bitfield-compat
+WARNING3 += -Wvla
+
+ifeq (${W},1)
+WARNINGS := $(WARNING1)
+else ifeq (${W},2)
+WARNINGS := $(WARNING1) $(WARNING2)
+else ifeq (${W},3)
+WARNINGS := $(WARNING1) $(WARNING2) $(WARNING3)
+endif
+
 CPPFLAGS		=	${DEFINES} ${INCLUDES} ${MBEDTLS_INC} -nostdinc		\
-				-Wmissing-include-dirs -Werror
+				-Wmissing-include-dirs -Werror $(WARNINGS)
 ASFLAGS			+=	$(CPPFLAGS) $(ASFLAGS_$(ARCH))			\
 				-D__ASSEMBLY__ -ffreestanding 			\
 				-Wa,--fatal-warnings

--- a/bl2/aarch32/bl2_arch_setup.c
+++ b/bl2/aarch32/bl2_arch_setup.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include "../bl2_private.h"
 
 /*******************************************************************************
  * Place holder function to perform any Secure SVC specific architectural

--- a/bl2/bl2_private.h
+++ b/bl2/bl2_private.h
@@ -8,6 +8,9 @@
 #define BL2_PRIVATE_H
 
 #if BL2_IN_XIP_MEM
+
+#include <stdint.h>
+
 /*******************************************************************************
  * Declarations of linker defined symbols which will tell us where BL2 lives
  * in Trusted ROM and RAM

--- a/drivers/io/io_block.c
+++ b/drivers/io/io_block.c
@@ -67,8 +67,10 @@ io_type_t device_type_block(void)
 static int find_first_block_state(const io_block_dev_spec_t *dev_spec,
 				  unsigned int *index_out)
 {
+	unsigned int index;
 	int result = -ENOENT;
-	for (int index = 0; index < MAX_IO_BLOCK_DEVICES; ++index) {
+
+	for (index = 0U; index < MAX_IO_BLOCK_DEVICES; ++index) {
 		/* dev_spec is used as identifier since it's unique */
 		if (state_pool[index].dev_spec == dev_spec) {
 			result = 0;

--- a/plat/common/plat_log_common.c
+++ b/plat/common/plat_log_common.c
@@ -5,6 +5,7 @@
  */
 
 #include <debug.h>
+#include <platform.h>
 
 /* Allow platforms to override the log prefix string */
 #pragma weak plat_log_get_prefix

--- a/plat/hisilicon/hikey/include/platform_def.h
+++ b/plat/hisilicon/hikey/include/platform_def.h
@@ -41,7 +41,7 @@
 #define MAX_IO_DEVICES			3
 #define MAX_IO_HANDLES			4
 /* eMMC RPMB and eMMC User Data */
-#define MAX_IO_BLOCK_DEVICES		2
+#define MAX_IO_BLOCK_DEVICES		U(2)
 
 /* GIC related constants (no GICR in GIC-400) */
 #define PLAT_ARM_GICD_BASE		0xF6801000

--- a/plat/hisilicon/hikey960/include/platform_def.h
+++ b/plat/hisilicon/hikey960/include/platform_def.h
@@ -38,7 +38,7 @@
 #define MAX_IO_DEVICES			3
 #define MAX_IO_HANDLES			4
 /* UFS RPMB and UFS User Data */
-#define MAX_IO_BLOCK_DEVICES		2
+#define MAX_IO_BLOCK_DEVICES		U(2)
 
 
 /*

--- a/plat/hisilicon/poplar/include/platform_def.h
+++ b/plat/hisilicon/poplar/include/platform_def.h
@@ -40,7 +40,7 @@
 /* IO framework user */
 #define MAX_IO_DEVICES			(4)
 #define MAX_IO_HANDLES			(4)
-#define MAX_IO_BLOCK_DEVICES		(2)
+#define MAX_IO_BLOCK_DEVICES		U(2)
 
 /* Memory size options */
 #define POPLAR_DRAM_SIZE_1G	0

--- a/plat/imx/imx7/warp7/include/platform_def.h
+++ b/plat/imx/imx7/warp7/include/platform_def.h
@@ -169,7 +169,7 @@
 #define MAX_XLAT_TABLES			6
 #define MAX_IO_DEVICES			2
 #define MAX_IO_HANDLES			3
-#define MAX_IO_BLOCK_DEVICES		1
+#define MAX_IO_BLOCK_DEVICES		1U
 
 /* UART defines */
 #if PLAT_WARP7_UART == 1

--- a/plat/socionext/uniphier/include/platform_def.h
+++ b/plat/socionext/uniphier/include/platform_def.h
@@ -53,7 +53,7 @@
 
 #define MAX_IO_HANDLES			2
 #define MAX_IO_DEVICES			2
-#define MAX_IO_BLOCK_DEVICES		1
+#define MAX_IO_BLOCK_DEVICES		U(1)
 
 #define TSP_SEC_MEM_BASE		(BL32_BASE)
 #define TSP_SEC_MEM_SIZE		((BL32_LIMIT) - (BL32_BASE))


### PR DESCRIPTION
This is based on the same warnings lists as defined in kernel.
To activate this, the option W=x has to be provided in make command, with x=1, 2 or 3.
W=1 adds warning of the first list, W=2 adds warnings of the first and second list, and W=3 adds the warnings of the 3 lists.
When activating this, the -Werror is disabled, or else we would only have the first warning(s), and the compilation would end.

This series also includes 2 patches that corrects some warnings.