### PR TITLE
mmc: correctly check ret in mmc_fill_device_info

### DIFF
--- a/drivers/mmc/mmc.c
+++ b/drivers/mmc/mmc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -300,7 +300,7 @@ static int mmc_fill_device_info(void)
 		break;
 	}
 
-	if (ret != 0) {
+	if (ret < 0) {
 		return ret;
 	}
 


### PR DESCRIPTION
In patch 93768644, ret will be MMC_STATE_TRAN (=4), which is a valid value.
We shouldn't exit the function in that case, but only if ret is < 0.

Signed-off-by: Yann Gautier <yann.gautier@st.com>