### PR TITLE
GICv3: Allow probe for fewer GICR interfaces than exposed by the frame

### DIFF
--- a/drivers/arm/gic/v3/gicv3_helpers.c
+++ b/drivers/arm/gic/v3/gicv3_helpers.c
@@ -341,8 +341,10 @@ void gicv3_rdistif_base_addrs_probe(uintptr_t *rdistif_base_addrs,
 			proc_num = (typer_val >> TYPER_PROC_NUM_SHIFT) &
 				TYPER_PROC_NUM_MASK;
 		}
-		assert(proc_num < rdistif_num);
-		rdistif_base_addrs[proc_num] = rdistif_base;
+
+		if (proc_num < rdistif_num)
+			rdistif_base_addrs[proc_num] = rdistif_base;
+
 		rdistif_base += (1U << GICR_PCPUBASE_SHIFT);
 	} while ((typer_val & TYPER_LAST_BIT) == 0U);
 }


### PR DESCRIPTION
Previously the GICv3 redistributor probe function
(gicv3_rdistif_base_addrs_probe()) asserted that the number of
per-CPU redistributor interfaces expected to be probed by the
platform is equal to the number exported by the redistributor
frame. This is a problem in case the number of CPUs in the
platform is less than the number of redistributor interfaces
in the frame. Hence this patch removes the assertion check
and allows probe for fewer redistributor interfaces as required
by the platform.

Change-Id: I3449763a3ad70817224442cbe184d001030c9874
Signed-off-by: Soby Mathew <soby.mathew@arm.com>