### PR TITLE
mmc: increase delay when initializing mmc

### DIFF
--- a/drivers/mmc/mmc.c
+++ b/drivers/mmc/mmc.c
@@ -404,7 +404,7 @@ static int mmc_send_op_cond(void)
 			return 0;
 		}
 
-		mdelay(1);
+		mdelay(10);
 	}
 
 	ERROR("CMD1 failed after %d retries\n", SEND_OP_COND_MAX_RETRIES);


### PR DESCRIPTION
Running TF-A 2.0 and later seems to cause a regression on the old CircuitCo HiKey 620 4GB (issue is not seen when running on LeMaker HiKey 620 8GB).

    NOTICE:  BL2: v2.0(release):v2.0
    NOTICE:  BL2: Built : 17:41:23, Dec 17 2018
    NOTICE:  acpu_dvfs_set_freq: set acpu freq success!ERROR:   CMD1 failed after 100 retries
    ERROR:   BL2: Failed to load image (-5)

The reason seems to be that during emmc enumeration when BL2 sends the command
    OCR_SECTOR_MODE | OCR_VDD_MIN_2V7 | OCR_VDD_MIN_1V7

it for some reason takes some more time to get a reply. So a delay with
mdelay(1), seems to not be enough any longer and therefore we increase it to
mdelay(10) instead which makes the device boot as expected again.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>

Note that I've tried with mdelay(5) which also seems to work, but since this is running in a loop running 100 times. I guess it doesn't actually matter that much if it's 1, 5 or 10. Since when the power state has changed it will take at most 10ms (instead of 1) to continue. This fixes the issue we've discussed in https://github.com/OP-TEE/optee_os/pull/2703#issuecomment-447924390.