### PR TITLE
make lpuart and imx uart work for debug mode

### DIFF
--- a/plat/imx/common/imx_uart_console.S
+++ b/plat/imx/common/imx_uart_console.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -16,10 +16,11 @@
 #define UTS   0xb4 /* UART Test Register (mx31) */
 #define  URXD_RX_DATA    (0xFF)
 
-	.globl	console_uart_register
-	.globl	console_uart_init
-	.globl	console_uart_putc
-	.globl	console_uart_getc
+	.globl	console_imx_uart_register
+	.globl	console_imx_uart_init
+	.globl	console_imx_uart_putc
+	.globl	console_imx_uart_getc
+	.globl	console_imx_uart_flush
 
 func console_imx_uart_register
 	mov	x7, x30
@@ -32,7 +33,7 @@ func console_imx_uart_register
 
 	mov	x0, x6
 	mov	x30, x7
-	finish_console_register imx_uart putc=1, getc=1
+	finish_console_register imx_uart putc=1, getc=1, flush=1
 
 register_fail:
 	ret	x7
@@ -82,3 +83,8 @@ getc_error:
 	mov	w0, #-1
 	ret
 endfunc console_imx_uart_getc
+
+func console_imx_uart_flush
+	mov	x0, #0
+	ret
+endfunc console_imx_uart_flush

--- a/plat/imx/common/include/imx_uart.h
+++ b/plat/imx/common/include/imx_uart.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -16,7 +16,7 @@ typedef struct {
 	uintptr_t base;
 } console_uart_t;
 
-int console_uart_register(uintptr_t baseaddr, uint32_t clock, uint32_t baud,
+int console_imx_uart_register(uintptr_t baseaddr, uint32_t clock, uint32_t baud,
 			   console_uart_t *console);
 #endif /*__ASSEMBLY__*/
 

--- a/plat/imx/common/lpuart_console.S
+++ b/plat/imx/common/lpuart_console.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -15,6 +15,7 @@
 	.globl	console_lpuart_init
 	.globl	console_lpuart_putc
 	.globl	console_lpuart_getc
+	.globl	console_lpuart_flush
 
 func console_lpuart_register
 	mov	x7, x30
@@ -27,7 +28,7 @@ func console_lpuart_register
 
 	mov	x0, x6
 	mov	x30, x7
-	finish_console_register lpuart putc=1, getc=1
+	finish_console_register lpuart putc=1, getc=1, flush=1
 
 register_fail:
 	ret	x7
@@ -70,3 +71,8 @@ getc_error:
 	mov	w0, #-1
 	ret
 endfunc console_lpuart_getc
+
+func console_lpuart_flush
+	mov	x0, #0
+	ret
+endfunc console_lpuart_flush

--- a/plat/imx/imx8m/imx8mq/imx8mq_bl31_setup.c
+++ b/plat/imx/imx8m/imx8mq/imx8mq_bl31_setup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -87,7 +87,7 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 #if DEBUG_CONSOLE
 	static console_uart_t console;
 
-	console_uart_register(IMX_BOOT_UART_BASE, IMX_BOOT_UART_CLK_IN_HZ,
+	console_imx_uart_register(IMX_BOOT_UART_BASE, IMX_BOOT_UART_CLK_IN_HZ,
 		IMX_CONSOLE_BAUDRATE, &console);
 #endif
 	/*


### PR DESCRIPTION
lpuart driver needs to implement .console_flush callback to make debug mode work, since common code will call debug uart's .console_flush callback without checking if it is valid. imx uart build failed with debug mode enabled and also need to add .console_flush callback to make it work.