### PR TITLE
plat/arm: Restrict PIE support to FVP

### DIFF
--- a/include/plat/arm/common/arm_def.h
+++ b/include/plat/arm/common/arm_def.h
@@ -405,16 +405,21 @@
 #define BL31_LIMIT			(ARM_AP_TZC_DRAM1_BASE +	\
 						PLAT_ARM_MAX_BL31_SIZE)
 #elif (RESET_TO_BL31)
-/* Ensure Position Independent support (PIE) is enabled for this config.*/
-# if !ENABLE_PIE
-#  error "BL31 must be a PIE if RESET_TO_BL31=1."
-# endif
+
+# if ENABLE_PIE
 /*
  * Since this is PIE, we can define BL31_BASE to 0x0 since this macro is solely
- * used for building BL31 when RESET_TO_BL31=1.
+ * used for building BL31 and not used for loading BL31.
  */
-#define BL31_BASE			0x0
-#define BL31_LIMIT			PLAT_ARM_MAX_BL31_SIZE
+#  define BL31_BASE			0x0
+#  define BL31_LIMIT			PLAT_ARM_MAX_BL31_SIZE
+# else
+/* Put BL31_BASE in the middle of the Trusted SRAM.*/
+#  define BL31_BASE			(ARM_TRUSTED_SRAM_BASE + \
+					(PLAT_ARM_TRUSTED_SRAM_SIZE >> 1))
+#  define BL31_LIMIT			(ARM_BL_RAM_BASE + ARM_BL_RAM_SIZE)
+# endif /* ENABLE_PIE */
+
 #else
 /* Put BL31 below BL2 in the Trusted SRAM.*/
 #define BL31_BASE			((ARM_BL_RAM_BASE + ARM_BL_RAM_SIZE)\

--- a/plat/arm/board/fvp/platform.mk
+++ b/plat/arm/board/fvp/platform.mk
@@ -201,9 +201,15 @@ ENABLE_AMU			:=	1
 # Enable dynamic mitigation support by default
 DYNAMIC_WORKAROUND_CVE_2018_3639	:=	1
 
-# Enable reclaiming of BL31 initialisation code for secondary cores stacks for FVP
 ifneq (${RESET_TO_BL31},1)
+# Enable reclaiming of BL31 initialisation code for secondary cores stacks for
+# FVP. We cannot enable PIE for this case because the overlayed init section
+# creates some dynamic relocations which cannot be handled by the fixup
+# logic currently.
 RECLAIM_INIT_CODE	:=	1
+else
+# Enable PIE support when RESET_TO_BL31=1
+ENABLE_PIE		:=	1
 endif
 
 ifeq (${ENABLE_AMU},1)

--- a/plat/arm/common/arm_common.mk
+++ b/plat/arm/common/arm_common.mk
@@ -133,11 +133,6 @@ ARM_CRYPTOCELL_INTEG		:=	0
 $(eval $(call assert_boolean,ARM_CRYPTOCELL_INTEG))
 $(eval $(call add_define,ARM_CRYPTOCELL_INTEG))
 
-# Enable PIE support for RESET_TO_BL31 case
-ifeq (${RESET_TO_BL31},1)
-    ENABLE_PIE			:=	1
-endif
-
 # CryptoCell integration relies on coherent buffers for passing data from
 # the AP CPU to the CryptoCell
 ifeq (${ARM_CRYPTOCELL_INTEG},1)


### PR DESCRIPTION
The patch SHA 55cf015c enabled PIE support when RESET_TO_BL31=1 for
all ARM platforms. But it seems n1sdp platform doesn't work with PIE
support yet. Hence restrict the ENABLE_PIE=1 to fvp platform.

Change-Id: If44e42528e4b0b57c69084503f346576fe0748bd
Signed-off-by: Soby Mathew <soby.mathew@arm.com>