### PR TITLE
ti: k3: common: Allow customizing UART baud rate using build options

### DIFF
--- a/plat/ti/k3/common/plat_common.mk
+++ b/plat/ti/k3/common/plat_common.mk
@@ -30,6 +30,10 @@ MULTI_CONSOLE_API	:=	1
 TI_16550_MDR_QUIRK	:=	1
 $(eval $(call add_define,TI_16550_MDR_QUIRK))
 
+# Allow customizing the UART baud rate
+K3_USART_BAUD		:=	115200
+$(eval $(call add_define,K3_USART_BAUD))
+
 # Libraries
 include lib/xlat_tables_v2/xlat_tables.mk
 

--- a/plat/ti/k3/include/platform_def.h
+++ b/plat/ti/k3/include/platform_def.h
@@ -136,10 +136,6 @@
 #define K3_USART_CLK_SPEED 48000000
 #endif
 
-#ifndef K3_USART_BAUD
-#define K3_USART_BAUD 115200
-#endif
-
 /* Crash console defaults */
 #define CRASH_CONSOLE_BASE K3_USART_BASE_ADDRESS
 #define CRASH_CONSOLE_CLK K3_USART_CLK_SPEED


### PR DESCRIPTION
To accommodate scenarios where we want to use a UART baud rate other than
the default 115,200 allow the associated compiler definition to be set
via the K3_USART_BAUD build option by updating the platform make file.

Since the platform make file now also contains the default value (still
115,200), go ahead and remove the redundant definition from the platform
header file.

Suggested-by: Andrew F. Davis <afd@ti.com>
Signed-off-by: Andreas Dannenberg <dannenberg@ti.com>