### PR TITLE
Make device tree pre-processing similar to U-boot/Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,7 @@ TF_LDFLAGS		+=	--gc-sections
 TF_LDFLAGS		+=	$(TF_LDFLAGS_$(ARCH))
 
 DTC_FLAGS		+=	-I dts -O dtb
+DTC_CPPFLAGS		+=	-nostdinc -Iinclude -undef -x assembler-with-cpp
 
 ################################################################################
 # Common sources and include directories

--- a/make_helpers/build_macros.mk
+++ b/make_helpers/build_macros.mk
@@ -464,7 +464,7 @@ $(eval DTBDEP := $(patsubst %.dtb,%.d,$(DOBJ)))
 $(DOBJ): $(2) $(filter-out %.d,$(MAKEFILE_LIST)) | fdt_dirs
 	$${ECHO} "  CPP     $$<"
 	$(eval DTBS       := $(addprefix $(1)/,$(call SOURCES_TO_DTBS,$(2))))
-	$$(Q)$$(CPP) $$(CPPFLAGS) -x assembler-with-cpp -MT $(DTBS) -MMD -MF $(DTSDEP) -o $(DPRE) $$<
+	$$(Q)$$(PP) $$(DTC_CPPFLAGS) -MT $(DTBS) -MMD -MF $(DTSDEP) -o $(DPRE) $$<
 	$${ECHO} "  DTC     $$<"
 	$$(Q)$$(DTC) $$(DTC_FLAGS) -i fdts -d $(DTBDEP) -o $$@ $(DPRE)
 


### PR DESCRIPTION
Following changes are done to make DT pre-processing similar to that of
U-boot/Linux kernel.

1. Creating seperate CPPFLAGS for DT preprocessing so that compiler
options specific to it can be accommodated.
e.g: "-undef" compiler option avoids replacing "linux" string(used in
device trees) with "1" as "linux" is a pre-defined macro in gnu99
standard.

2. Replace CPP with PP for DT pre-processing, as CPP in U-boot/Linux is
exported as "${CROSS_COMPILE}gcc -E" while in TF-A it is exported as
"${CROSS_COMPILE}cpp".

Change-Id: If4c61a249d51614d9f53ae30b602036d50c02349
Signed-off-by: Manish Pandey <manish.pandey2@arm.com>