### PR TITLE
Fix a variable expansion in Arm platform makefiles

### DIFF
--- a/plat/arm/board/juno/platform.mk
+++ b/plat/arm/board/juno/platform.mk
@@ -94,7 +94,7 @@ endif
 endif
 
 ifneq (${RESET_TO_BL31},0)
-  $(error "Using BL31 as the reset vector is not supported on ${PLATFORM} platform. \
+  $(error "Using BL31 as the reset vector is not supported on ${PLAT} platform. \
   Please set RESET_TO_BL31 to 0.")
 endif
 

--- a/plat/arm/css/sgi/sgi-common.mk
+++ b/plat/arm/css/sgi/sgi-common.mk
@@ -47,7 +47,7 @@ BL31_SOURCES		+=	${CSS_ENT_BASE}/sgi_ras.c
 endif
 
 ifneq (${RESET_TO_BL31},0)
-  $(error "Using BL31 as the reset vector is not supported on ${PLATFORM} platform. \
+  $(error "Using BL31 as the reset vector is not supported on ${PLAT} platform. \
   Please set RESET_TO_BL31 to 0.")
 endif
 

--- a/plat/arm/css/sgm/sgm-common.mk
+++ b/plat/arm/css/sgm/sgm-common.mk
@@ -46,7 +46,7 @@ BL31_SOURCES		+=	$(SGM_CPU_SOURCES)			\
 				${CSS_SGM_BASE}/sgm_plat_config.c
 
 ifneq (${RESET_TO_BL31},0)
-  $(error "Using BL31 as the reset vector is not supported on ${PLATFORM} platform. \
+  $(error "Using BL31 as the reset vector is not supported on ${PLAT} platform. \
   Please set RESET_TO_BL31 to 0.")
 endif
 


### PR DESCRIPTION
The top level makefile defines the PLAT variable, not PLATFORM.
This mistake was causing an empty variable expansion and showing an
incomplete error message.
