### PR TITLE
Move BL1 and BL2 private defines to bl_common.h

### DIFF
--- a/bl1/bl1_private.h
+++ b/bl1/bl1_private.h
@@ -9,16 +9,7 @@
 
 #include <stdint.h>
 
-#include <lib/utils_def.h>
-
-/*******************************************************************************
- * Declarations of linker defined symbols which will tell us where BL1 lives
- * in Trusted ROM and RAM
- ******************************************************************************/
-IMPORT_SYM(uintptr_t, __BL1_ROM_END__,   BL1_ROM_END);
-
-IMPORT_SYM(uintptr_t, __BL1_RAM_START__, BL1_RAM_BASE);
-IMPORT_SYM(uintptr_t, __BL1_RAM_END__,   BL1_RAM_LIMIT);
+#include <common/bl_common.h>
 
 /******************************************
  * Function prototypes
@@ -36,4 +27,5 @@ register_t bl1_fwu_smc_handler(unsigned int smc_fid,
 		void *cookie,
 		void *handle,
 		unsigned int flags);
+
 #endif /* BL1_PRIVATE_H */

--- a/bl2/bl2_private.h
+++ b/bl2/bl2_private.h
@@ -7,22 +7,7 @@
 #ifndef BL2_PRIVATE_H
 #define BL2_PRIVATE_H
 
-#if BL2_IN_XIP_MEM
-
-#include <stdint.h>
-
-/*******************************************************************************
- * Declarations of linker defined symbols which will tell us where BL2 lives
- * in Trusted ROM and RAM
- ******************************************************************************/
-extern uintptr_t __BL2_ROM_END__;
-#define BL2_ROM_END (uintptr_t)(&__BL2_ROM_END__)
-
-extern uintptr_t __BL2_RAM_START__;
-extern uintptr_t __BL2_RAM_END__;
-#define BL2_RAM_BASE (uintptr_t)(&__BL2_RAM_START__)
-#define BL2_RAM_LIMIT (uintptr_t)(&__BL2_RAM_END__)
-#endif
+#include <common/bl_common.h>
 
 /******************************************
  * Forward declarations

--- a/include/common/bl_common.h
+++ b/include/common/bl_common.h
@@ -78,7 +78,12 @@ IMPORT_SYM(unsigned long, __RO_START__,		BL_CODE_BASE);
 IMPORT_SYM(unsigned long, __RO_END__,		BL_CODE_END);
 #endif
 
-#if defined(IMAGE_BL2)
+#if defined(IMAGE_BL1)
+IMPORT_SYM(uintptr_t, __BL1_ROM_END__,   BL1_ROM_END);
+
+IMPORT_SYM(uintptr_t, __BL1_RAM_START__, BL1_RAM_BASE);
+IMPORT_SYM(uintptr_t, __BL1_RAM_END__,   BL1_RAM_LIMIT);
+#elif defined(IMAGE_BL2)
 IMPORT_SYM(unsigned long, __BL2_END__,		BL2_END);
 #elif defined(IMAGE_BL2U)
 IMPORT_SYM(unsigned long, __BL2U_END__,		BL2U_END);
@@ -88,6 +93,17 @@ IMPORT_SYM(unsigned long, __BL31_END__,		BL31_END);
 #elif defined(IMAGE_BL32)
 IMPORT_SYM(unsigned long, __BL32_END__,		BL32_END);
 #endif /* IMAGE_BLX */
+
+/* The following symbols are only exported from the BL2 at EL3 linker script. */
+#if BL2_IN_XIP_MEM && defined(IMAGE_BL2)
+extern uintptr_t __BL2_ROM_END__;
+#define BL2_ROM_END (uintptr_t)(&__BL2_ROM_END__)
+
+extern uintptr_t __BL2_RAM_START__;
+extern uintptr_t __BL2_RAM_END__;
+#define BL2_RAM_BASE (uintptr_t)(&__BL2_RAM_START__)
+#define BL2_RAM_LIMIT (uintptr_t)(&__BL2_RAM_END__)
+#endif /* BL2_IN_XIP_MEM */
 
 /*
  * The next 2 constants identify the extents of the coherent memory region.

--- a/plat/arm/common/arm_bl1_setup.c
+++ b/plat/arm/common/arm_bl1_setup.c
@@ -19,8 +19,6 @@
 #include <arm_def.h>
 #include <plat_arm.h>
 
-#include "../../../bl1/bl1_private.h"
-
 /* Weak definitions may be overridden in specific ARM standard platform */
 #pragma weak bl1_early_platform_setup
 #pragma weak bl1_plat_arch_setup

--- a/plat/arm/css/sgi/sgi_plat.c
+++ b/plat/arm/css/sgi/sgi_plat.c
@@ -17,7 +17,6 @@
 #include <arm_def.h>
 #include <arm_spm_def.h>
 #include <plat_arm.h>
-#include "../../../../bl1/bl1_private.h"
 
 #if USE_COHERENT_MEM
 /*

--- a/plat/hisilicon/hikey/hikey_bl1_setup.c
+++ b/plat/hisilicon/hikey/hikey_bl1_setup.c
@@ -22,7 +22,6 @@
 #include <hikey_def.h>
 #include <hikey_layout.h>
 
-#include "../../../bl1/bl1_private.h"
 #include "hikey_private.h"
 
 /* Data structure which holds the extents of the trusted RAM for BL1 */

--- a/plat/hisilicon/hikey960/hikey960_bl1_setup.c
+++ b/plat/hisilicon/hikey960/hikey960_bl1_setup.c
@@ -25,7 +25,6 @@
 #include <plat/common/platform.h>
 
 #include <hi3660.h>
-#include "../../../bl1/bl1_private.h"
 #include "hikey960_def.h"
 #include "hikey960_private.h"
 

--- a/plat/hisilicon/poplar/bl1_plat_setup.c
+++ b/plat/hisilicon/poplar/bl1_plat_setup.c
@@ -22,7 +22,6 @@
 #include <lib/mmio.h>
 #include <plat/common/platform.h>
 
-#include "../../../bl1/bl1_private.h"
 #include "hi3798cv200.h"
 #include "plat_private.h"
 

--- a/plat/layerscape/common/ls_bl1_setup.c
+++ b/plat/layerscape/common/ls_bl1_setup.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
+#include <common/bl_common.h>
 #include <common/debug.h>
 
 #include "ls_16550.h"
 #include "plat_ls.h"
-#include "../../../bl1/bl1_private.h"
 
 /* Data structure which holds the extents of the trusted SRAM for BL1*/
 static meminfo_t bl1_tzram_layout;

--- a/plat/marvell/common/marvell_bl1_setup.c
+++ b/plat/marvell/common/marvell_bl1_setup.c
@@ -8,7 +8,6 @@
 #include <platform_def.h>
 
 #include <bl1/bl1.h>
-#include <bl1/bl1_private.h>
 #include <common/bl_common.h>
 #include <common/debug.h>
 #include <drivers/arm/sp805.h>

--- a/plat/qemu/qemu_private.h
+++ b/plat/qemu/qemu_private.h
@@ -9,8 +9,6 @@
 
 #include <stdint.h>
 
-#include "../../bl1/bl1_private.h"
-
 void qemu_configure_mmu_svc_mon(unsigned long total_base,
 			unsigned long total_size,
 			unsigned long code_start, unsigned long code_limit,

--- a/plat/rpi3/rpi3_bl1_setup.c
+++ b/plat/rpi3/rpi3_bl1_setup.c
@@ -13,7 +13,6 @@
 #include <lib/xlat_tables/xlat_mmu_helpers.h>
 #include <lib/xlat_tables/xlat_tables_defs.h>
 
-#include "../../bl1/bl1_private.h"
 #include "rpi3_private.h"
 
 /* Data structure which holds the extents of the trusted SRAM for BL1 */


### PR DESCRIPTION
The definitions in bl1/bl1_private.h and bl2/bl2_private.h are useful for platforms that may need to access them.