### PR TITLE
stm32mp1: do not include platform header files directly in drivers

### DIFF
--- a/drivers/st/clk/stm32mp1_clk.c
+++ b/drivers/st/clk/stm32mp1_clk.c
@@ -11,6 +11,8 @@
 
 #include <libfdt.h>
 
+#include <platform_def.h>
+
 #include <arch.h>
 #include <arch_helpers.h>
 #include <common/debug.h>
@@ -24,9 +26,6 @@
 #include <lib/mmio.h>
 #include <lib/utils_def.h>
 #include <plat/common/platform.h>
-
-#include <stm32mp1_dt.h>
-#include <stm32mp1_private.h>
 
 #define MAX_HSI_HZ	64000000
 

--- a/drivers/st/clk/stm32mp1_clkfunc.c
+++ b/drivers/st/clk/stm32mp1_clkfunc.c
@@ -8,11 +8,11 @@
 
 #include <libfdt.h>
 
+#include <platform_def.h>
+
 #include <drivers/st/stm32mp1_clk.h>
 #include <drivers/st/stm32mp1_clkfunc.h>
 #include <dt-bindings/clock/stm32mp1-clksrc.h>
-
-#include <stm32mp1_dt.h>
 
 #define DT_RCC_NODE_NAME	"rcc@50000000"
 #define DT_RCC_CLK_COMPAT	"st,stm32mp1-rcc"

--- a/drivers/st/ddr/stm32mp1_ddr.c
+++ b/drivers/st/ddr/stm32mp1_ddr.c
@@ -6,6 +6,8 @@
 
 #include <stddef.h>
 
+#include <platform_def.h>
+
 #include <arch.h>
 #include <arch_helpers.h>
 #include <common/debug.h>
@@ -20,9 +22,6 @@
 #include <dt-bindings/clock/stm32mp1-clks.h>
 #include <lib/mmio.h>
 #include <plat/common/platform.h>
-
-#include <stm32mp1_def.h>
-#include <stm32mp1_dt.h>
 
 struct reg_desc {
 	const char *name;

--- a/drivers/st/ddr/stm32mp1_ram.c
+++ b/drivers/st/ddr/stm32mp1_ram.c
@@ -20,10 +20,6 @@
 #include <dt-bindings/clock/stm32mp1-clks.h>
 #include <lib/mmio.h>
 
-#include <boot_api.h>
-#include <stm32mp1_dt.h>
-#include <stm32mp1_private.h>
-
 #define DDR_PATTERN	0xAAAAAAAAU
 #define DDR_ANTIPATTERN	0x55555555U
 

--- a/drivers/st/io/io_stm32image.c
+++ b/drivers/st/io/io_stm32image.c
@@ -18,8 +18,6 @@
 #include <lib/utils.h>
 #include <plat/common/platform.h>
 
-#include <boot_api.h>
-
 static uintptr_t backend_dev_handle;
 static uintptr_t backend_image_spec;
 static uint32_t *stm32_img;

--- a/drivers/st/mmc/stm32_sdmmc2.c
+++ b/drivers/st/mmc/stm32_sdmmc2.c
@@ -8,6 +8,10 @@
 #include <errno.h>
 #include <string.h>
 
+#include <libfdt.h>
+
+#include <platform_def.h>
+
 #include <arch.h>
 #include <arch_helpers.h>
 #include <common/debug.h>
@@ -19,12 +23,9 @@
 #include <drivers/st/stm32mp1_reset.h>
 #include <dt-bindings/clock/stm32mp1-clks.h>
 #include <dt-bindings/reset/stm32mp1-resets.h>
-#include <libfdt.h>
 #include <lib/mmio.h>
 #include <lib/utils.h>
 #include <plat/common/platform.h>
-
-#include <stm32mp1_dt.h>
 
 /* Registers offsets */
 #define SDMMC_POWER			0x00U

--- a/drivers/st/pmic/stm32mp1_pmic.c
+++ b/drivers/st/pmic/stm32mp1_pmic.c
@@ -20,9 +20,6 @@
 #include <lib/mmio.h>
 #include <lib/utils_def.h>
 
-#include <stm32mp1_def.h>
-#include <stm32mp1_dt.h>
-
 /* I2C Timing hard-coded value, for I2C clock source is HSI at 64MHz */
 #define I2C_TIMING			0x10D07DB5
 

--- a/include/drivers/st/stm32mp1_pmic.h
+++ b/include/drivers/st/stm32mp1_pmic.h
@@ -9,7 +9,7 @@
 
 #include <stdbool.h>
 
-#include <stm32mp1_def.h>
+#include <platform_def.h>
 
 bool dt_check_pmic(void);
 int dt_pmic_enable_boot_on_regulators(void);

--- a/plat/st/stm32mp1/platform.mk
+++ b/plat/st/stm32mp1/platform.mk
@@ -22,8 +22,6 @@ PLAT_PARTITION_MAX_ENTRIES	:=	$(shell echo $$(($(STM32_TF_A_COPIES) + 1)))
 $(eval $(call add_define,PLAT_PARTITION_MAX_ENTRIES))
 
 PLAT_INCLUDES		:=	-Iplat/st/stm32mp1/include/
-PLAT_INCLUDES		+=	-Iplat/st/stm32mp1/
-PLAT_INCLUDES		+=	-Iinclude/common/tbbr
 
 # Device tree
 STM32_DTB_FILE_NAME	?=	stm32mp157c-ev1.dtb

--- a/plat/st/stm32mp1/stm32mp1_def.h
+++ b/plat/st/stm32mp1/stm32mp1_def.h
@@ -11,6 +11,12 @@
 #include <lib/utils_def.h>
 #include <lib/xlat_tables/xlat_tables_defs.h>
 
+#ifndef __ASSEMBLY__
+#include <boot_api.h>
+#include <stm32mp1_dt.h>
+#include <stm32mp1_private.h>
+#endif
+
 /*******************************************************************************
  * STM32MP1 memory map related constants
  ******************************************************************************/


### PR DESCRIPTION
Instead, only platform_def.h is included.
The required files to be included are added in stm32mp1_def.h.

Signed-off-by: Yann Gautier <yann.gautier@st.com>