### PR TITLE
Enable DIT if supported

### DIFF
--- a/include/common/aarch32/el3_common_macros.S
+++ b/include/common/aarch32/el3_common_macros.S
@@ -110,6 +110,18 @@
 	stcopr	r0, SDCR
 #endif
 
+	/*
+	 * If Data Independent Timing (DIT) functionality is implemented,
+	 * always enable DIT in EL3
+	 */
+	ldcopr	r0, ID_PFR0
+	and	r0, r0, #(ID_PFR0_DIT_MASK << ID_PFR0_DIT_SHIFT)
+	cmp	r0, #ID_PFR0_DIT_SUPPORTED
+	bne	1f
+	mrs	r0, cpsr
+	orr	r0, r0, #CPSR_DIT_BIT
+	msr	cpsr_cxsf, r0
+1:
 	.endm
 
 /* -----------------------------------------------------------------------------

--- a/include/common/aarch64/el3_common_macros.S
+++ b/include/common/aarch64/el3_common_macros.S
@@ -130,6 +130,18 @@
 	 */
 	mov_imm x0, (CPTR_EL3_RESET_VAL & ~(TCPAC_BIT | TTA_BIT | TFP_BIT))
 	msr	cptr_el3, x0
+
+	/*
+	 * If Data Independent Timing (DIT) functionality is implemented,
+	 * always enable DIT in EL3
+	 */
+	mrs	x0, id_aa64pfr0_el1
+	ubfx	x0, x0, #ID_AA64PFR0_DIT_SHIFT, #ID_AA64PFR0_DIT_LENGTH
+	cmp	x0, #ID_AA64PFR0_DIT_SUPPORTED
+	bne	1f
+	mov	x0, #DIT_BIT
+	msr	DIT, x0
+1:
 	.endm
 
 /* -----------------------------------------------------------------------------

--- a/include/lib/aarch32/arch.h
+++ b/include/lib/aarch32/arch.h
@@ -94,10 +94,16 @@
 /* CSSELR definitions */
 #define LEVEL_SHIFT		U(1)
 
-/* ID_PFR0 definitions */
+/* ID_PFR0 AMU definitions */
 #define ID_PFR0_AMU_SHIFT	U(20)
 #define ID_PFR0_AMU_LENGTH	U(4)
 #define ID_PFR0_AMU_MASK	U(0xf)
+
+/* ID_PFR0 DIT definitions */
+#define ID_PFR0_DIT_SHIFT	U(24)
+#define ID_PFR0_DIT_LENGTH	U(4)
+#define ID_PFR0_DIT_MASK	U(0xf)
+#define ID_PFR0_DIT_SUPPORTED	(U(1) << ID_PFR0_DIT_SHIFT)
 
 /* ID_PFR1 definitions */
 #define ID_PFR1_VIRTEXT_SHIFT	U(12)
@@ -276,6 +282,7 @@
 #define DISABLE_ALL_EXCEPTIONS \
 		(SPSR_FIQ_BIT | SPSR_IRQ_BIT | SPSR_ABT_BIT)
 
+#define CPSR_DIT_BIT		(U(1) << 21)
 /*
  * TTBCR definitions
  */

--- a/include/lib/aarch64/arch.h
+++ b/include/lib/aarch64/arch.h
@@ -135,6 +135,10 @@
 #define ID_AA64PFR0_SVE_LENGTH	U(4)
 #define ID_AA64PFR0_MPAM_SHIFT	U(40)
 #define ID_AA64PFR0_MPAM_MASK	ULL(0xf)
+#define ID_AA64PFR0_DIT_SHIFT	U(48)
+#define ID_AA64PFR0_DIT_MASK	ULL(0xf)
+#define ID_AA64PFR0_DIT_LENGTH	U(4)
+#define ID_AA64PFR0_DIT_SUPPORTED	U(1)
 #define ID_AA64PFR0_CSV2_SHIFT	U(56)
 #define ID_AA64PFR0_CSV2_MASK	ULL(0xf)
 #define ID_AA64PFR0_CSV2_LENGTH	U(4)
@@ -778,7 +782,7 @@
 
 /*******************************************************************************
  * RAS system registers
- *******************************************************************************/
+ ******************************************************************************/
 #define DISR_EL1		S3_0_C12_C1_1
 #define DISR_A_BIT		U(31)
 
@@ -807,7 +811,13 @@
 
 /*******************************************************************************
  * Armv8.3 Pointer Authentication Registers
- *******************************************************************************/
+ ******************************************************************************/
 #define APGAKeyLo_EL1		S3_0_C2_C3_0
+
+/*******************************************************************************
+ * Armv8.4 Data Independent Timing Registers
+ ******************************************************************************/
+#define DIT			S3_3_C4_C2_5
+#define DIT_BIT			BIT(24)
 
 #endif /* ARCH_H */


### PR DESCRIPTION
This patch enables the Data Independent Timing
functionality (DIT) in EL3 if supported
by the PE.

Change-Id: Ia527d6aa2ee88a9a9fe1c941220404b9ff5567e5
Signed-off-by: Sathees Balya <sathees.balya@arm.com>