### PR TITLE
drivers: generic_delay_timer: Assert presence of Generic Timer

### DIFF
--- a/drivers/delay_timer/generic_delay_timer.c
+++ b/drivers/delay_timer/generic_delay_timer.c
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <assert.h>
 
+#include <arch_features.h>
 #include <arch_helpers.h>
 #include <common/bl_common.h>
 #include <common/debug.h>
@@ -43,6 +44,8 @@ void generic_delay_timer_init_args(uint32_t mult, uint32_t div)
 
 void generic_delay_timer_init(void)
 {
+	assert(is_armv7_gentimer_present());
+
 	/* Value in ticks */
 	unsigned int mult = MHZ_TICKS_PER_SEC;
 

--- a/include/arch/aarch32/arch.h
+++ b/include/arch/aarch32/arch.h
@@ -114,6 +114,8 @@
 #define ID_PFR1_VIRTEXT_MASK	U(0xf)
 #define GET_VIRT_EXT(id)	(((id) >> ID_PFR1_VIRTEXT_SHIFT) \
 				 & ID_PFR1_VIRTEXT_MASK)
+#define ID_PFR1_GENTIMER_SHIFT	U(16)
+#define ID_PFR1_GENTIMER_MASK	U(0xf)
 #define ID_PFR1_GIC_SHIFT	U(28)
 #define ID_PFR1_GIC_MASK	U(0xf)
 

--- a/include/arch/aarch32/arch_features.h
+++ b/include/arch/aarch32/arch_features.h
@@ -11,6 +11,12 @@
 
 #include <arch_helpers.h>
 
+static inline bool is_armv7_gentimer_present(void)
+{
+	return ((read_id_pfr1() >> ID_PFR1_GENTIMER_SHIFT) &
+		ID_PFR1_GENTIMER_MASK) != 0U;
+}
+
 static inline bool is_armv8_2_ttcnp_present(void)
 {
 	return ((read_id_mmfr4() >> ID_MMFR4_CNP_SHIFT) &

--- a/include/arch/aarch64/arch_features.h
+++ b/include/arch/aarch64/arch_features.h
@@ -11,6 +11,12 @@
 
 #include <arch_helpers.h>
 
+static inline bool is_armv7_gentimer_present(void)
+{
+	/* The Generic Timer is always present in an ARMv8-A implementation */
+	return true;
+}
+
 static inline bool is_armv8_2_ttcnp_present(void)
 {
 	return ((read_id_aa64mmfr2_el1() >> ID_AA64MMFR2_EL1_CNP_SHIFT) &


### PR DESCRIPTION
The Generic Timer is an optional extension to an ARMv7-A implementation. The generic delay timer can be used from any architecture supported by the Trusted Firmware. In ARMv7 it is needed to check that this feature is present. In ARMv8 it is always present.