### PR TITLE
tools/fiptool: Fix UUID parsing in blob handling

### DIFF
--- a/tools/fiptool/fiptool.c
+++ b/tools/fiptool/fiptool.c
@@ -271,10 +271,10 @@ static void uuid_from_str(uuid_t *u, const char *s)
 	    &u->node[2], &u->node[3],
 	    &u->node[4], &u->node[5]);
 	/*
-	 * Given the format specifier above, we expect 11 items to be scanned
+	 * Given the format specifier above, we expect 16 items to be scanned
 	 * for a properly formatted UUID.
 	 */
-	if (n != 11)
+	if (n != 16)
 		log_errx("Invalid UUID: %s", s);
 }
 


### PR DESCRIPTION
Commit 033648652f ("Make TF UUID RFC 4122 compliant") changed the scanf
parsing string to handle endianness correctly.
However that changed the number of items sscanf handles, without
adjusting the sanity check just below.

Increase the expected return value from 11 to 16 to let fiptool handle
UUIDs given as blob parameters correctly again.

Signed-off-by: Andre Przywara <andre.przywara@arm.com>