### PR TITLE
build: find "armclang" string in the 'CC' variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,7 +154,7 @@ target32-directive	= 	-target armv8a-none-eabi
 march32-directive	= 	-march=armv8-a
 endif
 
-ifeq ($(notdir $(CC)),armclang)
+ifneq ($(findstring armclang,$(notdir $(CC))),)
 TF_CFLAGS_aarch32	=	-target arm-arm-none-eabi $(march32-directive)
 TF_CFLAGS_aarch64	=	-target aarch64-arm-none-eabi -march=armv8-a
 LD			=	$(LINKER)


### PR DESCRIPTION
This patch modifies the search criteria to see if we are using 'armclang'
as the compiler. Switch over to using 'findstring' which enables platforms
to do fancy stuff using scripts e.g. check if armclang timed out and retry
compilation.

Change-Id: If2162ebadb9033f6457a4e8d4243345e711defe6
Signed-off-by: Kalyani Chidambaram Vaidyanathan <kalyanic@nvidia.com>
Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>