### PR TITLE
trusty: Require dynamic translation tables

### DIFF
--- a/services/spd/trusty/trusty.mk
+++ b/services/spd/trusty/trusty.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -12,6 +12,8 @@ SPD_SOURCES		:=	services/spd/trusty/trusty.c		\
 ifeq (${TRUSTY_SPD_WITH_GENERIC_SERVICES},1)
 SPD_SOURCES		+=	services/spd/trusty/generic-arm64-smcall.c
 endif
+
+BL31_CFLAGS	+=		-DPLAT_XLAT_TABLES_DYNAMIC=1
 
 NEED_BL32		:=	yes
 


### PR DESCRIPTION
Trusty requires dynamic translation tables support, so the makefile of Trusty itself should request it. Not doing so causes platforms such as FVP to fail to build with Trusty. Other platforms like Tegra still build because they use dynamic translation tables by default.