### PR TITLE
GIC: Remove lowest priority constants

### DIFF
--- a/include/drivers/arm/gic_common.h
+++ b/include/drivers/arm/gic_common.h
@@ -35,11 +35,9 @@
 #define GIC_INTR_CFG_LEVEL		(0 << 1)
 #define GIC_INTR_CFG_EDGE		(1 << 1)
 
-/* Constants to categorise priorities */
+/* Highest possible interrupt priorities */
 #define GIC_HIGHEST_SEC_PRIORITY	U(0x00)
-#define GIC_LOWEST_SEC_PRIORITY		U(0x7f)
 #define GIC_HIGHEST_NS_PRIORITY		U(0x80)
-#define GIC_LOWEST_NS_PRIORITY		U(0xfe) /* 0xff would disable all interrupts */
 
 /*******************************************************************************
  * GIC Distributor interface register offsets that are common to GICv3 & GICv2


### PR DESCRIPTION
The GIC lowest priority values for each world depends on the number of
priority values implemented in hardware. These constants currently
defined in gic_common.h only meant to enumerate lowest possible
architectural values. Since these values are not used in generic code or
upstream platforms, and that general use of these constants can be
wrong, remove these. Platforms should either define and use these as
appropriate, or determine correct values at run time.

Change-Id: I3805cea8ceb8a592b9eff681ea1b63b7496cec5f
Signed-off-by: Jeenu Viswambharan <jeenu.viswambharan@arm.com>