### PR TITLE
Add a minimal reset framework

### DIFF
--- a/drivers/reset/reset.c
+++ b/drivers/reset/reset.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019, STMicroelectronics - All Rights Reserved
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <assert.h>
+
+#include <drivers/reset.h>
+
+static const struct reset_ops *reset_ops;
+
+void reset_assert(unsigned int id)
+{
+	assert((reset_ops != NULL) && (reset_ops->reset_assert != NULL));
+
+	reset_ops->reset_assert(id);
+}
+
+void reset_deassert(unsigned int id)
+{
+	assert((reset_ops != NULL) && (reset_ops->reset_deassert != NULL));
+
+	reset_ops->reset_deassert(id);
+}
+
+bool reset_asserted_status(unsigned int id)
+{
+	assert((reset_ops != NULL) &&
+	       (reset_ops->reset_asserted_status != NULL));
+
+	return reset_ops->reset_asserted_status(id);
+}
+
+void register_reset_driver(const struct reset_ops *ops)
+{
+	assert((ops != NULL) && (reset_ops == NULL));
+
+	reset_ops = ops;
+}

--- a/drivers/st/mmc/stm32_sdmmc2.c
+++ b/drivers/st/mmc/stm32_sdmmc2.c
@@ -17,11 +17,11 @@
 #include <common/debug.h>
 #include <drivers/delay_timer.h>
 #include <drivers/mmc.h>
+#include <drivers/reset.h>
 #include <drivers/st/stm32_gpio.h>
 #include <drivers/st/stm32_sdmmc2.h>
 #include <drivers/st/stm32mp1_clk.h>
 #include <drivers/st/stm32mp1_rcc.h>
-#include <drivers/st/stm32mp1_reset.h>
 #include <dt-bindings/clock/stm32mp1-clks.h>
 #include <dt-bindings/reset/stm32mp1-resets.h>
 #include <lib/mmio.h>
@@ -727,9 +727,9 @@ int stm32_sdmmc2_mmc_init(struct stm32_sdmmc2_params *params)
 		return ret;
 	}
 
-	stm32mp1_reset_assert(sdmmc2_params.reset_id);
+	reset_assert(sdmmc2_params.reset_id);
 	udelay(2);
-	stm32mp1_reset_deassert(sdmmc2_params.reset_id);
+	reset_deassert(sdmmc2_params.reset_id);
 	mdelay(1);
 
 	sdmmc2_params.clk_rate = stm32mp1_clk_get_rate(sdmmc2_params.clock_id);

--- a/drivers/st/reset/stm32mp1_reset.c
+++ b/drivers/st/reset/stm32mp1_reset.c
@@ -10,6 +10,7 @@
 
 #include <common/bl_common.h>
 #include <common/debug.h>
+#include <drivers/reset.h>
 #include <drivers/st/stm32mp1_rcc.h>
 #include <drivers/st/stm32mp1_reset.h>
 #include <lib/mmio.h>
@@ -17,7 +18,7 @@
 
 #define RST_CLR_OFFSET	4U
 
-void stm32mp1_reset_assert(uint32_t id)
+static void stm32mp1_reset_assert(unsigned int id)
 {
 	uint32_t offset = (id / (uint32_t)__LONG_BIT) * sizeof(uintptr_t);
 	uint32_t bit = id % (uint32_t)__LONG_BIT;
@@ -28,7 +29,7 @@ void stm32mp1_reset_assert(uint32_t id)
 	}
 }
 
-void stm32mp1_reset_deassert(uint32_t id)
+static void stm32mp1_reset_deassert(unsigned int id)
 {
 	uint32_t offset = ((id / (uint32_t)__LONG_BIT) * sizeof(uintptr_t)) +
 			  RST_CLR_OFFSET;
@@ -38,4 +39,14 @@ void stm32mp1_reset_deassert(uint32_t id)
 	while ((mmio_read_32(RCC_BASE + offset) & BIT(bit)) != 0U) {
 		;
 	}
+}
+
+static const struct reset_ops stm32mp1_reset_ops = {
+	.reset_assert = stm32mp1_reset_assert,
+	.reset_deassert = stm32mp1_reset_deassert,
+};
+
+void stm32mp1_reset_init(void)
+{
+	register_reset_driver(&stm32mp1_reset_ops);
 }

--- a/include/drivers/reset.h
+++ b/include/drivers/reset.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019, STMicroelectronics - All Rights Reserved
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef RESET_H
+#define RESET_H
+
+#include <stdbool.h>
+
+struct reset_ops {
+	void (*reset_assert)(unsigned int id);
+	void (*reset_deassert)(unsigned int id);
+	/* reset_asserted_status: true = asserted, false = deasserted */
+	bool (*reset_asserted_status)(unsigned int id);
+};
+
+void reset_assert(unsigned int id);
+void reset_deassert(unsigned int id);
+bool reset_asserted_status(unsigned int id);
+void register_reset_driver(const struct reset_ops *ops);
+
+#endif /* RESET_H */

--- a/include/drivers/st/stm32mp1_reset.h
+++ b/include/drivers/st/stm32mp1_reset.h
@@ -7,9 +7,6 @@
 #ifndef STM32MP1_RESET_H
 #define STM32MP1_RESET_H
 
-#include <stdint.h>
-
-void stm32mp1_reset_assert(uint32_t reset_id);
-void stm32mp1_reset_deassert(uint32_t reset_id);
+void stm32mp1_reset_init(void);
 
 #endif /* STM32MP1_RESET_H */

--- a/maintainers.rst
+++ b/maintainers.rst
@@ -181,6 +181,13 @@ Renesas rcar-gen3 platform port
 :F: drivers/renesas/rcar
 :F: tools/renesas/rcar_layout_create
 
+Reset driver
+------------
+:M: Yann Gautier <yann.gautier@st.com>
+:G: `Yann-lms`_
+:F: drivers/reset/reset.c
+:F: include/drivers/reset.h
+
 RockChip platform port
 ----------------------
 :M: Tony Xie <tony.xie@rock-chips.com>

--- a/plat/st/stm32mp1/bl2_plat_setup.c
+++ b/plat/st/stm32mp1/bl2_plat_setup.c
@@ -15,6 +15,7 @@
 #include <common/desc_image_load.h>
 #include <drivers/delay_timer.h>
 #include <drivers/generic_delay_timer.h>
+#include <drivers/reset.h>
 #include <drivers/st/stm32_console.h>
 #include <drivers/st/stm32mp_pmic.h>
 #include <drivers/st/stm32mp1_clk.h>
@@ -211,6 +212,8 @@ void bl2_el3_plat_arch_setup(void)
 		panic();
 	}
 
+	stm32mp1_reset_init();
+
 	result = dt_get_stdout_uart_info(&dt_uart_info);
 
 	if ((result <= 0) ||
@@ -228,9 +231,9 @@ void bl2_el3_plat_arch_setup(void)
 		goto skip_console_init;
 	}
 
-	stm32mp1_reset_assert((uint32_t)dt_uart_info.reset);
+	reset_assert((unsigned int)dt_uart_info.reset);
 	udelay(2);
-	stm32mp1_reset_deassert((uint32_t)dt_uart_info.reset);
+	reset_deassert((unsigned int)dt_uart_info.reset);
 	mdelay(1);
 
 	clk_rate = stm32mp1_clk_get_rate((unsigned long)dt_uart_info.clock);

--- a/plat/st/stm32mp1/platform.mk
+++ b/plat/st/stm32mp1/platform.mk
@@ -47,6 +47,7 @@ PLAT_BL_COMMON_SOURCES	+=	${LIBFDT_SRCS}						\
 				drivers/arm/tzc/tzc400.c				\
 				drivers/delay_timer/delay_timer.c			\
 				drivers/delay_timer/generic_delay_timer.c		\
+				drivers/reset/reset.c					\
 				drivers/st/bsec/bsec.c					\
 				drivers/st/clk/stm32mp1_clk.c				\
 				drivers/st/clk/stm32mp1_clkfunc.c			\

--- a/plat/st/stm32mp1/sp_min/sp_min_setup.c
+++ b/plat/st/stm32mp1/sp_min/sp_min_setup.c
@@ -20,6 +20,7 @@
 #include <drivers/st/stm32_console.h>
 #include <drivers/st/stm32_gpio.h>
 #include <drivers/st/stm32mp1_clk.h>
+#include <drivers/st/stm32mp1_reset.h>
 #include <dt-bindings/clock/stm32mp1-clks.h>
 #include <lib/el3_runtime/context_mgmt.h>
 #include <lib/mmio.h>
@@ -142,6 +143,8 @@ void sp_min_platform_setup(void)
 			MT_CODE | MT_SECURE);
 
 	configure_mmu();
+
+	stm32mp1_reset_init();
 
 	/* Initialize tzc400 after DDR initialization */
 	stm32mp1_security_setup();


### PR DESCRIPTION
With this framework, the drivers could be more generic instead of directly calling platform reset drivers.