### PR TITLE
juno:Fix CSS_USE_SCMI_SDS_DRIVER=0 configuration

### DIFF
--- a/plat/arm/board/juno/juno_pm.c
+++ b/plat/arm/board/juno/juno_pm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -9,5 +9,9 @@
 
 const plat_psci_ops_t *plat_arm_psci_override_pm_ops(plat_psci_ops_t *ops)
 {
+#if CSS_USE_SCMI_SDS_DRIVER
 	return css_scmi_override_pm_ops(ops);
+#else
+	return ops;
+#endif /* CSS_USE_SCMI_SDS_DRIVER */
 }


### PR DESCRIPTION
A previous commit 89f2e589856f ("plat/arm: remove weak implemention of
'plat_arm_psci_override_pm_ops' function") introduced a problem with the
CSS_USE_SCMI_SDS_DRIVER configuration. In juno_pm.c the
css_scmi_override_pm_ops function was used regardless of whether the
flag was set. This patch ifdefs the function to restore the original
behaviour.

Change-Id: I508025ba70cf3a9250cc6270c1df209179c37ae7
Signed-off-by: Joel Hutton <Joel.Hutton@Arm.com>