### PR TITLE
romlib: Add platform specific jump table list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -880,7 +880,7 @@ ${SPTOOL}:
 
 .PHONY: libraries
 romlib.bin: libraries
-	${Q}${MAKE} BUILD_PLAT=${BUILD_PLAT} INCLUDES='${INCLUDES}' DEFINES='${DEFINES}' --no-print-directory -C ${ROMLIBPATH} all
+	${Q}${MAKE} PLAT_DIR=${PLAT_DIR} BUILD_PLAT=${BUILD_PLAT} INCLUDES='${INCLUDES}' DEFINES='${DEFINES}' --no-print-directory -C ${ROMLIBPATH} all
 
 cscope:
 	@echo "  CSCOPE"

--- a/lib/romlib/Makefile
+++ b/lib/romlib/Makefile
@@ -60,11 +60,16 @@ $(WRAPPER_DIR)/jmpvar.s: $(BUILD_DIR)/romlib.elf
 
 $(LIB_DIR)/libwrappers.a: jmptbl.i $(WRAPPER_DIR)/jmpvar.o
 	@echo "  AR      $@"
-	$(Q)./genwrappers.sh -b $(WRAPPER_DIR) -o $@ jmptbl.i
+	$(Q)./genwrappers.sh -b $(WRAPPER_DIR) -o $@ $(BUILD_DIR)/jmptbl.i
 
 $(BUILD_DIR)/jmptbl.s: jmptbl.i
 	@echo "  TBL     $@"
-	$(Q)./gentbl.sh -o $@ jmptbl.i
+	if [ -e "../../$(PLAT_DIR)/jmptbl.i" ] ; \
+	then \
+		$(Q)./gentbl.sh -o $@ -b $(BUILD_DIR) ../../$(PLAT_DIR)/jmptbl.i; \
+	else \
+		@echo "USE_ROMLIB=1 requires jump table list file: jmptbl.i in platform directory"; \
+	fi
 
 clean:
 	@rm -f $(BUILD_DIR)/*

--- a/lib/romlib/gentbl.sh
+++ b/lib/romlib/gentbl.sh
@@ -6,6 +6,7 @@
 set -e
 
 output=jmptbl.s
+build=.
 
 for i
 do
@@ -14,27 +15,45 @@ do
 		output=$2
 		shift 2
 		;;
+	-b)
+		build=$2
+		shift 2
+		;;
 	--)
 		shift
 		break
 		;;
 	-*)
-		echo usage: gentbl.sh [-o output]  file ... >&2
+		echo usage: gentbl.sh [-o output] [-b dir] file ... >&2
 		exit 1
 		;;
 	esac
 done
 
 tmp=`mktemp`
-trap "rm -f $tmp" EXIT INT QUIT
-
+trap "rm -f $$.tmp" EXIT INT QUIT
 rm -f $output
 
+# Pre-process include files
+awk '!/^$/ && !/[:blank:]*#.*/{
+if (NF == 2 && $1 == "include") {
+	while ((getline line < $2) > 0)
+		if (line !~ /^$/ && line !~ /[:blank:]*#.*/)
+			print line
+		close($2)
+} else
+	print
+}' "$@" |
+awk -v OFS="\t" '
+BEGIN{print "#index\tlib\tfunction\t[patch]"}
+{print NR-1, $0}' | tee $build/jmptbl.i |
 awk -v OFS="\n" '
 BEGIN {print "\t.text",
              "\t.globl\tjmptbl",
              "jmptbl:"}
       {sub(/[:blank:]*#.*/,"")}
-!/^$/ {print "\tb\t" $3}' "$@" > $tmp
-
-mv $tmp $output
+!/^$/ {if ($3 == "reserved")
+		print "\t.word\t0x0"
+	else
+		print "\tb\t" $3}' > $$.tmp &&
+mv $$.tmp $output

--- a/lib/romlib/genwrappers.sh
+++ b/lib/romlib/genwrappers.sh
@@ -31,7 +31,7 @@ do
 done
 
 awk  '{sub(/[:blank:]*#.*/,"")}
-!/^$/ && !/\\tpatch$/ {print $1*4, $2, $3}' "$@" |
+!/^$/ && !/\\tpatch$/ !/\\treserved$/ {print $1*4, $2, $3}' "$@" |
 while read idx lib sym
 do
 	file=$build/${lib}_$sym

--- a/lib/romlib/jmptbl.i
+++ b/lib/romlib/jmptbl.i
@@ -4,37 +4,40 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 # Format:
-# index	lib	function	[patch]
+# lib	function	[patch]
 # Add "patch" at the end of the line to patch a function. For example:
-# 14	mbedtls	mbedtls_memory_buffer_alloc_init	patch
+# mbedtls	mbedtls_memory_buffer_alloc_init	patch
+# Holes can be introduced in the table by using a special keyword "reserved".
+# Example:
+# reserved	reserved
+# The jump table will contain an invalid instruction instead of branch
 
-0	rom	rom_lib_init
-1	fdt	fdt_getprop_namelen
-2	fdt	fdt_setprop_inplace
-3	fdt	fdt_check_header
-4	fdt	fdt_node_offset_by_compatible
-5	mbedtls	mbedtls_asn1_get_alg
-6	mbedtls	mbedtls_asn1_get_alg_null
-7	mbedtls	mbedtls_asn1_get_bitstring_null
-8	mbedtls	mbedtls_asn1_get_bool
-9	mbedtls	mbedtls_asn1_get_int
-10	mbedtls	mbedtls_asn1_get_tag
-11	mbedtls	mbedtls_free
-12	mbedtls	mbedtls_md
-13	mbedtls	mbedtls_md_get_size
-14	mbedtls	mbedtls_memory_buffer_alloc_init
-15	mbedtls	mbedtls_oid_get_md_alg
-16	mbedtls	mbedtls_oid_get_numeric_string
-17	mbedtls	mbedtls_oid_get_pk_alg
-18	mbedtls	mbedtls_oid_get_sig_alg
-19	mbedtls	mbedtls_pk_free
-20	mbedtls	mbedtls_pk_init
-21	mbedtls	mbedtls_pk_parse_subpubkey
-22	mbedtls	mbedtls_pk_verify_ext
-23	mbedtls	mbedtls_platform_set_calloc_free
-24	mbedtls	mbedtls_platform_set_snprintf
-25	mbedtls	mbedtls_x509_get_rsassa_pss_params
-26	mbedtls	mbedtls_x509_get_sig_alg
-27	mbedtls	mbedtls_md_info_from_type
-28	c	exit
-29	c	atexit
+rom	rom_lib_init
+fdt	fdt_getprop_namelen
+fdt	fdt_setprop_inplace
+fdt	fdt_check_header
+fdt	fdt_node_offset_by_compatible
+mbedtls	mbedtls_asn1_get_alg
+mbedtls	mbedtls_asn1_get_alg_null
+mbedtls	mbedtls_asn1_get_bitstring_null
+mbedtls	mbedtls_asn1_get_bool
+mbedtls	mbedtls_asn1_get_int
+mbedtls	mbedtls_asn1_get_tag
+mbedtls	mbedtls_free
+mbedtls	mbedtls_md
+mbedtls	mbedtls_md_get_size
+mbedtls	mbedtls_memory_buffer_alloc_init
+mbedtls	mbedtls_oid_get_md_alg
+mbedtls	mbedtls_oid_get_numeric_string
+mbedtls	mbedtls_oid_get_pk_alg
+mbedtls	mbedtls_oid_get_sig_alg
+mbedtls	mbedtls_pk_free
+mbedtls	mbedtls_pk_init
+mbedtls	mbedtls_pk_parse_subpubkey
+mbedtls	mbedtls_pk_verify_ext
+mbedtls	mbedtls_platform_set_snprintf
+mbedtls	mbedtls_x509_get_rsassa_pss_params
+mbedtls	mbedtls_x509_get_sig_alg
+mbedtls	mbedtls_md_info_from_type
+c	exit
+c	atexit

--- a/plat/arm/board/fvp/jmptbl.i
+++ b/plat/arm/board/fvp/jmptbl.i
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Platform specific romlib functions can be added or included here.
+# The index in the output file will be generated cumulatively in the same
+# order as it is given in this file.
+# Output file can be found at: $BUILD_DIR/jmptbl.i
+#
+# Format:
+# lib	function	[patch]
+# Example:
+# rom	rom_lib_init
+# fdt	fdt_getprop_namelen	patch
+
+include ../../lib/romlib/jmptbl.i

--- a/plat/arm/board/juno/jmptbl.i
+++ b/plat/arm/board/juno/jmptbl.i
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Platform specific romlib functions can be added or included here.
+# The index in the output file will be generated cumulatively in the same
+# order as it is given in this file.
+# Output file can be found at: $BUILD_DIR/jmptbl.i
+#
+# Format:
+# lib	function	[patch]
+# Example:
+# rom	rom_lib_init
+# fdt	fdt_getprop_namelen	patch
+
+include ../../lib/romlib/jmptbl.i


### PR DESCRIPTION
This patch allows platforms to define their
own jump table list for library at ROM. The
file has the list of functions to be used
from library at ROM. It can also include
other list files.

Change-Id: I721c35d7dad3dcadbb3a7f3277bfd5d3e1f6e00a
Signed-off-by: Sathees Balya <sathees.balya@arm.com>