### PR TITLE
plat/arm: Fix header dependencies

### DIFF
--- a/include/plat/arm/common/arm_def.h
+++ b/include/plat/arm/common/arm_def.h
@@ -6,8 +6,6 @@
 #ifndef ARM_DEF_H
 #define ARM_DEF_H
 
-#include <platform_def.h>
-
 #include <arch.h>
 #include <common/interrupt_props.h>
 #include <common/tbbr/tbbr_img_def.h>

--- a/include/plat/arm/common/arm_spm_def.h
+++ b/include/plat/arm/common/arm_spm_def.h
@@ -9,8 +9,6 @@
 #include <lib/utils_def.h>
 #include <lib/xlat_tables/xlat_tables_defs.h>
 
-#include <arm_def.h>
-
 /*
  * Reserve 4 MiB for binaries of Secure Partitions and Resource Description
  * blobs.

--- a/include/plat/arm/css/common/css_def.h
+++ b/include/plat/arm/css/common/css_def.h
@@ -11,8 +11,6 @@
 #include <drivers/arm/gic_common.h>
 #include <drivers/arm/tzc400.h>
 
-#include <arm_def.h>
-
 /*************************************************************************
  * Definitions common to all ARM Compute SubSystems (CSS)
  *************************************************************************/

--- a/plat/arm/board/common/aarch32/board_arm_helpers.S
+++ b/plat/arm/board/common/aarch32/board_arm_helpers.S
@@ -6,7 +6,7 @@
 
 #include <asm_macros.S>
 #include <common/bl_common.h>
-#include <v2m_def.h>
+#include <platform_def.h>
 
 	.globl  plat_report_exception
 

--- a/plat/arm/board/common/aarch64/board_arm_helpers.S
+++ b/plat/arm/board/common/aarch64/board_arm_helpers.S
@@ -6,7 +6,7 @@
 
 #include <asm_macros.S>
 #include <common/bl_common.h>
-#include <v2m_def.h>
+#include <platform_def.h>
 
 	.globl  plat_report_exception
 

--- a/plat/arm/board/common/board_arm_trusted_boot.c
+++ b/plat/arm/board/common/board_arm_trusted_boot.c
@@ -11,8 +11,7 @@
 #include <lib/cassert.h>
 #include <plat/common/platform.h>
 #include <tools_share/tbbr_oid.h>
-
-#include <arm_def.h>
+#include <platform_def.h>
 
 /* SHA256 algorithm */
 #define SHA256_BYTES			32

--- a/plat/arm/board/fvp/aarch32/fvp_helpers.S
+++ b/plat/arm/board/fvp/aarch32/fvp_helpers.S
@@ -7,8 +7,8 @@
 #include <arch.h>
 #include <asm_macros.S>
 #include <platform_def.h>
+
 #include "../drivers/pwrc/fvp_pwrc.h"
-#include "../fvp_def.h"
 
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_get_my_entrypoint

--- a/plat/arm/board/fvp/aarch64/fvp_helpers.S
+++ b/plat/arm/board/fvp/aarch64/fvp_helpers.S
@@ -9,9 +9,8 @@
 #include <drivers/arm/gicv2.h>
 #include <drivers/arm/gicv3.h>
 #include <platform_def.h>
-#include <v2m_def.h>
+
 #include "../drivers/pwrc/fvp_pwrc.h"
-#include "../fvp_def.h"
 
 	.globl	plat_secondary_cold_boot_setup
 	.globl	plat_get_my_entrypoint

--- a/plat/arm/board/fvp/drivers/pwrc/fvp_pwrc.c
+++ b/plat/arm/board/fvp/drivers/pwrc/fvp_pwrc.c
@@ -6,10 +6,9 @@
 
 #include <lib/bakery_lock.h>
 #include <lib/mmio.h>
+#include <platform_def.h>
 
 #include <plat_arm.h>
-
-#include "../../fvp_def.h"
 #include "../../fvp_private.h"
 #include "fvp_pwrc.h"
 

--- a/plat/arm/board/fvp/fvp_bl2_setup.c
+++ b/plat/arm/board/fvp/fvp_bl2_setup.c
@@ -8,10 +8,9 @@
 #include <drivers/generic_delay_timer.h>
 #include <lib/mmio.h>
 #include <plat/common/platform.h>
+#include <platform_def.h>
 
 #include <plat_arm.h>
-#include <v2m_def.h>
-#include "fvp_def.h"
 #include "fvp_private.h"
 
 void bl2_early_platform_setup2(u_register_t arg0, u_register_t arg1, u_register_t arg2, u_register_t arg3)

--- a/plat/arm/board/fvp/fvp_bl2u_setup.c
+++ b/plat/arm/board/fvp/fvp_bl2u_setup.c
@@ -5,9 +5,9 @@
  */
 
 #include <plat/common/platform.h>
+#include <platform_def.h>
 
 #include <plat_arm.h>
-#include "fvp_def.h"
 #include "fvp_private.h"
 
 void bl2u_early_platform_setup(struct meminfo *mem_layout, void *plat_info)

--- a/plat/arm/board/fvp/fvp_common.c
+++ b/plat/arm/board/fvp/fvp_common.c
@@ -13,15 +13,12 @@
 #include <lib/mmio.h>
 #include <lib/xlat_tables/xlat_tables_compat.h>
 #include <plat/common/platform.h>
+#include <platform_def.h>
 #include <services/secure_partition.h>
 
 #include <arm_config.h>
-#include <arm_def.h>
-#include <arm_spm_def.h>
 #include <plat_arm.h>
-#include <v2m_def.h>
 
-#include "../fvp_def.h"
 #include "fvp_private.h"
 
 /* Defines for GIC Driver build time selection */

--- a/plat/arm/board/fvp/fvp_pm.c
+++ b/plat/arm/board/fvp/fvp_pm.c
@@ -14,14 +14,13 @@
 #include <lib/mmio.h>
 #include <lib/psci/psci.h>
 #include <plat/common/platform.h>
+#include <platform_def.h>
 
 #include <arm_config.h>
 #include <plat_arm.h>
-#include <v2m_def.h>
 
 #include "../../../../drivers/arm/gic/v3/gicv3_private.h"
 #include "drivers/pwrc/fvp_pwrc.h"
-#include "fvp_def.h"
 #include "fvp_private.h"
 
 

--- a/plat/arm/board/fvp/fvp_trusted_boot.c
+++ b/plat/arm/board/fvp/fvp_trusted_boot.c
@@ -9,9 +9,8 @@
 #include <string.h>
 
 #include <plat/common/platform.h>
+#include <platform_def.h>
 #include <tools_share/tbbr_oid.h>
-
-#include "fvp_def.h"
 
 /*
  * Store a new non-volatile counter value. On some FVP versions, the

--- a/plat/arm/board/fvp/include/plat_macros.S
+++ b/plat/arm/board/fvp/include/plat_macros.S
@@ -7,8 +7,7 @@
 #define PLAT_MACROS_S
 
 #include <arm_macros.S>
-#include <v2m_def.h>
-#include "../fvp_def.h"
+#include <platform_def.h>
 
 	/* ---------------------------------------------
 	 * The below required platform porting macro

--- a/plat/arm/board/juno/aarch32/juno_helpers.S
+++ b/plat/arm/board/juno/aarch32/juno_helpers.S
@@ -11,9 +11,7 @@
 #include <cortex_a57.h>
 #include <cortex_a72.h>
 #include <cpu_macros.S>
-#include <v2m_def.h>
-#include "../juno_def.h"
-
+#include <platform_def.h>
 
 	.globl	plat_reset_handler
 	.globl	plat_arm_calc_core_pos

--- a/plat/arm/board/juno/aarch64/juno_helpers.S
+++ b/plat/arm/board/juno/aarch64/juno_helpers.S
@@ -11,10 +11,7 @@
 #include <cortex_a57.h>
 #include <cortex_a72.h>
 #include <cpu_macros.S>
-#include <css_def.h>
-#include <v2m_def.h>
-#include "../juno_def.h"
-
+#include <platform_def.h>
 
 	.globl	plat_reset_handler
 	.globl	plat_arm_calc_core_pos

--- a/plat/arm/board/juno/juno_bl1_setup.c
+++ b/plat/arm/board/juno/juno_bl1_setup.c
@@ -11,10 +11,10 @@
 #include <common/tbbr/tbbr_img_def.h>
 #include <drivers/arm/sp805.h>
 #include <plat/common/platform.h>
+#include <platform_def.h>
 
 #include <plat_arm.h>
 #include <sds.h>
-#include <v2m_def.h>
 
 void juno_reset_to_aarch32_state(void);
 

--- a/plat/arm/board/juno/juno_common.c
+++ b/plat/arm/board/juno/juno_common.c
@@ -3,7 +3,8 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-#include <arm_def.h>
+
+#include <platform_def.h>
 #include <plat_arm.h>
 
 /*

--- a/plat/arm/board/juno/juno_err.c
+++ b/plat/arm/board/juno/juno_err.c
@@ -8,8 +8,7 @@
 
 #include <arch_helpers.h>
 #include <plat/common/platform.h>
-
-#include <v2m_def.h>
+#include <platform_def.h>
 
 /*
  * Juno error handler

--- a/plat/arm/board/juno/juno_security.c
+++ b/plat/arm/board/juno/juno_security.c
@@ -7,10 +7,10 @@
 #include <common/debug.h>
 #include <drivers/arm/nic_400.h>
 #include <lib/mmio.h>
+#include <platform_def.h>
 
 #include <plat_arm.h>
 #include <soc_css.h>
-#include "juno_def.h"
 #include "juno_tzmp1_def.h"
 
 #ifdef JUNO_TZMP1

--- a/plat/arm/board/juno/juno_stack_protector.c
+++ b/plat/arm/board/juno/juno_stack_protector.c
@@ -7,9 +7,9 @@
 #include <arch_helpers.h>
 #include <common/debug.h>
 #include <lib/utils.h>
+#include <platform_def.h>
 
 #include "juno_decl.h"
-#include "juno_def.h"
 
 u_register_t plat_get_stack_protector_canary(void)
 {

--- a/plat/arm/board/juno/juno_topology.c
+++ b/plat/arm/board/juno/juno_topology.c
@@ -5,11 +5,10 @@
  */
 
 #include <plat/common/platform.h>
+#include <platform_def.h>
 
-#include <arm_def.h>
 #include <css_pm.h>
 #include <plat_arm.h>
-#include "juno_def.h"
 #include "../../css/drivers/scmi/scmi.h"
 #include "../../css/drivers/mhu/css_mhu_doorbell.h"
 

--- a/plat/arm/board/juno/juno_trng.c
+++ b/plat/arm/board/juno/juno_trng.c
@@ -9,9 +9,9 @@
 
 #include <lib/mmio.h>
 #include <lib/utils_def.h>
+#include <platform_def.h>
 
 #include "juno_decl.h"
-#include "juno_def.h"
 
 #define NSAMPLE_CLOCKS	1 /* min 1 cycle, max 231 cycles */
 #define NRETRIES	5

--- a/plat/arm/board/juno/juno_tzmp1_def.h
+++ b/plat/arm/board/juno/juno_tzmp1_def.h
@@ -7,8 +7,6 @@
 #ifndef JUNO_TZMP1_DEF_H
 #define JUNO_TZMP1_DEF_H
 
-#include <plat_arm.h>
-
 /*
  * Public memory regions for both protected and non-protected mode
  *

--- a/plat/arm/board/n1sdp/include/platform_def.h
+++ b/plat/arm/board/n1sdp/include/platform_def.h
@@ -9,6 +9,7 @@
 
 #include <arm_def.h>
 #include <css_def.h>
+#include <v2m_def.h>
 
 /* UART related constants */
 #define PLAT_ARM_BOOT_UART_BASE			0x2A400000

--- a/plat/arm/board/n1sdp/n1sdp_plat.c
+++ b/plat/arm/board/n1sdp/n1sdp_plat.c
@@ -10,7 +10,6 @@
 #include <common/debug.h>
 #include <plat/common/platform.h>
 
-#include <arm_def.h>
 #include <plat_arm.h>
 
 /*

--- a/plat/arm/common/arm_bl1_setup.c
+++ b/plat/arm/common/arm_bl1_setup.c
@@ -16,7 +16,6 @@
 #include <lib/xlat_tables/xlat_tables_compat.h>
 #include <plat/common/platform.h>
 
-#include <arm_def.h>
 #include <plat_arm.h>
 
 #include "../../../bl1/bl1_private.h"

--- a/plat/arm/common/arm_bl2_el3_setup.c
+++ b/plat/arm/common/arm_bl2_el3_setup.c
@@ -8,8 +8,8 @@
 
 #include <drivers/generic_delay_timer.h>
 #include <plat/common/platform.h>
+#include <platform_def.h>
 
-#include <arm_def.h>
 #include <plat_arm.h>
 
 #pragma weak bl2_el3_early_platform_setup

--- a/plat/arm/common/arm_bl2_setup.c
+++ b/plat/arm/common/arm_bl2_setup.c
@@ -20,7 +20,6 @@
 #include <lib/utils.h>
 #include <plat/common/platform.h>
 
-#include <arm_def.h>
 #include <plat_arm.h>
 
 /* Data structure which holds the extents of the trusted SRAM for BL2 */

--- a/plat/arm/common/arm_bl2u_setup.c
+++ b/plat/arm/common/arm_bl2u_setup.c
@@ -14,7 +14,6 @@
 #include <drivers/generic_delay_timer.h>
 #include <plat/common/platform.h>
 
-#include <arm_def.h>
 #include <plat_arm.h>
 
 /* Weak definitions may be overridden in specific ARM standard platform */

--- a/plat/arm/common/arm_bl31_setup.c
+++ b/plat/arm/common/arm_bl31_setup.c
@@ -16,8 +16,8 @@
 #include <lib/utils.h>
 #include <lib/xlat_tables/xlat_tables_compat.h>
 #include <plat/common/platform.h>
+#include <platform_def.h>
 
-#include <arm_def.h>
 #include <plat_arm.h>
 
 /*

--- a/plat/arm/common/arm_gicv3.c
+++ b/plat/arm/common/arm_gicv3.c
@@ -11,7 +11,6 @@
 #include <lib/utils.h>
 #include <plat/common/platform.h>
 
-#include <arm_def.h>
 #include <plat_arm.h>
 
 /******************************************************************************

--- a/plat/arm/common/arm_image_load.c
+++ b/plat/arm/common/arm_image_load.c
@@ -8,7 +8,6 @@
 #include <common/desc_image_load.h>
 #include <plat/common/platform.h>
 
-#include <arm_def.h>
 #include <plat_arm.h>
 
 #pragma weak plat_flush_next_bl_params

--- a/plat/arm/common/arm_pm.c
+++ b/plat/arm/common/arm_pm.c
@@ -13,7 +13,6 @@
 #include <lib/psci/psci.h>
 #include <plat/common/platform.h>
 
-#include <arm_def.h>
 #include <plat_arm.h>
 
 /* Allow ARM Standard platforms to override these functions */

--- a/plat/arm/common/arm_tzc400.c
+++ b/plat/arm/common/arm_tzc400.c
@@ -9,8 +9,6 @@
 #include <common/debug.h>
 #include <drivers/arm/tzc400.h>
 
-#include <arm_def.h>
-#include <arm_spm_def.h>
 #include <plat_arm.h>
 
 /* Weak definitions may be overridden in specific ARM standard platform */

--- a/plat/arm/common/arm_tzc_dmc500.c
+++ b/plat/arm/common/arm_tzc_dmc500.c
@@ -11,7 +11,6 @@
 #include <common/debug.h>
 #include <drivers/arm/tzc_dmc500.h>
 
-#include <arm_def.h>
 #include <plat_arm.h>
 
 /*******************************************************************************

--- a/plat/arm/common/tsp/arm_tsp_setup.c
+++ b/plat/arm/common/tsp/arm_tsp_setup.c
@@ -14,7 +14,6 @@
 #include <drivers/arm/pl011.h>
 #include <drivers/console.h>
 
-#include <arm_def.h>
 #include <plat_arm.h>
 
 #define BL32_END (unsigned long)(&__BL32_END__)

--- a/plat/arm/css/common/aarch32/css_helpers.S
+++ b/plat/arm/css/common/aarch32/css_helpers.S
@@ -3,10 +3,11 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 #include <arch.h>
 #include <asm_macros.S>
 #include <cpu_macros.S>
-#include <css_def.h>
+#include <platform_def.h>
 
 	.weak	plat_secondary_cold_boot_setup
 	.weak	plat_get_my_entrypoint

--- a/plat/arm/css/common/aarch64/css_helpers.S
+++ b/plat/arm/css/common/aarch64/css_helpers.S
@@ -3,10 +3,11 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+
 #include <arch.h>
 #include <asm_macros.S>
 #include <cpu_macros.S>
-#include <css_def.h>
+#include <platform_def.h>
 
 	.weak	plat_secondary_cold_boot_setup
 	.weak	plat_get_my_entrypoint

--- a/plat/arm/css/common/css_bl2_setup.c
+++ b/plat/arm/css/common/css_bl2_setup.c
@@ -10,8 +10,8 @@
 #include <common/debug.h>
 #include <lib/mmio.h>
 #include <lib/utils.h>
+#include <platform_def.h>
 
-#include <css_def.h>
 #include <plat_arm.h>
 
 #include "../drivers/scp/css_scp.h"

--- a/plat/arm/css/drivers/mhu/css_mhu.c
+++ b/plat/arm/css/drivers/mhu/css_mhu.c
@@ -12,7 +12,6 @@
 #include <lib/bakery_lock.h>
 #include <lib/mmio.h>
 
-#include <css_def.h>
 #include <plat_arm.h>
 
 #include "css_mhu.h"

--- a/plat/arm/css/drivers/scp/css_bom_bootloader.c
+++ b/plat/arm/css/drivers/scp/css_bom_bootloader.c
@@ -10,8 +10,7 @@
 #include <arch_helpers.h>
 #include <common/debug.h>
 #include <plat/common/platform.h>
-
-#include <css_def.h>
+#include <platform_def.h>
 
 #include "../mhu/css_mhu.h"
 #include "../scpi/css_scpi.h"

--- a/plat/arm/css/drivers/scp/css_pm_scmi.c
+++ b/plat/arm/css/drivers/scp/css_pm_scmi.c
@@ -10,8 +10,8 @@
 #include <arch_helpers.h>
 #include <common/debug.h>
 #include <plat/common/platform.h>
+#include <platform_def.h>
 
-#include <css_def.h>
 #include <css_pm.h>
 #include <plat_arm.h>
 

--- a/plat/arm/css/drivers/scp/css_sds.c
+++ b/plat/arm/css/drivers/scp/css_sds.c
@@ -11,8 +11,7 @@
 #include <common/debug.h>
 #include <drivers/delay_timer.h>
 #include <plat/common/platform.h>
-
-#include <css_def.h>
+#include <platform_def.h>
 
 #include "css_scp.h"
 #include "../sds/sds.h"

--- a/plat/arm/css/drivers/scpi/css_scpi.c
+++ b/plat/arm/css/drivers/scpi/css_scpi.c
@@ -11,8 +11,7 @@
 #include <common/debug.h>
 #include <lib/utils.h>
 #include <plat/common/platform.h>
-
-#include <css_def.h>
+#include <platform_def.h>
 
 #include "../mhu/css_mhu.h"
 #include "css_scpi.h"

--- a/plat/arm/css/drivers/sds/sds.c
+++ b/plat/arm/css/drivers/sds/sds.c
@@ -10,8 +10,8 @@
 
 #include <arch_helpers.h>
 #include <common/debug.h>
+#include <platform_def.h>
 
-#include <css_def.h>
 #include "sds.h"
 #include "sds_private.h"
 

--- a/plat/arm/css/sgi/sgi_plat.c
+++ b/plat/arm/css/sgi/sgi_plat.c
@@ -14,8 +14,6 @@
 #include <plat/common/platform.h>
 #include <services/secure_partition.h>
 
-#include <arm_def.h>
-#include <arm_spm_def.h>
 #include <plat_arm.h>
 #include "../../../../bl1/bl1_private.h"
 

--- a/plat/arm/css/sgm/sgm_mmap_config.c
+++ b/plat/arm/css/sgm/sgm_mmap_config.c
@@ -9,7 +9,6 @@
 #include <common/bl_common.h>
 #include <common/debug.h>
 
-#include <arm_def.h>
 #include <plat_arm.h>
 #include <sgm_variant.h>
 

--- a/plat/arm/soc/common/soc_css_security.c
+++ b/plat/arm/soc/common/soc_css_security.c
@@ -9,9 +9,7 @@
 #include <drivers/arm/nic_400.h>
 #include <lib/mmio.h>
 
-#include <board_css_def.h>
 #include <soc_css.h>
-#include <soc_css_def.h>
 
 void soc_css_init_nic400(void)
 {


### PR DESCRIPTION
From now on, platform_def.h must include any header with definitions that are platform-specific (like arm_def.h) and the included headers mustn't include back platform_def.h, and shouldn't be used by other files. Only platform_def.h should be included in other files. This will ensure that all needed definitions are present, rather than needing to include all the headers in all the definitions' headers just in case.

This also prevents problems like cyclic dependencies.