### PR TITLE
rpi3: Remove duplicate initialization for BL32_IMAGE_ID and mark one more function as static.

### DIFF
--- a/plat/rpi3/rpi3_io_storage.c
+++ b/plat/rpi3/rpi3_io_storage.c
@@ -133,11 +133,6 @@ static const struct plat_io_policy policies[] = {
 		(uintptr_t)&bl32_uuid_spec,
 		open_fip
 	},
-	[BL32_IMAGE_ID] = {
-		&fip_dev_handle,
-		(uintptr_t)&bl32_uuid_spec,
-		open_fip
-	},
 	[BL32_EXTRA1_IMAGE_ID] = {
 		&fip_dev_handle,
 		(uintptr_t)&bl32_extra1_uuid_spec,

--- a/plat/rpi3/rpi3_pm.c
+++ b/plat/rpi3/rpi3_pm.c
@@ -140,7 +140,7 @@ static int rpi3_pwr_domain_on(u_register_t mpidr)
  * being turned off earlier. The target_state encodes the low power state that
  * each level has woken up from.
  ******************************************************************************/
-void rpi3_pwr_domain_on_finish(const psci_power_state_t *target_state)
+static void rpi3_pwr_domain_on_finish(const psci_power_state_t *target_state)
 {
 	assert(target_state->pwr_domain_state[MPIDR_AFFLVL0] ==
 					PLAT_LOCAL_STATE_OFF);


### PR DESCRIPTION
Signed-off-by: Florian La Roche <Florian.LaRoche@gmail.com>