### PR TITLE
spd: trusty: trusty_setup should bail on unknown image

### DIFF
--- a/services/spd/trusty/trusty.c
+++ b/services/spd/trusty/trusty.c
@@ -416,7 +416,8 @@ static int32_t trusty_setup(void)
 	} else if (instr >> 8 == 0xd53810U || instr >> 16 == 0x9400U) {
 		INFO("trusty: Found 64 bit image\n");
 	} else {
-		NOTICE("trusty: Found unknown image, 0x%x\n", instr);
+		ERROR("trusty: Found unknown image, 0x%x\n", instr);
+		return -1;
 	}
 
 	SET_PARAM_HEAD(ep_info, PARAM_EP, VERSION_1, SECURE | EP_ST_ENABLE);


### PR DESCRIPTION
When an unknown Trusty image is found, there's no point of still trying
to register the BL32 init handler. Instead, we just should bail out of
the trusty_setup() and allow the system to continue to boot.

Signed-off-by: David Lin <dtwlin@google.com>