### PR TITLE
Correct typographical errors

### DIFF
--- a/bl31/bl31.ld.S
+++ b/bl31/bl31.ld.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -240,7 +240,7 @@ SECTIONS
          * Time-stamps are stored in normal .bss memory
          *
          * The compiler will allocate enough memory for one CPU's time-stamps,
-         * the remaining memory for other CPU's is allocated by the
+         * the remaining memory for other CPUs is allocated by the
          * linker script
          */
         . = ALIGN(CACHE_WRITEBACK_GRANULE);

--- a/bl31/bl31_main.c
+++ b/bl31/bl31_main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -68,7 +68,7 @@ void __init bl31_lib_init(void)
  * before passing control to the bootloader or an Operating System. This
  * function calls runtime_svc_init() which initializes all registered runtime
  * services. The run time services would setup enough context for the core to
- * swtich to the next exception level. When this function returns, the core will
+ * switch to the next exception level. When this function returns, the core will
  * switch to the programmed exception level via. an ERET.
  ******************************************************************************/
 void bl31_main(void)
@@ -96,13 +96,13 @@ void bl31_main(void)
 	 * decide which is the next image (BL32 or BL33) and how to execute it.
 	 * If the SPD runtime service is present, it would want to pass control
 	 * to BL32 first in S-EL1. In that case, SPD would have registered a
-	 * function to intialize bl32 where it takes responsibility of entering
+	 * function to initialize bl32 where it takes responsibility of entering
 	 * S-EL1 and returning control back to bl31_main. Once this is done we
 	 * can prepare entry into BL33 as normal.
 	 */
 
 	/*
-	 * If SPD had registerd an init hook, invoke it.
+	 * If SPD had registered an init hook, invoke it.
 	 */
 	if (bl32_init != NULL) {
 		INFO("BL31: Initializing BL32\n");

--- a/bl32/sp_min/sp_min.ld.S
+++ b/bl32/sp_min/sp_min.ld.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -167,7 +167,7 @@ SECTIONS
          * Time-stamps are stored in normal .bss memory
          *
          * The compiler will allocate enough memory for one CPU's time-stamps,
-         * the remaining memory for other CPU's is allocated by the
+         * the remaining memory for other CPUs is allocated by the
          * linker script
          */
         . = ALIGN(CACHE_WRITEBACK_GRANULE);

--- a/bl32/sp_min/sp_min_main.c
+++ b/bl32/sp_min/sp_min_main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -35,7 +35,7 @@ static void *sp_min_cpu_ctx_ptr[PLATFORM_CORE_COUNT];
 static smc_ctx_t sp_min_smc_context[PLATFORM_CORE_COUNT];
 
 /******************************************************************************
- * Define the smccc helper library API's
+ * Define the smccc helper library APIs
  *****************************************************************************/
 void *smc_get_ctx(unsigned int security_state)
 {

--- a/bl32/tsp/tsp_main.c
+++ b/bl32/tsp/tsp_main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -362,7 +362,7 @@ tsp_args_t *tsp_smc_handler(uint64_t func,
 
 	/*
 	 * Request a service back from dispatcher/secure monitor. This call
-	 * return and thereafter resume exectuion
+	 * return and thereafter resume execution
 	 */
 	tsp_get_magic(service_args);
 
@@ -395,7 +395,7 @@ tsp_args_t *tsp_smc_handler(uint64_t func,
 }
 
 /*******************************************************************************
- * TSP smc abort handler. This function is called when aborting a preemtped
+ * TSP smc abort handler. This function is called when aborting a preempted
  * yielding SMC request. It should cleanup all resources owned by the SMC
  * handler such as locks or dynamically allocated memory so following SMC
  * request are executed in a clean environment.

--- a/bl32/tsp/tsp_timer.c
+++ b/bl32/tsp/tsp_timer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -80,7 +80,7 @@ void tsp_generic_timer_save(void)
 }
 
 /*******************************************************************************
- * This function restores the timer context post cpu resummption
+ * This function restores the timer context post cpu resumption
  ******************************************************************************/
 void tsp_generic_timer_restore(void)
 {

--- a/common/backtrace/backtrace.c
+++ b/common/backtrace/backtrace.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -231,7 +231,7 @@ static void unwind_stack(struct frame_record *fr, uintptr_t current_pc,
  * Usage of the trace: addr2line can be used to map the addresses to function
  * and source code location when given the ELF file compiled with debug
  * information. The "-i" flag is highly recommended to improve display of
- * inlined function. The *.dump files generated when buildidng each image can
+ * inlined function. The *.dump files generated when building each image can
  * also be used.
  *
  * WARNING: In case of corrupted stack, this function could display security

--- a/docs/auth-framework.rst
+++ b/docs/auth-framework.rst
@@ -160,7 +160,7 @@ These components are responsible for initiating the authentication process for a
 particular image in BL1 or BL2. For each BL image that requires authentication,
 the Generic code asks recursively the Authentication module what is the parent
 image until either an authenticated image or the ROT is reached. Then the
-Generic code calls the IO framewotk to load the image and calls the
+Generic code calls the IO framework to load the image and calls the
 Authentication module to authenticate it, following the CoT from ROT to Image.
 
 TF-A Platform Port (PP)
@@ -422,7 +422,7 @@ An IPL for each type must be registered using the following macro:
 -  ``_name``: a string containing the IPL name for debugging purposes.
 -  ``_init``: initialization function pointer.
 -  ``_check_int``: check image integrity function pointer.
--  ``_get_param``: extract authentication parameter funcion pointer.
+-  ``_get_param``: extract authentication parameter function pointer.
 
 The ``init()`` function will be used to initialize the IPL.
 
@@ -925,7 +925,7 @@ three functions:
 The mbedTLS library algorithm support is configured by the
 ``TF_MBEDTLS_KEY_ALG`` variable which can take in 3 values: `rsa`, `ecdsa` or
 `rsa+ecdsa`. This variable allows the Makefile to include the corresponding
-sources in the build for the various algorthms. Setting the variable to
+sources in the build for the various algorithms. Setting the variable to
 `rsa+ecdsa` enables support for both rsa and ecdsa algorithms in the mbedTLS
 library.
 

--- a/docs/change-log.rst
+++ b/docs/change-log.rst
@@ -10,7 +10,7 @@ Trusted Firmware-A - version 2.0
 New Features
 ------------
 
--  Removal of a number of deprecated API's
+-  Removal of a number of deprecated APIs
 
    -  A new Platform Compatibility Policy document has been created which
       references a wiki page that maintains a listing of deprecated
@@ -20,7 +20,7 @@ New Features
       from the code base.
 
    -  Various Arm and partner platforms have been updated to remove the use of
-      removed API's in this release.
+      removed APIs in this release.
 
    -  This release is otherwise unchanged from 1.6 release
 
@@ -130,7 +130,7 @@ New Features
       the clang linker is not used because it is unable to link TF-A objects
       due to immaturity of clang linker functionality at this time.
 
--  Refactor support API's into Libraries
+-  Refactor support APIs into Libraries
 
    -  Evolve libfdt, mbed TLS library and standard C library sources as
       proper libraries that TF-A may be linked against.
@@ -435,7 +435,7 @@ New features
 
    -  Introduced APIs to get and set the memory attributes of a region.
 
-   -  Added support to manage both priviledge levels in translation regimes that
+   -  Added support to manage both privilege levels in translation regimes that
       describe translations for 2 Exception levels, specifically the EL1&0
       translation regime, and extended the memory map region attributes to
       include specifying Non-privileged access.
@@ -683,7 +683,7 @@ New features
 -  Enhancements to Firmware Update feature:
 
    -  The FWU logic now checks for overlapping images to prevent execution of
-      unauthenticated arbitary code.
+      unauthenticated arbitrary code.
 
    -  Introduced new FWU_SMC_IMAGE_RESET SMC that changes the image loading
       state machine to go from COPYING, COPIED or AUTHENTICATED states to
@@ -855,7 +855,7 @@ New features
 
    -  Essential control registers are fully initialised on EL3 start-up, when
       initialising the non-secure and secure context structures and when
-      preparing to leave EL3 for a lower EL. This gives better alignement with
+      preparing to leave EL3 for a lower EL. This gives better alignment with
       the Arm ARM which states that software must initialise RES0 and RES1
       fields with 0 / 1.
 
@@ -1345,7 +1345,7 @@ New features
 -  It is now possible to specify the name of the FIP at build time by defining
    the ``FIP_NAME`` variable.
 
--  Issues with depedencies on the 'fiptool' makefile target have been
+-  Issues with dependencies on the 'fiptool' makefile target have been
    rectified. The ``fip_create`` tool is now rebuilt whenever its source files
    change.
 
@@ -1376,7 +1376,7 @@ New features
       the secure world. This can be done by setting the build flag
       ``FVP_TSP_RAM_LOCATION`` to the value ``dram``.
 
--  Separate transation tables are created for each boot loader image. The
+-  Separate translation tables are created for each boot loader image. The
    ``IMAGE_BLx`` build options are used to do this. This allows each stage to
    create mappings only for areas in the memory map that it needs.
 
@@ -1530,7 +1530,7 @@ New features
    -  Clarified the platform porting interface to the TSP.
 
    -  Reworked the TSPD setup code to support the alternate BL3-2
-      intialization flow where BL3-1 generic code hands control to BL3-2,
+      initialization flow where BL3-1 generic code hands control to BL3-2,
       rather than expecting the TSPD to hand control directly to BL3-2.
 
    -  Considerable rework to PSCI generic code to support CPU specific
@@ -1569,7 +1569,7 @@ Issues resolved since last release
 
 -  Removed the concept of top/bottom image loading. The image loader now
    automatically detects the position of the image inside the current memory
-   layout and updates the layout to minimize fragementation. This resolves the
+   layout and updates the layout to minimize fragmentation. This resolves the
    image loader limitations of previously releases. There are currently no
    plans to support dynamic image loading.
 

--- a/docs/firmware-design.rst
+++ b/docs/firmware-design.rst
@@ -203,7 +203,7 @@ BL1 performs minimal architectural initialization as follows.
 
    The ``plat_report_exception()`` implementation on the Arm FVP port programs
    the Versatile Express System LED register in the following format to
-   indicate the occurence of an unexpected exception:
+   indicate the occurrence of an unexpected exception:
 
    ::
 
@@ -1991,7 +1991,7 @@ Coherent memory usage in PSCI implementation
 The ``psci_non_cpu_pd_nodes`` data structure stores the platform's power domain
 tree information for state management of power domains. By default, this data
 structure is allocated in the coherent memory region in TF-A because it can be
-accessed by multple CPUs, either with caches enabled or disabled.
+accessed by multiple CPUs, either with caches enabled or disabled.
 
 .. code:: c
 
@@ -2031,7 +2031,7 @@ cache lines after these fields are written.
 
 The field ``local_state`` can be concurrently accessed by multiple CPUs in
 different cache states. A Lamport's Bakery lock ``psci_locks`` is used to ensure
-mutual exlusion to this field and a clean and invalidate is needed after it
+mutual exclusion to this field and a clean and invalidate is needed after it
 is written.
 
 Bakery lock data
@@ -2225,7 +2225,7 @@ appropriately map the code region as executable and the read-only data as
 execute-never.
 
 This has an impact on memory footprint, as padding bytes need to be introduced
-between the code and read-only data to ensure the segragation of the two. To
+between the code and read-only data to ensure the segregation of the two. To
 limit the memory cost, this flag also changes the memory layout such that the
 code and exception vectors are now contiguous, like so:
 
@@ -2352,12 +2352,12 @@ has finished and be used for runtime data.
 
 The build option ``RECLAIM_INIT_CODE`` can be set to mark this boot time code
 with a ``.text.init.*`` attribute which can be filtered and placed suitably
-within the BL image for later reclaimation by the platform. The platform can
-specify the fiter and the memory region for this init section in BL31 via the
+within the BL image for later reclamation by the platform. The platform can
+specify the filter and the memory region for this init section in BL31 via the
 plat.ld.S linker script. For example, on the FVP, this section is placed
 overlapping the secondary CPU stacks so that after the cold boot is done, this
 memory can be reclaimed for the stacks. The init memory section is initially
-mapped with ``RO``, ``EXECUTE`` attributes. After BL31 initilization has
+mapped with ``RO``, ``EXECUTE`` attributes. After BL31 initialization has
 completed, the FVP changes the attributes of this section to ``RW``,
 ``EXECUTE_NEVER`` allowing it to be used for runtime data. The memory attributes
 are changed within the ``bl31_plat_runtime_setup`` platform hook. The init
@@ -2553,7 +2553,7 @@ extension is mandatory to support the TF-A bootloader and runtime services.
 
 Platform implementing an Armv7-A system can to define from its target
 Cortex-A architecture through ``ARM_CORTEX_A<X> = yes`` in their
-``plaform.mk`` script. For example ``ARM_CORTEX_A15=yes`` for a
+``platform.mk`` script. For example ``ARM_CORTEX_A15=yes`` for a
 Cortex-A15 target.
 
 Platform can also set ``ARM_WITH_NEON=yes`` to enable neon support.

--- a/docs/firmware-update.rst
+++ b/docs/firmware-update.rst
@@ -266,14 +266,14 @@ FWU\_SMC\_IMAGE\_AUTH
         if (image_id is invalid) return -EPERM
         if (secure world caller)
             if (image_id state is not RESET) return -EPERM
-            if (image_addr/image_size is not mappped into BL1) return -ENOMEM
+            if (image_addr/image_size is not mapped into BL1) return -ENOMEM
         else // normal world caller
             if (image_id is secure image)
                 if (image_id state is not COPIED) return -EPERM
             else // image_id is non-secure image
                 if (image_id state is not RESET) return -EPERM
                 if (image_addr/image_size is in secure memory) return -ENOMEM
-                if (image_addr/image_size not mappped into BL1) return -ENOMEM
+                if (image_addr/image_size not mapped into BL1) return -ENOMEM
 
 This SMC authenticates the image specified by ``image_id``. If the image is in the
 RESET state, BL1 authenticates the image in place using the provided

--- a/docs/porting-guide.rst
+++ b/docs/porting-guide.rst
@@ -390,7 +390,7 @@ also be defined:
 -  **#define : SCP\_BL2\_IMAGE\_ID**
 
    SCP\_BL2 image identifier, used by BL2 to load SCP\_BL2 into secure memory
-   from platform storage before being transfered to the SCP.
+   from platform storage before being transferred to the SCP.
 
 -  **#define : SCP\_FW\_KEY\_CERT\_ID**
 
@@ -439,9 +439,9 @@ platform, the following constants must also be defined:
 -  **#define : TSP\_SEC\_MEM\_SIZE**
 
    Defines the size of the secure memory used by the BL32 image on the
-   platform. ``TSP_SEC_MEM_BASE`` and ``TSP_SEC_MEM_SIZE`` must fully accomodate
-   the memory required by the BL32 image, defined by ``BL32_BASE`` and
-   ``BL32_LIMIT``.
+   platform. ``TSP_SEC_MEM_BASE`` and ``TSP_SEC_MEM_SIZE`` must fully
+   accommodate the memory required by the BL32 image, defined by ``BL32_BASE``
+   and ``BL32_LIMIT``.
 
 -  **#define : TSP\_IRQ\_SEC\_PHY\_TIMER**
 
@@ -821,11 +821,11 @@ Function : plat\_my\_core\_pos()
     Argument : void
     Return   : unsigned int
 
-This funtion returns the index of the calling CPU which is used as a
+This function returns the index of the calling CPU which is used as a
 CPU-specific linear index into blocks of memory (for example while allocating
 per-CPU stacks). This function will be invoked very early in the
 initialization sequence which mandates that this function should be
-implemented in assembly and should not rely on the avalability of a C
+implemented in assembly and should not rely on the availability of a C
 runtime environment. This function can clobber x0 - x8 and must preserve
 x9 - x29.
 
@@ -929,7 +929,7 @@ Function : plat\_reset\_handler()
 
 A platform may need to do additional initialization after reset. This function
 allows the platform to do the platform specific intializations. Platform
-specific errata workarounds could also be implemented here. The api should
+specific errata workarounds could also be implemented here. The API should
 preserve the values of callee saved registers x19 to x29.
 
 The default implementation doesn't do anything. If a platform needs to override
@@ -1543,7 +1543,7 @@ The AP Firmware Updater Configuration, BL2U, is an optional part of the FWU
 process and is executed only by the primary CPU. BL1 passes control to BL2U at
 ``BL2U_BASE``. BL2U executes in Secure-EL1 and is responsible for:
 
-#. (Optional) Transfering the optional SCP\_BL2U binary image from AP secure
+#. (Optional) Transferring the optional SCP\_BL2U binary image from AP secure
    memory to SCP RAM. BL2U uses the SCP\_BL2U ``image_info`` passed by BL1.
    ``SCP_BL2U_BASE`` defines the address in AP secure memory where SCP\_BL2U
    should be copied from. Subsequent handling of the SCP\_BL2U image is
@@ -1649,7 +1649,7 @@ CPUs. BL31 executes at EL3 and is responsible for:
    implementation.
 
 #. Optionally passing control to the BL32 image, pre-loaded at a platform-
-   specific address by BL2. BL31 exports a set of apis that allow runtime
+   specific address by BL2. BL31 exports a set of APIs that allow runtime
    services to specify the security state in which the next image should be
    executed and run the corresponding image. On ARM platforms, BL31 uses the
    ``bl_params`` list populated by BL2 in memory to do this.
@@ -1800,7 +1800,7 @@ defined by the translation library, and can be found in the file
 ``include/lib/xlat_tables/xlat_mmu_helpers.h``.
 
 On DynamIQ systems, this function must not use stack while enabling MMU, which
-is how the function in xlat table library version 2 is implementated.
+is how the function in xlat table library version 2 is implemented.
 
 Function : plat\_get\_syscnt\_freq2() [mandatory]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2030,7 +2030,7 @@ Function : plat\_get\_power\_domain\_tree\_desc() [mandatory]
 
 This function returns a pointer to the byte array containing the power domain
 topology tree description. The format and method to construct this array are
-described in `Power Domain Topology Design`_. The BL31 PSCI initilization code
+described in `Power Domain Topology Design`_. The BL31 PSCI initialization code
 requires this array to be described by the platform, either statically or
 dynamically, to initialize the power domain topology tree. In case the array
 is populated dynamically, then plat\_core\_pos\_by\_mpidr() and
@@ -2070,7 +2070,7 @@ plat\_psci\_ops.cpu\_standby()
 
 Perform the platform-specific actions to enter the standby state for a cpu
 indicated by the passed argument. This provides a fast path for CPU standby
-wherein overheads of PSCI state management and lock acquistion is avoided.
+wherein overheads of PSCI state management and lock acquisition is avoided.
 For this handler to be invoked by the PSCI ``CPU_SUSPEND`` API implementation,
 the suspend state type specified in the ``power-state`` parameter should be
 STANDBY and the target power domain level specified should be the CPU. The
@@ -2345,7 +2345,7 @@ state or EL3/S-EL1 in the secure state. The design of this framework is
 described in the `IMF Design Guide`_
 
 A platform should export the following APIs to support the IMF. The following
-text briefly describes each api and its implementation in Arm standard
+text briefly describes each API and its implementation in Arm standard
 platforms. The API implementation depends upon the type of interrupt controller
 present in the platform. Arm standard platform layer supports both
 `Arm Generic Interrupt Controller version 2.0 (GICv2)`_
@@ -2552,7 +2552,7 @@ Crash Reporting mechanism (in BL31)
 
 BL31 implements a crash reporting mechanism which prints the various registers
 of the CPU to enable quick crash analysis and debugging. This mechanism relies
-on the platform implementating ``plat_crash_console_init``,
+on the platform implementing ``plat_crash_console_init``,
 ``plat_crash_console_putc`` and ``plat_crash_console_flush``.
 
 The file ``plat/common/aarch64/crash_console_helpers.S`` contains sample

--- a/docs/psci-lib-integration-guide.rst
+++ b/docs/psci-lib-integration-guide.rst
@@ -240,7 +240,7 @@ As explained in `Secure payload power management callback`_,
 the EL3 Runtime Software may want to perform some bookkeeping during power
 management operations. This function is used to register the ``spd_pm_ops_t``
 (first argument) callbacks with the PSCI library which will be called
-ppropriately during power management. Calling this function is optional and
+appropriately during power management. Calling this function is optional and
 need to be called by the primary CPU during the cold boot sequence after
 ``psci_setup()`` has completed.
 

--- a/docs/ras.rst
+++ b/docs/ras.rst
@@ -203,8 +203,8 @@ doesn't return.
 Engaging the RAS framework
 --------------------------
 
-Enabling RAS support is a platform choice conjunctional of three distinct but
-related build options:
+Enabling RAS support is a platform choice constructed from three distinct, but
+related, build options:
 
 -  ``RAS_EXTENSION=1`` includes the RAS framework in the run time firmware;
 
@@ -244,7 +244,7 @@ allocate the highest secure priority for RAS handling.
 
 .. __: exception-handling.rst#partitioning-priority-levels
 
-Handling of both `interrrupt`__ and `non-interrupt`__ exceptions follow the
+Handling of both `interrupt`__ and `non-interrupt`__ exceptions follow the
 sequences outlined in the |EHF| documentation. I.e., for interrupts, the
 priority management is implicit; but for non-interrupt exceptions, they're
 explicit using `EHF APIs`__.

--- a/docs/secure-partition-manager-design.rst
+++ b/docs/secure-partition-manager-design.rst
@@ -309,7 +309,7 @@ SPM to delegate service requests to the Secure Partition. The interface also
 allows the Secure Partition to:
 
 - Register with the SPM a service that it provides.
-- Indicate completion of a service request delagated by the SPM
+- Indicate completion of a service request delegated by the SPM
 
 Miscellaneous interfaces
 ------------------------

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -108,7 +108,7 @@ Building TF-A
    ``CC`` needs to point to the clang or armclang binary, which will
    also select the clang or armclang assembler. Be aware that the
    GNU linker is used by default.  In case of being needed the linker
-   can be overriden using the ``LD`` variable. Clang linker version 6 is
+   can be overridden using the ``LD`` variable. Clang linker version 6 is
    known to work with TF-A.
 
    In both cases ``CROSS_COMPILE`` should be set as described above.
@@ -357,8 +357,8 @@ Common build options
    supports the format used by GCC when T32 interworking is disabled. For this
    reason enabling this option in AArch32 will force the compiler to only
    generate A32 code. This option is enabled by default only in AArch64 debug
-   builds, but this behaviour can be overriden in each platform's Makefile or in
-   the build command line.
+   builds, but this behaviour can be overridden in each platform's Makefile or
+   in the build command line.
 
 -  ``ENABLE_MPAM_FOR_LOWER_ELS``: Boolean option to enable lower ELs to use MPAM
    feature. MPAM is an optional Armv8.4 extension that enables various memory
@@ -428,7 +428,7 @@ Common build options
    handled at EL3, and a panic will result. This is supported only for AArch64
    builds.
 
--  ``FAULT_INJECTION_SUPPORT``: ARMv8.4 externsions introduced support for fault
+-  ``FAULT_INJECTION_SUPPORT``: ARMv8.4 extensions introduced support for fault
    injection from lower ELs, and this build option enables lower ELs to use
    Error Records accessed via System Registers to inject faults. This is
    applicable only to AArch64 builds.

--- a/drivers/arm/ccn/ccn.c
+++ b/drivers/arm/ccn/ccn.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -370,7 +370,7 @@ void ccn_exit_dvm_domain(unsigned long long master_iface_map)
  * system. The state is expected to be one of NO_L3, SF_ONLY, L3_HAM or
  * L3_FAM. Instead of comparing the states reported by all HN-Fs, the state of
  * the first present HN-F node is reported. Since the driver does not export an
- * interface to program them seperately, there is no reason to perform this
+ * interface to program them separately, there is no reason to perform this
  * check. An HN-F could report that the L3 cache is transitioning from one mode
  * to another e.g. HNF_PM_NOL3_2_SFONLY. In this case, the function waits for
  * the transition to complete and reports the final state.
@@ -383,7 +383,7 @@ unsigned int ccn_get_l3_run_mode(void)
 	assert(ccn_plat_desc->periphbase);
 
 	/*
-	 * Wait for a L3 cache paritition to enter any run mode. The pstate
+	 * Wait for a L3 cache partition to enter any run mode. The pstate
 	 * parameter is read from an HN-F P-state status register. A non-zero
 	 * value in bits[1:0] means that the cache is transitioning to a run
 	 * mode.
@@ -428,7 +428,7 @@ void ccn_set_l3_run_mode(unsigned int mode)
 	region_id = HNF_REGION_ID_START;
 	FOR_EACH_PRESENT_REGION_ID(region_id, mn_hnf_id_map) {
 		/*
-		 * Wait for a L3 cache paritition to enter a target run
+		 * Wait for a L3 cache partition to enter a target run
 		 * mode. The pstate parameter is read from an HN-F P-state
 		 * status register.
 		 */
@@ -584,7 +584,7 @@ void ccn_write_node_reg(node_types_t node_type, unsigned int node_id,
 		return;
 	}
 
-	/* Setting the value of Auxilary Control Register of the Node */
+	/* Setting the value of Auxiliary Control Register of the Node */
 	ccn_reg_write(ccn_plat_desc->periphbase, region_id, reg_offset, val);
 	VERBOSE("Value is successfully written at address 0x%lx.\n",
 			(ccn_plat_desc->periphbase
@@ -611,7 +611,7 @@ unsigned long long ccn_read_node_reg(node_types_t node_type,
 		return ULL(0);
 	}
 
-	/* Setting the value of Auxilary Control Register of the Node */
+	/* Setting the value of Auxiliary Control Register of the Node */
 	val = ccn_reg_read(ccn_plat_desc->periphbase, region_id, reg_offset);
 	VERBOSE("Value is successfully read from address 0x%lx.\n",
 			(ccn_plat_desc->periphbase

--- a/drivers/partition/partition.c
+++ b/drivers/partition/partition.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -75,7 +75,7 @@ static int load_mbr_header(uintptr_t image_handle, mbr_entry_t *mbr_entry)
 
 /*
  * Load GPT header and check the GPT signature.
- * If partiton numbers could be found, check & update it.
+ * If partition numbers could be found, check & update it.
  */
 static int load_gpt_header(uintptr_t image_handle)
 {

--- a/lib/aarch32/arm32_aeabi_divmod.c
+++ b/lib/aarch32/arm32_aeabi_divmod.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -18,12 +18,12 @@
  *     unsigned denominator);
  */
 
-/* struct qr - stores qutient/remainder to handle divmod EABI interfaces. */
+/* struct qr - stores quotient/remainder to handle divmod EABI interfaces. */
 struct qr {
 	unsigned int q;		/* computed quotient */
 	unsigned int r;		/* computed remainder */
-	unsigned int q_n;	/* specficies if quotient shall be negative */
-	unsigned int r_n;	/* specficies if remainder shall be negative */
+	unsigned int q_n;	/* specifies if quotient shall be negative */
+	unsigned int r_n;	/* specifies if remainder shall be negative */
 };
 
 static void uint_div_qr(unsigned int numerator, unsigned int denominator,

--- a/lib/el3_runtime/aarch64/context_mgmt.c
+++ b/lib/el3_runtime/aarch64/context_mgmt.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -55,7 +55,7 @@ void __init cm_init(void)
  * The security state to initialize is determined by the SECURE attribute
  * of the entry_point_info.
  *
- * The EE and ST attributes are used to configure the endianess and secure
+ * The EE and ST attributes are used to configure the endianness and secure
  * timer availability for the new execution context.
  *
  * To prepare the register state for entry call cm_prepare_el3_exit() and
@@ -124,7 +124,7 @@ void cm_setup_context(cpu_context_t *ctx, const entry_point_info_t *ep)
 
 #ifdef IMAGE_BL31
 	/*
-	 * SCR_EL3.IRQ, SCR_EL3.FIQ: Enable the physical FIQ and IRQ rounting as
+	 * SCR_EL3.IRQ, SCR_EL3.FIQ: Enable the physical FIQ and IRQ routing as
 	 *  indicated by the interrupt routing model for BL31.
 	 */
 	scr_el3 |= get_scr_el3_from_routing_model(security_state);
@@ -175,7 +175,7 @@ void cm_setup_context(cpu_context_t *ctx, const entry_point_info_t *ep)
 
 	/*
 	 * Store the initialised SCTLR_EL1 value in the cpu_context - SCTLR_EL2
-	 * and other EL2 registers are set up by cm_preapre_ns_entry() as they
+	 * and other EL2 registers are set up by cm_prepare_ns_entry() as they
 	 * are not part of the stored cpu_context.
 	 */
 	write_ctx_reg(get_sysregs_ctx(ctx), CTX_SCTLR_EL1, sctlr_elx);
@@ -350,7 +350,7 @@ void cm_prepare_el3_exit(uint32_t security_state)
 					| CPTR_EL2_TFP_BIT));
 
 			/*
-			 * Initiliase CNTHCTL_EL2. All fields are
+			 * Initialise CNTHCTL_EL2. All fields are
 			 * architecturally UNKNOWN on reset and are set to zero
 			 * except for field(s) listed below.
 			 *

--- a/plat/arm/common/arm_gicv3.c
+++ b/plat/arm/common/arm_gicv3.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -152,7 +152,7 @@ void plat_arm_gic_save(void)
 	 * If an ITS is available, save its context before
 	 * the Redistributor using:
 	 * gicv3_its_save_disable(gits_base, &its_ctx[i])
-	 * Additionnaly, an implementation-defined sequence may
+	 * Additionally, an implementation-defined sequence may
 	 * be required to save the whole ITS state.
 	 */
 

--- a/plat/arm/common/tsp/arm_tsp_setup.c
+++ b/plat/arm/common/tsp/arm_tsp_setup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -78,7 +78,7 @@ void tsp_platform_setup(void)
 void tsp_plat_arch_setup(void)
 {
 #if USE_COHERENT_MEM
-	/* Ensure ARM platforms dont use coherent memory in TSP */
+	/* Ensure ARM platforms don't use coherent memory in TSP */
 	assert((BL_COHERENT_RAM_END - BL_COHERENT_RAM_BASE) == 0U);
 #endif
 

--- a/plat/arm/css/drivers/mhu/css_mhu_doorbell.c
+++ b/plat/arm/css/drivers/mhu/css_mhu_doorbell.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -32,7 +32,7 @@ void mhuv2_ring_doorbell(struct scmi_channel_plat_info *plat_info)
 			plat_info->db_modify_mask,
 			plat_info->db_preserve_mask);
 
-	/* clear the access request for the recevier */
+	/* clear the access request for the receiver */
 	MHU_V2_CLEAR_REQUEST(MHUV2_BASE_ADDR);
 
 	return;

--- a/services/spd/opteed/teesmc_opteed.h
+++ b/services/spd/opteed/teesmc_opteed.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,13 +10,13 @@
 #define TEESMC_OPTEED_H
 
 /*
- * This file specify SMC function IDs used when returning from TEE to the
+ * This file specifies SMC function IDs used when returning from TEE to the
  * secure monitor.
  *
  * All SMC Function IDs indicates SMC32 Calling Convention but will carry
  * full 64 bit values in the argument registers if invoked from Aarch64
  * mode. This violates the SMC Calling Convention, but since this
- * convention only coveres API towards Normwal World it's something that
+ * convention only coveres API towards Normal World it's something that
  * only concerns the OP-TEE Dispatcher in ARM Trusted Firmware and OP-TEE
  * OS at Secure EL1.
  */

--- a/services/spd/tlkd/tlkd_main.c
+++ b/services/spd/tlkd/tlkd_main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -341,7 +341,7 @@ static uintptr_t tlkd_smc_handler(uint32_t smc_fid,
 
 		/*
 		 * SP has been successfully initialized. Register power
-		 * managemnt hooks with PSCI
+		 * management hooks with PSCI
 		 */
 		psci_register_spd_pm_hook(&tlkd_pm_ops);
 

--- a/services/spd/trusty/trusty.c
+++ b/services/spd/trusty/trusty.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -100,7 +100,7 @@ static struct args trusty_context_switch(uint32_t security_state, uint64_t r0,
 
 	/*
 	 * To avoid the additional overhead in PSCI flow, skip FP context
-	 * saving/restoring in case of CPU suspend and resume, asssuming that
+	 * saving/restoring in case of CPU suspend and resume, assuming that
 	 * when it's needed the PSCI caller has preserved FP context before
 	 * going here.
 	 */
@@ -302,7 +302,7 @@ static int32_t trusty_init(void)
 
 	/*
 	 * Adjust secondary cpu entry point for 32 bit images to the
-	 * end of exeption vectors
+	 * end of exception vectors
 	 */
 	if ((cpu != 0) && (reg_width == MODE_RW_32)) {
 		INFO("trusty: cpu %d, adjust entry point to 0x%lx\n",

--- a/services/spd/tspd/tspd_main.c
+++ b/services/spd/tspd/tspd_main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -375,7 +375,7 @@ static uintptr_t tspd_smc_handler(uint32_t smc_fid,
 
 			/*
 			 * TSP has been successfully initialized. Register power
-			 * managemnt hooks with PSCI
+			 * management hooks with PSCI
 			 */
 			psci_register_spd_pm_hook(&tspd_pm);
 

--- a/services/std_svc/sdei/sdei_private.h
+++ b/services/std_svc/sdei/sdei_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -54,7 +54,7 @@
 /*
  * 'info' parameter to SDEI_EVENT_GET_INFO SMC.
  *
- * Note that the SDEI v1.0 speification mistakenly enumerates the
+ * Note that the SDEI v1.0 specification mistakenly enumerates the
  * SDEI_INFO_EV_SIGNALED as SDEI_INFO_SIGNALED. This will be corrected in a
  * future version.
  */


### PR DESCRIPTION
Corrects typos in core files, documentation files, drivers, Arm
platforms and services.

None of the corrections are functional; they are limited to comments
in code and other documentation.

Change-Id: I5c1027b06ef149864f315ccc0ea473e2a16bfd1d
Signed-off-by: Paul Beesley <paul.beesley@arm.com>