### PR TITLE
imx: warp7: Migrate to MULTI_CONSOLE_API

### DIFF
--- a/drivers/imx/uart/imx_uart.c
+++ b/drivers/imx/uart/imx_uart.c
@@ -62,8 +62,8 @@ static uint32_t read_reg(uintptr_t base, uint32_t offset)
 	return mmio_read_32(base + offset);
 }
 
-int console_core_init(uintptr_t base_addr, unsigned int uart_clk,
-		      unsigned int baud_rate)
+int console_imx_uart_core_init(uintptr_t base_addr, unsigned int uart_clk,
+			       unsigned int baud_rate)
 {
 	uint32_t val;
 	uint8_t clk_idx = 1;
@@ -129,12 +129,12 @@ int console_core_init(uintptr_t base_addr, unsigned int uart_clk,
  * Clobber list : r2
  * --------------------------------------------------------
  */
-int console_core_putc(int c, uintptr_t base_addr)
+int console_imx_uart_core_putc(int c, uintptr_t base_addr)
 {
 	uint32_t val;
 
 	if (c == '\n')
-		console_core_putc('\r', base_addr);
+		console_imx_uart_core_putc('\r', base_addr);
 
 	/* Write data */
 	write_reg(base_addr, IMX_UART_TXD_OFFSET, c);
@@ -155,7 +155,7 @@ int console_core_putc(int c, uintptr_t base_addr)
  * Clobber list : r0, r1
  * ---------------------------------------------
  */
-int console_core_getc(uintptr_t base_addr)
+int console_imx_uart_core_getc(uintptr_t base_addr)
 {
 	uint32_t val;
 
@@ -175,7 +175,7 @@ int console_core_getc(uintptr_t base_addr)
  * Clobber list : r0, r1
  * ---------------------------------------------
  */
-int console_core_flush(uintptr_t base_addr)
+int console_imx_uart_core_flush(uintptr_t base_addr)
 {
 	return 0;
 }

--- a/drivers/imx/uart/imx_uart.h
+++ b/drivers/imx/uart/imx_uart.h
@@ -6,6 +6,8 @@
 #ifndef IMX_UART_H
 #define IMX_UART_H
 
+#include <drivers/console.h>
+
 #define IMX_UART_RXD_OFFSET	0x00
 #define IMX_UART_RXD_CHARRDY	BIT(15)
 #define IMX_UART_RXD_ERR	BIT(14)
@@ -149,5 +151,18 @@
 #define IMX_UART_TS_TXFULL	BIT(4)
 #define IMX_UART_TS_RXFULL	BIT(3)
 #define IMX_UART_TS_SOFTRST	BIT(0)
+
+#ifndef __ASSEMBLY__
+
+typedef struct {
+	console_t console;
+	uintptr_t base;
+} console_imx_uart_t;
+
+int console_imx_uart_register(uintptr_t baseaddr,
+			      uint32_t clock,
+			      uint32_t baud,
+			      console_imx_uart_t *console);
+#endif /*__ASSEMBLY__*/
 
 #endif /* IMX_UART_H */

--- a/plat/imx/common/aarch32/imx_uart_console.S
+++ b/plat/imx/common/aarch32/imx_uart_console.S
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <arch.h>
+#include <asm_macros.S>
+#define USE_FINISH_CONSOLE_REG_2
+#include <console_macros.S>
+#include <assert_macros.S>
+#include "imx_uart.h"
+
+	.globl	console_imx_uart_register
+	.globl	console_imx_uart_putc
+	.globl	console_imx_uart_getc
+	.globl	console_imx_uart_flush
+
+func console_imx_uart_register
+	push	{r4, lr}
+	mov	r4, r3
+	cmp	r4, #0
+	beq	register_fail
+	str	r0, [r4, #CONSOLE_T_DRVDATA]
+
+	bl	console_imx_uart_core_init
+	cmp	r0, #0
+	bne	register_fail
+
+	mov	r0, r4
+	pop	{r4, lr}
+	finish_console_register imx_uart putc=1, getc=1, flush=1
+
+register_fail:
+	pop	{r4, pc}
+endfunc console_imx_uart_register
+
+func console_imx_uart_putc
+	ldr	r1, [r1, #CONSOLE_T_DRVDATA]
+	b console_imx_uart_core_putc
+endfunc console_imx_uart_putc
+
+func console_imx_uart_getc
+	ldr	r0, [r0, #CONSOLE_T_DRVDATA]
+	b console_imx_uart_core_getc
+endfunc console_imx_uart_getc
+
+func console_imx_uart_flush
+	ldr	r0, [r0, #CONSOLE_T_DRVDATA]
+	b console_imx_uart_core_flush
+endfunc console_imx_uart_flush

--- a/plat/imx/imx7/warp7/platform.mk
+++ b/plat/imx/imx7/warp7/platform.mk
@@ -59,6 +59,7 @@ BL2_SOURCES		+=	common/desc_image_load.c			\
 				plat/imx/imx7/warp7/warp7_bl2_mem_params_desc.c \
 				plat/imx/imx7/warp7/warp7_io_storage.c		\
 				plat/imx/imx7/warp7/warp7_image_load.c		\
+				plat/imx/common/aarch32/imx_uart_console.S	\
 				${XLAT_TABLES_LIB_SRCS}
 
 ifneq (${TRUSTED_BOARD_BOOT},0)
@@ -117,6 +118,9 @@ SEPARATE_CODE_AND_RODATA	:= 1
 
 # Use Coherent memory
 USE_COHERENT_MEM		:= 1
+
+# Use multi console API
+MULTI_CONSOLE_API               := 1
 
 # PLAT_WARP7_UART
 PLAT_WARP7_UART			:=1

--- a/plat/imx/imx7/warp7/warp7_bl2_el3_setup.c
+++ b/plat/imx/imx7/warp7/warp7_bl2_el3_setup.c
@@ -258,6 +258,8 @@ void bl2_el3_early_platform_setup(u_register_t arg1, u_register_t arg2,
 	uint32_t uart1_en_bits = (uint32_t)UART1_CLK_SELECT;
 	uint32_t uart6_en_bits = (uint32_t)UART6_CLK_SELECT;
 	uint32_t usdhc_clock_sel = PLAT_WARP7_SD - 1;
+	static console_imx_uart_t console;
+	int console_scope = CONSOLE_FLAG_BOOT | CONSOLE_FLAG_RUNTIME;
 
 	/* Initialize the AIPS */
 	imx_aips_init();
@@ -278,8 +280,12 @@ void bl2_el3_early_platform_setup(u_register_t arg1, u_register_t arg2,
 	warp7_setup_pinmux();
 
 	/* Init UART, storage and friends */
-	console_init(PLAT_WARP7_BOOT_UART_BASE, PLAT_WARP7_BOOT_UART_CLK_IN_HZ,
-		     PLAT_WARP7_CONSOLE_BAUDRATE);
+	console_imx_uart_register(PLAT_WARP7_BOOT_UART_BASE,
+				  PLAT_WARP7_BOOT_UART_CLK_IN_HZ,
+				  PLAT_WARP7_CONSOLE_BAUDRATE,
+				  &console);
+	console_set_scope(&console.console, console_scope);
+
 	warp7_usdhc_setup();
 
 	/* Open handles to persistent storage */


### PR DESCRIPTION
This commit migrates to MULTI_CONSOLE_API for IMX Warp7 board.
We also rename the functions in imx_uart driver to more specific one.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>