### PR TITLE
Change copyright guidelines

### DIFF
--- a/acknowledgements.rst
+++ b/acknowledgements.rst
@@ -1,3 +1,9 @@
+**Note: This file is only relevant for legacy contributions, to acknowledge the
+specific contributors referred to in "Arm Limited and Contributors" copyright
+notices. As contributors are now encouraged to put their name or company name
+directly into the copyright notices, this file is not relevant for new
+contributions.**
+
 Contributor Acknowledgements
 ============================
 

--- a/contributing.rst
+++ b/contributing.rst
@@ -50,19 +50,19 @@ Making Changes
       other in-source documentation needs updating.
    -  Ensure that each changed file has the correct copyright and license
       information. Files that entirely consist of contributions to this
-      project should have the copyright notice and BSD-3-Clause SPDX license
-      identifier as shown in `license.rst`_. Files that contain
-      changes to imported Third Party IP should contain a notice as follows,
-      with the original copyright and license text retained:
+      project should have a copyright notice and BSD-3-Clause SPDX license
+      identifier of the form as shown in `license.rst`_. Files that contain
+      changes to imported Third Party IP files should retain their original
+      copyright and license notices. For significant contributions you may
+      add your own copyright notice in following format:
 
       ::
 
-          Portions copyright (c) [XXXX-]YYYY, Arm Limited and Contributors. All rights reserved.
+          Portions copyright (c) [XXXX-]YYYY, <OWNER>. All rights reserved.
 
       where XXXX is the year of first contribution (if different to YYYY) and
-      YYYY is the year of most recent contribution.
-   -  If not done previously, you may add your name or your company name to
-      the `Acknowledgements`_ file.
+      YYYY is the year of most recent contribution. <OWNER> is your name or
+      your company name.
    -  If you are submitting new files that you intend to be the technical
       sub-maintainer for (for example, a new platform port), then also update
       the `Maintainers`_ file.

--- a/license.rst
+++ b/license.rst
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2018, Arm Limited and Contributors. All rights reserved.
+Copyright (c) [XXXX-]YYYY, <OWNER>. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:


### PR DESCRIPTION
Copyright guidance has been changed for migration of the
ARM run project to trustedfirmware.org where the project
governance is different.

Change-Id: I059177453fb357843eced93c2a55b3705a379683
Signed-off-by: Joanna Farley <joanna.farley@arm.com>