### PR TITLE
clang: 32 bit compilation should include march32-directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ AS			=	$(CC) -c -x assembler-with-cpp $(TF_CFLAGS_$(ARCH))
 CPP			=	$(CC) -E $(TF_CFLAGS_$(ARCH))
 PP			=	$(CC) -E $(TF_CFLAGS_$(ARCH))
 else ifneq ($(findstring clang,$(notdir $(CC))),)
-TF_CFLAGS_aarch32	=	$(target32-directive)
+TF_CFLAGS_aarch32	=	$(target32-directive) $(march32-directive)
 TF_CFLAGS_aarch64	=	-target aarch64-elf
 LD			=	$(LINKER)
 AS			=	$(CC) -c -x assembler-with-cpp $(TF_CFLAGS_$(ARCH))


### PR DESCRIPTION
This is done for other compilers, and without this some code does not
compile, like inline assembly code.

Fixes ARM-software/tf-issues#657.

Signed-off-by: Yann Gautier <yann.gautier@st.com>