### PR TITLE
Sanitize SPD include paths

### DIFF
--- a/services/spd/tlkd/tlkd.mk
+++ b/services/spd/tlkd/tlkd.mk
@@ -4,7 +4,9 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #
 
+ifeq (${ERROR_DEPRECATED},0)
 SPD_INCLUDES		:=	-Iinclude/bl32/payloads
+endif
 
 SPD_SOURCES		:=	services/spd/tlkd/tlkd_common.c		\
 				services/spd/tlkd/tlkd_helpers.S	\

--- a/services/spd/tlkd/tlkd_main.c
+++ b/services/spd/tlkd/tlkd_main.c
@@ -13,12 +13,13 @@
  * handle the request locally or delegate it to the Secure Payload. It is also
  * responsible for initialising and maintaining communication with the SP.
  ******************************************************************************/
-#include <arch_helpers.h>
 #include <assert.h>
 #include <errno.h>
 #include <stddef.h>
 
+#include <arch_helpers.h>
 #include <bl31/bl31.h>
+#include <bl32/payloads/tlk.h>
 #include <common/bl_common.h>
 #include <common/debug.h>
 #include <common/runtime_svc.h>
@@ -26,7 +27,6 @@
 #include <plat/common/platform.h>
 #include <tools_share/uuid.h>
 
-#include <tlk.h>
 #include "tlkd_private.h"
 
 extern const spd_pm_ops_t tlkd_pm_ops;

--- a/services/spd/tlkd/tlkd_pm.c
+++ b/services/spd/tlkd/tlkd_pm.c
@@ -7,11 +7,11 @@
 #include <assert.h>
 
 #include <arch_helpers.h>
+#include <bl32/payloads/tlk.h>
 #include <common/bl_common.h>
 #include <common/debug.h>
 #include <lib/el3_runtime/context_mgmt.h>
 #include <lib/psci/psci.h>
-#include <tlk.h>
 
 #include "tlkd_private.h"
 

--- a/services/spd/tspd/tspd.mk
+++ b/services/spd/tspd/tspd.mk
@@ -5,7 +5,10 @@
 #
 
 TSPD_DIR		:=	services/spd/tspd
+
+ifeq (${ERROR_DEPRECATED},0)
 SPD_INCLUDES		:=	-Iinclude/bl32/tsp
+endif
 
 SPD_SOURCES		:=	services/spd/tspd/tspd_common.c		\
 				services/spd/tspd/tspd_helpers.S	\


### PR DESCRIPTION
Commit 09d40e0e0828 ("Sanitise includes across codebase") modified the include paths of the TSP includes but it didn't remove the include path from the makefile or did the same for TLK. This patch does the remaining work.