### PR TITLE
gic: make sure ProcessorSleep bit clear successfully

### DIFF
--- a/plat/imx/common/plat_imx8_gic.c
+++ b/plat/imx/common/plat_imx8_gic.c
@@ -9,6 +9,8 @@
 #include <common/bl_common.h>
 #include <common/interrupt_props.h>
 #include <drivers/arm/gicv3.h>
+#include <drivers/arm/arm_gicv3_common.h>
+#include <lib/mmio.h>
 #include <lib/utils.h>
 #include <plat/common/platform.h>
 
@@ -52,8 +54,27 @@ void plat_gic_driver_init(void)
 #endif
 }
 
+static __inline void plat_gicr_exit_sleep(void)
+{
+	unsigned int val = mmio_read_32(PLAT_GICR_BASE + GICR_WAKER);
+
+	/*
+	 * ProcessorSleep bit can ONLY be set to zero when
+	 * Quiescent bit and Sleep bit are both zero, so
+	 * need to make sure Quiescent bit and Sleep bit
+	 * are zero before clearing ProcessorSleep bit.
+	 */
+	if (val & WAKER_QSC_BIT) {
+		mmio_write_32(PLAT_GICR_BASE + GICR_WAKER, val & ~WAKER_SL_BIT);
+		/* Wait till the WAKER_QSC_BIT changes to 0 */
+		while ((mmio_read_32(PLAT_GICR_BASE + GICR_WAKER) & WAKER_QSC_BIT) != 0U)
+			;
+	}
+}
+
 void plat_gic_init(void)
 {
+	plat_gicr_exit_sleep();
 	gicv3_distif_init();
 	gicv3_rdistif_init(plat_my_core_pos());
 	gicv3_cpuif_enable(plat_my_core_pos());


### PR DESCRIPTION
GICR_WAKER.ProcessorSleep can only be set to zero when:
— GICR_WAKER.Sleep bit[0] == 0.
— GICR_WAKER.Quiescent bit[31] == 0.

On some platforms, when system reboot with GIC in sleep
mode but with power ON, such as on NXP's i.MX8QM, Linux
kernel enters suspend but could be requested to reboot,
and GIC is in sleep mode and it is inside a power domain
which is ON in this scenario, when CPU reset, the GIC
driver trys to set CORE's redistributor interface to awake,
with GICR_WAKER.Sleep bit[0] and GICR_WAKER.Quiescent bit[31]
both set, the ProcessorSleep bit[1] will never be clear
and cause system hang.

This patch makes sure GICR_WAKER.Sleep bit[0] and
GICR_WAKER.Quiescent bit[31] are both zeor before clearing
ProcessorSleep bit[1].

Signed-off-by: Anson Huang <Anson.Huang@nxp.com>