### PR TITLE
Fix CPU headers' definitions

### DIFF
--- a/include/lib/cpus/aarch32/aem_generic.h
+++ b/include/lib/cpus/aarch32/aem_generic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,7 +7,9 @@
 #ifndef AEM_GENERIC_H
 #define AEM_GENERIC_H
 
+#include <lib/utils_def.h>
+
 /* BASE AEM midr for revision 0 */
-#define BASE_AEM_MIDR 0x410FD0F0
+#define BASE_AEM_MIDR		U(0x410FD0F0)
 
 #endif /* AEM_GENERIC_H */

--- a/include/lib/cpus/aarch32/cortex_a12.h
+++ b/include/lib/cpus/aarch32/cortex_a12.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,14 +7,16 @@
 #ifndef CORTEX_A12_H
 #define CORTEX_A12_H
 
+#include <lib/utils_def.h>
+
 /*******************************************************************************
  * Cortex-A12 midr with version/revision set to 0
  ******************************************************************************/
-#define CORTEX_A12_MIDR			0x410FC0C0
+#define CORTEX_A12_MIDR			U(0x410FC0C0)
 
 /*******************************************************************************
  * CPU Auxiliary Control register specific definitions.
  ******************************************************************************/
-#define CORTEX_A12_ACTLR_SMP_BIT	(1 << 6)
+#define CORTEX_A12_ACTLR_SMP_BIT	(U(1) << 6)
 
 #endif /* CORTEX_A12_H */

--- a/include/lib/cpus/aarch32/cortex_a15.h
+++ b/include/lib/cpus/aarch32/cortex_a15.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,15 +7,17 @@
 #ifndef CORTEX_A15_H
 #define CORTEX_A15_H
 
+#include <lib/utils_def.h>
+
 /*******************************************************************************
  * Cortex-A15 midr with version/revision set to 0
  ******************************************************************************/
-#define CORTEX_A15_MIDR			0x410FC0F0
+#define CORTEX_A15_MIDR			U(0x410FC0F0)
 
 /*******************************************************************************
  * CPU Auxiliary Control register specific definitions.
  ******************************************************************************/
-#define CORTEX_A15_ACTLR_INV_BTB_BIT	(1 << 0)
-#define CORTEX_A15_ACTLR_SMP_BIT	(1 << 6)
+#define CORTEX_A15_ACTLR_INV_BTB_BIT	(U(1) << 0)
+#define CORTEX_A15_ACTLR_SMP_BIT	(U(1) << 6)
 
 #endif /* CORTEX_A15_H */

--- a/include/lib/cpus/aarch32/cortex_a17.h
+++ b/include/lib/cpus/aarch32/cortex_a17.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,14 +7,16 @@
 #ifndef CORTEX_A17_H
 #define CORTEX_A17_H
 
+#include <lib/utils_def.h>
+
 /*******************************************************************************
  * Cortex-A17 midr with version/revision set to 0
  ******************************************************************************/
-#define CORTEX_A17_MIDR			0x410FC0E0
+#define CORTEX_A17_MIDR			U(0x410FC0E0)
 
 /*******************************************************************************
  * CPU Auxiliary Control register specific definitions.
  ******************************************************************************/
-#define CORTEX_A17_ACTLR_SMP_BIT	(1 << 6)
+#define CORTEX_A17_ACTLR_SMP_BIT	(U(1) << 6)
 
 #endif /* CORTEX_A17_H */

--- a/include/lib/cpus/aarch32/cortex_a32.h
+++ b/include/lib/cpus/aarch32/cortex_a32.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,14 +7,16 @@
 #ifndef CORTEX_A32_H
 #define CORTEX_A32_H
 
+#include <lib/utils_def.h>
+
 /* Cortex-A32 Main ID register for revision 0 */
-#define CORTEX_A32_MIDR				0x410FD010
+#define CORTEX_A32_MIDR				U(0x410FD010)
 
 /*******************************************************************************
  * CPU Extended Control register specific definitions.
  * CPUECTLR_EL1 is an implementation-specific register.
  ******************************************************************************/
 #define CORTEX_A32_CPUECTLR_EL1			p15, 1, c15
-#define CORTEX_A32_CPUECTLR_SMPEN_BIT		(1 << 6)
+#define CORTEX_A32_CPUECTLR_SMPEN_BIT		(ULL(1) << 6)
 
 #endif /* CORTEX_A32_H */

--- a/include/lib/cpus/aarch32/cortex_a5.h
+++ b/include/lib/cpus/aarch32/cortex_a5.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,14 +7,16 @@
 #ifndef CORTEX_A5_H
 #define CORTEX_A5_H
 
+#include <lib/utils_def.h>
+
 /*******************************************************************************
  * Cortex-A8 midr with version/revision set to 0
  ******************************************************************************/
-#define CORTEX_A5_MIDR			0x410FC050
+#define CORTEX_A5_MIDR			U(0x410FC050)
 
 /*******************************************************************************
  * CPU Auxiliary Control register specific definitions.
  ******************************************************************************/
-#define CORTEX_A5_ACTLR_SMP_BIT		(1 << 6)
+#define CORTEX_A5_ACTLR_SMP_BIT		(U(1) << 6)
 
 #endif /* CORTEX_A5_H */

--- a/include/lib/cpus/aarch32/cortex_a53.h
+++ b/include/lib/cpus/aarch32/cortex_a53.h
@@ -1,11 +1,13 @@
 /*
- * Copyright (c) 2016-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CORTEX_A53_H
 #define CORTEX_A53_H
+
+#include <lib/utils_def.h>
 
 /* Cortex-A53 midr for revision 0 */
 #define CORTEX_A53_MIDR 0x410FD030
@@ -42,9 +44,10 @@
  ******************************************************************************/
 #define CORTEX_A53_CPUACTLR			p15, 0, c15
 
-#define CORTEX_A53_CPUACTLR_ENDCCASCI_SHIFT	44
-#define CORTEX_A53_CPUACTLR_ENDCCASCI		(1 << CORTEX_A53_CPUACTLR_ENDCCASCI_SHIFT)
-#define CORTEX_A53_CPUACTLR_DTAH		(1 << 24)
+#define CORTEX_A53_CPUACTLR_ENDCCASCI_SHIFT	U(44)
+#define CORTEX_A53_CPUACTLR_ENDCCASCI		(ULL(1) << CORTEX_A53_CPUACTLR_ENDCCASCI_SHIFT)
+#define CORTEX_A53_CPUACTLR_DTAH_SHIFT		U(24)
+#define CORTEX_A53_CPUACTLR_DTAH		(ULL(1) << CORTEX_A53_CPUACTLR_DTAH_SHIFT)
 
 /*******************************************************************************
  * L2 Auxiliary Control register specific definitions.

--- a/include/lib/cpus/aarch32/cortex_a53.h
+++ b/include/lib/cpus/aarch32/cortex_a53.h
@@ -10,29 +10,29 @@
 #include <lib/utils_def.h>
 
 /* Cortex-A53 midr for revision 0 */
-#define CORTEX_A53_MIDR 0x410FD030
+#define CORTEX_A53_MIDR			U(0x410FD030)
 
 /* Retention timer tick definitions */
-#define RETENTION_ENTRY_TICKS_2		0x1
-#define RETENTION_ENTRY_TICKS_8		0x2
-#define RETENTION_ENTRY_TICKS_32	0x3
-#define RETENTION_ENTRY_TICKS_64	0x4
-#define RETENTION_ENTRY_TICKS_128	0x5
-#define RETENTION_ENTRY_TICKS_256	0x6
-#define RETENTION_ENTRY_TICKS_512	0x7
+#define RETENTION_ENTRY_TICKS_2		U(0x1)
+#define RETENTION_ENTRY_TICKS_8		U(0x2)
+#define RETENTION_ENTRY_TICKS_32	U(0x3)
+#define RETENTION_ENTRY_TICKS_64	U(0x4)
+#define RETENTION_ENTRY_TICKS_128	U(0x5)
+#define RETENTION_ENTRY_TICKS_256	U(0x6)
+#define RETENTION_ENTRY_TICKS_512	U(0x7)
 
 /*******************************************************************************
  * CPU Extended Control register specific definitions.
  ******************************************************************************/
 #define CORTEX_A53_ECTLR			p15, 1, c15
 
-#define CORTEX_A53_ECTLR_SMP_BIT		(1 << 6)
+#define CORTEX_A53_ECTLR_SMP_BIT		(U(1) << 6)
 
-#define CORTEX_A53_ECTLR_CPU_RET_CTRL_SHIFT	0
-#define CORTEX_A53_ECTLR_CPU_RET_CTRL_MASK	(0x7 << CORTEX_A53_ECTLR_CPU_RET_CTRL_SHIFT)
+#define CORTEX_A53_ECTLR_CPU_RET_CTRL_SHIFT	U(0)
+#define CORTEX_A53_ECTLR_CPU_RET_CTRL_MASK	(ULL(0x7) << CORTEX_A53_ECTLR_CPU_RET_CTRL_SHIFT)
 
-#define CORTEX_A53_ECTLR_FPU_RET_CTRL_SHIFT	3
-#define CORTEX_A53_ECTLR_FPU_RET_CTRL_MASK	(0x7 << CORTEX_A53_ECTLR_FPU_RET_CTRL_SHIFT)
+#define CORTEX_A53_ECTLR_FPU_RET_CTRL_SHIFT	U(3)
+#define CORTEX_A53_ECTLR_FPU_RET_CTRL_MASK	(ULL(0x7) << CORTEX_A53_ECTLR_FPU_RET_CTRL_SHIFT)
 
 /*******************************************************************************
  * CPU Memory Error Syndrome register specific definitions.
@@ -54,16 +54,16 @@
  ******************************************************************************/
 #define CORTEX_A53_L2ACTLR			p15, 1, c15, c0, 0
 
-#define CORTEX_A53_L2ACTLR_ENABLE_UNIQUECLEAN	(1 << 14)
-#define CORTEX_A53_L2ACTLR_DISABLE_CLEAN_PUSH	(1 << 3)
+#define CORTEX_A53_L2ACTLR_ENABLE_UNIQUECLEAN	(U(1) << 14)
+#define CORTEX_A53_L2ACTLR_DISABLE_CLEAN_PUSH	(U(1) << 3)
 
 /*******************************************************************************
  * L2 Extended Control register specific definitions.
  ******************************************************************************/
 #define CORTEX_A53_L2ECTLR			p15, 1, c9, c0, 3
 
-#define CORTEX_A53_L2ECTLR_RET_CTRL_SHIFT	0
-#define CORTEX_A53_L2ECTLR_RET_CTRL_MASK	(0x7 << L2ECTLR_RET_CTRL_SHIFT)
+#define CORTEX_A53_L2ECTLR_RET_CTRL_SHIFT	U(0)
+#define CORTEX_A53_L2ECTLR_RET_CTRL_MASK	(U(0x7) << L2ECTLR_RET_CTRL_SHIFT)
 
 /*******************************************************************************
  * L2 Memory Error Syndrome register specific definitions.

--- a/include/lib/cpus/aarch32/cortex_a57.h
+++ b/include/lib/cpus/aarch32/cortex_a57.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,16 +10,16 @@
 #include <lib/utils_def.h>
 
 /* Cortex-A57 midr for revision 0 */
-#define CORTEX_A57_MIDR 0x410FD070
+#define CORTEX_A57_MIDR			U(0x410FD070)
 
 /* Retention timer tick definitions */
-#define RETENTION_ENTRY_TICKS_2		0x1
-#define RETENTION_ENTRY_TICKS_8		0x2
-#define RETENTION_ENTRY_TICKS_32	0x3
-#define RETENTION_ENTRY_TICKS_64	0x4
-#define RETENTION_ENTRY_TICKS_128	0x5
-#define RETENTION_ENTRY_TICKS_256	0x6
-#define RETENTION_ENTRY_TICKS_512	0x7
+#define RETENTION_ENTRY_TICKS_2		U(0x1)
+#define RETENTION_ENTRY_TICKS_8		U(0x2)
+#define RETENTION_ENTRY_TICKS_32	U(0x3)
+#define RETENTION_ENTRY_TICKS_64	U(0x4)
+#define RETENTION_ENTRY_TICKS_128	U(0x5)
+#define RETENTION_ENTRY_TICKS_256	U(0x6)
+#define RETENTION_ENTRY_TICKS_512	U(0x7)
 
 /*******************************************************************************
  * CPU Extended Control register specific definitions.
@@ -31,7 +31,7 @@
 #define CORTEX_A57_ECTLR_L2_IPFTCH_DIST_MASK	(ULL(0x3) << 35)
 #define CORTEX_A57_ECTLR_L2_DPFTCH_DIST_MASK	(ULL(0x3) << 32)
 
-#define CORTEX_A57_ECTLR_CPU_RET_CTRL_SHIFT	0
+#define CORTEX_A57_ECTLR_CPU_RET_CTRL_SHIFT	U(0)
 #define CORTEX_A57_ECTLR_CPU_RET_CTRL_MASK	(ULL(0x7) << CORTEX_A57_ECTLR_CPU_RET_CTRL_SHIFT)
 
 /*******************************************************************************
@@ -61,19 +61,19 @@
  ******************************************************************************/
 #define CORTEX_A57_L2CTLR				p15, 1, c9, c0, 2
 
-#define CORTEX_A57_L2CTLR_DATA_RAM_LATENCY_SHIFT	0
-#define CORTEX_A57_L2CTLR_TAG_RAM_LATENCY_SHIFT		6
+#define CORTEX_A57_L2CTLR_DATA_RAM_LATENCY_SHIFT	U(0)
+#define CORTEX_A57_L2CTLR_TAG_RAM_LATENCY_SHIFT		U(6)
 
-#define CORTEX_A57_L2_DATA_RAM_LATENCY_3_CYCLES		0x2
-#define CORTEX_A57_L2_TAG_RAM_LATENCY_3_CYCLES		0x2
+#define CORTEX_A57_L2_DATA_RAM_LATENCY_3_CYCLES		U(0x2)
+#define CORTEX_A57_L2_TAG_RAM_LATENCY_3_CYCLES		U(0x2)
 
 /*******************************************************************************
  * L2 Extended Control register specific definitions.
  ******************************************************************************/
 #define CORTEX_A57_L2ECTLR			p15, 1, c9, c0, 3
 
-#define CORTEX_A57_L2ECTLR_RET_CTRL_SHIFT	0
-#define CORTEX_A57_L2ECTLR_RET_CTRL_MASK	(ULL(0x7) << CORTEX_A57_L2ECTLR_RET_CTRL_SHIFT)
+#define CORTEX_A57_L2ECTLR_RET_CTRL_SHIFT	U(0)
+#define CORTEX_A57_L2ECTLR_RET_CTRL_MASK	(U(0x7) << CORTEX_A57_L2ECTLR_RET_CTRL_SHIFT)
 
 /*******************************************************************************
  * L2 Memory Error Syndrome register specific definitions.

--- a/include/lib/cpus/aarch32/cortex_a7.h
+++ b/include/lib/cpus/aarch32/cortex_a7.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,14 +7,16 @@
 #ifndef CORTEX_A7_H
 #define CORTEX_A7_H
 
+#include <lib/utils_def.h>
+
 /*******************************************************************************
  * Cortex-A7 midr with version/revision set to 0
  ******************************************************************************/
-#define CORTEX_A7_MIDR			0x410FC070
+#define CORTEX_A7_MIDR			U(0x410FC070)
 
 /*******************************************************************************
  * CPU Auxiliary Control register specific definitions.
  ******************************************************************************/
-#define CORTEX_A7_ACTLR_SMP_BIT		(1 << 6)
+#define CORTEX_A7_ACTLR_SMP_BIT		(U(1) << 6)
 
 #endif /* CORTEX_A7_H */

--- a/include/lib/cpus/aarch32/cortex_a72.h
+++ b/include/lib/cpus/aarch32/cortex_a72.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,7 +10,7 @@
 #include <lib/utils_def.h>
 
 /* Cortex-A72 midr for revision 0 */
-#define CORTEX_A72_MIDR 0x410FD080
+#define CORTEX_A72_MIDR		U(0x410FD080)
 
 /*******************************************************************************
  * CPU Extended Control register specific definitions.
@@ -43,12 +43,12 @@
  ******************************************************************************/
 #define CORTEX_A72_L2CTLR				p15, 1, c9, c0, 2
 
-#define CORTEX_A72_L2CTLR_DATA_RAM_LATENCY_SHIFT	0
-#define CORTEX_A72_L2CTLR_TAG_RAM_LATENCY_SHIFT		6
+#define CORTEX_A72_L2CTLR_DATA_RAM_LATENCY_SHIFT	U(0)
+#define CORTEX_A72_L2CTLR_TAG_RAM_LATENCY_SHIFT		U(6)
 
-#define CORTEX_A72_L2_DATA_RAM_LATENCY_3_CYCLES		0x2
-#define CORTEX_A72_L2_TAG_RAM_LATENCY_2_CYCLES		0x1
-#define CORTEX_A72_L2_TAG_RAM_LATENCY_3_CYCLES		0x2
+#define CORTEX_A72_L2_DATA_RAM_LATENCY_3_CYCLES		U(0x2)
+#define CORTEX_A72_L2_TAG_RAM_LATENCY_2_CYCLES		U(0x1)
+#define CORTEX_A72_L2_TAG_RAM_LATENCY_3_CYCLES		U(0x2)
 
 /*******************************************************************************
  * L2 Memory Error Syndrome register specific definitions.

--- a/include/lib/cpus/aarch32/cortex_a9.h
+++ b/include/lib/cpus/aarch32/cortex_a9.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,16 +7,18 @@
 #ifndef CORTEX_A9_H
 #define CORTEX_A9_H
 
+#include <lib/utils_def.h>
+
 /*******************************************************************************
  * Cortex-A9 midr with version/revision set to 0
  ******************************************************************************/
-#define CORTEX_A9_MIDR			0x410FC090
+#define CORTEX_A9_MIDR			U(0x410FC090)
 
 /*******************************************************************************
  * CPU Auxiliary Control register specific definitions.
  ******************************************************************************/
-#define CORTEX_A9_ACTLR_SMP_BIT		(1 << 6)
-#define CORTEX_A9_ACTLR_FLZW_BIT	(1 << 3)
+#define CORTEX_A9_ACTLR_SMP_BIT		(U(1) << 6)
+#define CORTEX_A9_ACTLR_FLZW_BIT	(U(1) << 3)
 
 /*******************************************************************************
  * CPU Power Control Register

--- a/include/lib/cpus/aarch64/aem_generic.h
+++ b/include/lib/cpus/aarch64/aem_generic.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,10 +7,12 @@
 #ifndef AEM_GENERIC_H
 #define AEM_GENERIC_H
 
+#include <lib/utils_def.h>
+
 /* BASE AEM midr for revision 0 */
-#define BASE_AEM_MIDR 0x410FD0F0
+#define BASE_AEM_MIDR		U(0x410FD0F0)
 
 /* Foundation AEM midr for revision 0 */
-#define FOUNDATION_AEM_MIDR  0x410FD000
+#define FOUNDATION_AEM_MIDR	U(0x410FD000)
 
 #endif /* AEM_GENERIC_H */

--- a/include/lib/cpus/aarch64/cortex_a35.h
+++ b/include/lib/cpus/aarch64/cortex_a35.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,14 +7,16 @@
 #ifndef CORTEX_A35_H
 #define CORTEX_A35_H
 
+#include <lib/utils_def.h>
+
 /* Cortex-A35 Main ID register for revision 0 */
-#define CORTEX_A35_MIDR				0x410FD040
+#define CORTEX_A35_MIDR				U(0x410FD040)
 
 /*******************************************************************************
  * CPU Extended Control register specific definitions.
  * CPUECTLR_EL1 is an implementation-specific register.
  ******************************************************************************/
 #define CORTEX_A35_CPUECTLR_EL1			S3_1_C15_C2_1
-#define CORTEX_A35_CPUECTLR_SMPEN_BIT		(1 << 6)
+#define CORTEX_A35_CPUECTLR_SMPEN_BIT		(ULL(1) << 6)
 
 #endif /* CORTEX_A35_H */

--- a/include/lib/cpus/aarch64/cortex_a53.h
+++ b/include/lib/cpus/aarch64/cortex_a53.h
@@ -26,13 +26,13 @@
  ******************************************************************************/
 #define CORTEX_A53_ECTLR_EL1				S3_1_C15_C2_1
 
-#define CORTEX_A53_ECTLR_SMP_BIT			(U(1) << 6)
+#define CORTEX_A53_ECTLR_SMP_BIT			(ULL(1) << 6)
 
 #define CORTEX_A53_ECTLR_CPU_RET_CTRL_SHIFT		U(0)
-#define CORTEX_A53_ECTLR_CPU_RET_CTRL_MASK		(U(0x7) << CORTEX_A53_ECTLR_CPU_RET_CTRL_SHIFT)
+#define CORTEX_A53_ECTLR_CPU_RET_CTRL_MASK		(ULL(0x7) << CORTEX_A53_ECTLR_CPU_RET_CTRL_SHIFT)
 
 #define CORTEX_A53_ECTLR_FPU_RET_CTRL_SHIFT		U(3)
-#define CORTEX_A53_ECTLR_FPU_RET_CTRL_MASK		(U(0x7) << CORTEX_A53_ECTLR_FPU_RET_CTRL_SHIFT)
+#define CORTEX_A53_ECTLR_FPU_RET_CTRL_MASK		(ULL(0x7) << CORTEX_A53_ECTLR_FPU_RET_CTRL_SHIFT)
 
 /*******************************************************************************
  * CPU Memory Error Syndrome register specific definitions.

--- a/include/lib/cpus/aarch64/cortex_a53.h
+++ b/include/lib/cpus/aarch64/cortex_a53.h
@@ -1,11 +1,13 @@
 /*
- * Copyright (c) 2014-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CORTEX_A53_H
 #define CORTEX_A53_H
+
+#include <lib/utils_def.h>
 
 /* Cortex-A53 midr for revision 0 */
 #define CORTEX_A53_MIDR			U(0x410FD030)
@@ -43,13 +45,13 @@
 #define CORTEX_A53_CPUACTLR_EL1				S3_1_C15_C2_0
 
 #define CORTEX_A53_CPUACTLR_EL1_ENDCCASCI_SHIFT		U(44)
-#define CORTEX_A53_CPUACTLR_EL1_ENDCCASCI		(U(1) << CORTEX_A53_CPUACTLR_EL1_ENDCCASCI_SHIFT)
+#define CORTEX_A53_CPUACTLR_EL1_ENDCCASCI		(ULL(1) << CORTEX_A53_CPUACTLR_EL1_ENDCCASCI_SHIFT)
 #define CORTEX_A53_CPUACTLR_EL1_RADIS_SHIFT		U(27)
-#define CORTEX_A53_CPUACTLR_EL1_RADIS			(U(3) << CORTEX_A53_CPUACTLR_EL1_RADIS_SHIFT)
+#define CORTEX_A53_CPUACTLR_EL1_RADIS			(ULL(3) << CORTEX_A53_CPUACTLR_EL1_RADIS_SHIFT)
 #define CORTEX_A53_CPUACTLR_EL1_L1RADIS_SHIFT		U(25)
-#define CORTEX_A53_CPUACTLR_EL1_L1RADIS			(U(3) << CORTEX_A53_CPUACTLR_EL1_L1RADIS_SHIFT)
+#define CORTEX_A53_CPUACTLR_EL1_L1RADIS			(ULL(3) << CORTEX_A53_CPUACTLR_EL1_L1RADIS_SHIFT)
 #define CORTEX_A53_CPUACTLR_EL1_DTAH_SHIFT		U(24)
-#define CORTEX_A53_CPUACTLR_EL1_DTAH			(U(1) << CORTEX_A53_CPUACTLR_EL1_DTAH_SHIFT)
+#define CORTEX_A53_CPUACTLR_EL1_DTAH			(ULL(1) << CORTEX_A53_CPUACTLR_EL1_DTAH_SHIFT)
 
 /*******************************************************************************
  * L2 Auxiliary Control register specific definitions.

--- a/include/lib/cpus/aarch64/cortex_a55.h
+++ b/include/lib/cpus/aarch64/cortex_a55.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,16 +7,18 @@
 #ifndef CORTEX_A55_H
 #define CORTEX_A55_H
 
+#include <lib/utils_def.h>
+
 /* Cortex-A55 MIDR for revision 0 */
-#define CORTEX_A55_MIDR		0x410fd050
+#define CORTEX_A55_MIDR			U(0x410fd050)
 
 /*******************************************************************************
  * CPU Extended Control register specific definitions.
  ******************************************************************************/
-#define CORTEX_A55_CPUPWRCTLR_EL1		S3_0_C15_C2_7
+#define CORTEX_A55_CPUPWRCTLR_EL1	S3_0_C15_C2_7
 #define CORTEX_A55_CPUECTLR_EL1		S3_0_C15_C1_4
 
 /* Definitions of register field mask in CORTEX_A55_CPUPWRCTLR_EL1 */
-#define CORTEX_A55_CORE_PWRDN_EN_MASK	0x1
+#define CORTEX_A55_CORE_PWRDN_EN_MASK	U(0x1)
 
 #endif /* CORTEX_A55_H */

--- a/include/lib/cpus/aarch64/cortex_a57.h
+++ b/include/lib/cpus/aarch64/cortex_a57.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -26,10 +26,10 @@
  ******************************************************************************/
 #define CORTEX_A57_ECTLR_EL1			S3_1_C15_C2_1
 
-#define CORTEX_A57_ECTLR_SMP_BIT		(U(1) << 6)
-#define CORTEX_A57_ECTLR_DIS_TWD_ACC_PFTCH_BIT	(U(1) << 38)
-#define CORTEX_A57_ECTLR_L2_IPFTCH_DIST_MASK	(U(0x3) << 35)
-#define CORTEX_A57_ECTLR_L2_DPFTCH_DIST_MASK	(U(0x3) << 32)
+#define CORTEX_A57_ECTLR_SMP_BIT		(ULL(1) << 6)
+#define CORTEX_A57_ECTLR_DIS_TWD_ACC_PFTCH_BIT	(ULL(1) << 38)
+#define CORTEX_A57_ECTLR_L2_IPFTCH_DIST_MASK	(ULL(0x3) << 35)
+#define CORTEX_A57_ECTLR_L2_DPFTCH_DIST_MASK	(ULL(0x3) << 32)
 
 #define CORTEX_A57_ECTLR_CPU_RET_CTRL_SHIFT	U(0)
 #define CORTEX_A57_ECTLR_CPU_RET_CTRL_MASK	(U(0x7) << CORTEX_A57_ECTLR_CPU_RET_CTRL_SHIFT)

--- a/include/lib/cpus/aarch64/cortex_a57.h
+++ b/include/lib/cpus/aarch64/cortex_a57.h
@@ -32,7 +32,7 @@
 #define CORTEX_A57_ECTLR_L2_DPFTCH_DIST_MASK	(ULL(0x3) << 32)
 
 #define CORTEX_A57_ECTLR_CPU_RET_CTRL_SHIFT	U(0)
-#define CORTEX_A57_ECTLR_CPU_RET_CTRL_MASK	(U(0x7) << CORTEX_A57_ECTLR_CPU_RET_CTRL_SHIFT)
+#define CORTEX_A57_ECTLR_CPU_RET_CTRL_MASK	(ULL(0x7) << CORTEX_A57_ECTLR_CPU_RET_CTRL_SHIFT)
 
 /*******************************************************************************
  * CPU Memory Error Syndrome register specific definitions.

--- a/include/lib/cpus/aarch64/cortex_a72.h
+++ b/include/lib/cpus/aarch64/cortex_a72.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,7 +10,7 @@
 #include <lib/utils_def.h>
 
 /* Cortex-A72 midr for revision 0 */
-#define CORTEX_A72_MIDR 				0x410FD080
+#define CORTEX_A72_MIDR 				U(0x410FD080)
 
 /*******************************************************************************
  * CPU Extended Control register specific definitions.
@@ -50,12 +50,12 @@
  ******************************************************************************/
 #define CORTEX_A72_L2CTLR_EL1				S3_1_C11_C0_2
 
-#define CORTEX_A72_L2CTLR_DATA_RAM_LATENCY_SHIFT	0
-#define CORTEX_A72_L2CTLR_TAG_RAM_LATENCY_SHIFT		6
+#define CORTEX_A72_L2CTLR_DATA_RAM_LATENCY_SHIFT	U(0)
+#define CORTEX_A72_L2CTLR_TAG_RAM_LATENCY_SHIFT		U(6)
 
-#define CORTEX_A72_L2_DATA_RAM_LATENCY_3_CYCLES		0x2
-#define CORTEX_A72_L2_TAG_RAM_LATENCY_2_CYCLES		0x1
-#define CORTEX_A72_L2_TAG_RAM_LATENCY_3_CYCLES		0x2
+#define CORTEX_A72_L2_DATA_RAM_LATENCY_3_CYCLES		U(0x2)
+#define CORTEX_A72_L2_TAG_RAM_LATENCY_2_CYCLES		U(0x1)
+#define CORTEX_A72_L2_TAG_RAM_LATENCY_3_CYCLES		U(0x2)
 
 /*******************************************************************************
  * L2 Memory Error Syndrome register specific definitions.

--- a/include/lib/cpus/aarch64/cortex_a73.h
+++ b/include/lib/cpus/aarch64/cortex_a73.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,15 +7,17 @@
 #ifndef CORTEX_A73_H
 #define CORTEX_A73_H
 
+#include <lib/utils_def.h>
+
 /* Cortex-A73 midr for revision 0 */
-#define CORTEX_A73_MIDR	0x410FD090
+#define CORTEX_A73_MIDR			U(0x410FD090)
 
 /*******************************************************************************
  * CPU Extended Control register specific definitions.
  ******************************************************************************/
 #define CORTEX_A73_CPUECTLR_EL1		S3_1_C15_C2_1	/* Instruction def. */
 
-#define CORTEX_A73_CPUECTLR_SMP_BIT	(1 << 6)
+#define CORTEX_A73_CPUECTLR_SMP_BIT	(ULL(1) << 6)
 
 /*******************************************************************************
  * L2 Memory Error Syndrome register specific definitions.
@@ -27,6 +29,6 @@
  ******************************************************************************/
 #define CORTEX_A73_IMP_DEF_REG1		S3_0_C15_C0_0
 
-#define CORTEX_A73_IMP_DEF_REG1_DISABLE_LOAD_PASS_STORE	(1 << 3)
+#define CORTEX_A73_IMP_DEF_REG1_DISABLE_LOAD_PASS_STORE	(ULL(1) << 3)
 
 #endif /* CORTEX_A73_H */

--- a/include/lib/cpus/aarch64/cortex_a75.h
+++ b/include/lib/cpus/aarch64/cortex_a75.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -23,7 +23,7 @@
  ******************************************************************************/
 #define CORTEX_A75_CPUACTLR_EL1		S3_0_C15_C1_0
 
-#define CORTEX_A75_CPUACTLR_EL1_DISABLE_LOAD_PASS_STORE	(1 << 35)
+#define CORTEX_A75_CPUACTLR_EL1_DISABLE_LOAD_PASS_STORE	(ULL(1) << 35)
 
 /* Definitions of register field mask in CORTEX_A75_CPUPWRCTLR_EL1 */
 #define CORTEX_A75_CORE_PWRDN_EN_MASK	U(0x1)

--- a/include/lib/cpus/aarch64/cortex_a75.h
+++ b/include/lib/cpus/aarch64/cortex_a75.h
@@ -28,7 +28,7 @@
 /* Definitions of register field mask in CORTEX_A75_CPUPWRCTLR_EL1 */
 #define CORTEX_A75_CORE_PWRDN_EN_MASK	U(0x1)
 
-#define CORTEX_A75_ACTLR_AMEN_BIT	(U(1) << 4)
+#define CORTEX_A75_ACTLR_AMEN_BIT	(ULL(1) << 4)
 
 /*
  * The Cortex-A75 core implements five counters, 0-4. Events 0, 1, 2, are

--- a/include/lib/cpus/aarch64/cortex_a76.h
+++ b/include/lib/cpus/aarch64/cortex_a76.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,23 +7,25 @@
 #ifndef CORTEX_A76_H
 #define CORTEX_A76_H
 
+#include <lib/utils_def.h>
+
 /* Cortex-A76 MIDR for revision 0 */
-#define CORTEX_A76_MIDR		0x410fd0b0
+#define CORTEX_A76_MIDR		U(0x410fd0b0)
 
 /*******************************************************************************
  * CPU Extended Control register specific definitions.
  ******************************************************************************/
 #define CORTEX_A76_CPUPWRCTLR_EL1	S3_0_C15_C2_7
-#define CORTEX_A76_CPUECTLR_EL1	S3_0_C15_C1_4
+#define CORTEX_A76_CPUECTLR_EL1		S3_0_C15_C1_4
 
 /*******************************************************************************
  * CPU Auxiliary Control register specific definitions.
  ******************************************************************************/
 #define CORTEX_A76_CPUACTLR2_EL1	S3_0_C15_C1_1
 
-#define CORTEX_A76_CPUACTLR2_EL1_DISABLE_LOAD_PASS_STORE	(1 << 16)
+#define CORTEX_A76_CPUACTLR2_EL1_DISABLE_LOAD_PASS_STORE	(ULL(1) << 16)
 
 /* Definitions of register field mask in CORTEX_A76_CPUPWRCTLR_EL1 */
-#define CORTEX_A76_CORE_PWRDN_EN_MASK	0x1
+#define CORTEX_A76_CORE_PWRDN_EN_MASK	U(0x1)
 
 #endif /* CORTEX_A76_H */

--- a/include/lib/cpus/aarch64/cortex_deimos.h
+++ b/include/lib/cpus/aarch64/cortex_deimos.h
@@ -1,11 +1,13 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CORTEX_DEIMOS_H
 #define CORTEX_DEIMOS_H
+
+#include <lib/utils_def.h>
 
 #define CORTEX_DEIMOS_MIDR					U(0x410FD0D0)
 

--- a/include/lib/cpus/aarch64/cortex_helios.h
+++ b/include/lib/cpus/aarch64/cortex_helios.h
@@ -1,11 +1,13 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #ifndef CORTEX_HELIOS_H
 #define CORTEX_HELIOS_H
+
+#include <lib/utils_def.h>
 
 #define CORTEX_HELIOS_MIDR		U(0x410FD060)
 

--- a/include/lib/cpus/aarch64/dsu_def.h
+++ b/include/lib/cpus/aarch64/dsu_def.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -28,6 +28,6 @@
 /********************************************************************
  * Masks applied for DSU errata workarounds			    *
  ********************************************************************/
-#define DSU_ERRATA_936184_MASK	(ULL(0x3) << 15)
+#define DSU_ERRATA_936184_MASK	(U(0x3) << 15)
 
 #endif /* DSU_DEF_H */


### PR DESCRIPTION
There were several CPU definitions with incorrect widths. This patch sets the width of all definitions to the correct ones according to the TRMs of the CPUs.

There are some values that should be 64-bit immediates but that resolve to 0 because the type of the value is 32-bit wide. This patch casts the expressions to 64-bit before the shift so that the definition has the correct value.

The definitions are only used in assembly so far, so the code is not actually affected by this bug. The assembler treats all values as 64-bit values, so there are no overflows.