### PR TITLE
doc: Fix broken external links

### DIFF
--- a/docs/change-log.rst
+++ b/docs/change-log.rst
@@ -969,7 +969,7 @@ New features
    fixed sample points at key places in the code.
 
 -  To support the QEMU platform port, imported libfdt v1.4.1 from
-   https://git.kernel.org/cgit/utils/dtc/dtc.git
+   https://git.kernel.org/pub/scm/utils/dtc/dtc.git
 
 -  Updated PSCI support:
 

--- a/docs/cpu-specific-build-macros.rst
+++ b/docs/cpu-specific-build-macros.rst
@@ -189,8 +189,8 @@ architecture that can be enabled by the platform as desired.
 
 .. _CVE-2017-5715: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5715
 .. _CVE-2018-3639: http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3639
-.. _Cortex-A53 MPCore Software Developers Errata Notice: http://infocenter.arm.com/help/topic/com.arm.doc.epm048406/Cortex_A53_MPCore_Software_Developers_Errata_Notice.pdf
-.. _Cortex-A57 MPCore Software Developers Errata Notice: http://infocenter.arm.com/help/topic/com.arm.doc.epm049219/cortex_a57_mpcore_software_developers_errata_notice.pdf
+.. _Cortex-A53 MPCore Software Developers Errata Notice: http://infocenter.arm.com/help/topic/com.arm.doc.epm048406/index.html
+.. _Cortex-A57 MPCore Software Developers Errata Notice: http://infocenter.arm.com/help/topic/com.arm.doc.epm049219/index.html
 .. _Cortex-A72 MPCore Software Developers Errata Notice: http://infocenter.arm.com/help/topic/com.arm.doc.epm012079/index.html
 .. _Firmware Design guide: firmware-design.rst
 .. _Cortex-A57 Software Optimization Guide: http://infocenter.arm.com/help/topic/com.arm.doc.uan0015b/Cortex_A57_Software_Optimization_Guide_external.pdf

--- a/docs/plat/hikey.rst
+++ b/docs/plat/hikey.rst
@@ -149,7 +149,7 @@ Flash images in recovery mode
 
        $sudo python hisi-idt.py -d /dev/ttyUSB1 --img1 recovery.bin
 
--  Update images. All aosp or debian images could be fetched from `link <https://builds.96boards.org/>`__.
+-  Update images. All aosp or debian images could be fetched from `link <http://releases.linaro.org/96boards/>`__.
 
    .. code:: shell
 
@@ -168,4 +168,4 @@ Boot UEFI in normal mode
 
 -  Reference `link <https://github.com/96boards-hikey/tools-images-hikey960/blob/master/build-from-source/README-ATF-UEFI-build-from-source.md>`__
 
-.. _link: https://github.com/96boards/documentation/blob/master/ConsumerEdition/HiKey/Quickstart/README.md
+.. _link: https://www.96boards.org/documentation/consumer/hikey/

--- a/docs/plat/hikey960.rst
+++ b/docs/plat/hikey960.rst
@@ -189,4 +189,4 @@ Boot UEFI in normal mode
 
 -  Reference `link <https://github.com/96boards-hikey/tools-images-hikey960/blob/master/build-from-source/README-ATF-UEFI-build-from-source.md>`__
 
-.. _link: http://www.96boards.org/documentation/ConsumerEdition/HiKey960/README.md
+.. _link: https://www.96boards.org/documentation/consumer/hikey/hikey960

--- a/docs/plat/meson-gxbb.rst
+++ b/docs/plat/meson-gxbb.rst
@@ -23,4 +23,4 @@ This port has been tested in a ODROID-C2. After building it, follow the
 instructions in the `U-Boot repository`_, replacing the mentioned **bl31.bin**
 by the one built from this port.
 
-.. _U-Boot repository: https://github.com/u-boot/u-boot/blob/master/board/amlogic/odroid-c2/README
+.. _U-Boot repository: https://github.com/u-boot/u-boot/blob/master/board/amlogic/odroid-c2/README.odroid-c2

--- a/docs/platform-compatibility-policy.rst
+++ b/docs/platform-compatibility-policy.rst
@@ -41,5 +41,5 @@ migrate before the removal of the deprecated interface.
 *Copyright (c) 2018, Arm Limited and Contributors. All rights reserved.*
 
 .. _Porting Guide: ./porting-guide.rst
-.. _Release information: https://github.com/ARM-software/arm-trusted-firmware/wiki/TF-A-Release-information#2removal-of-deprecated-interfaces
+.. _Release information: https://github.com/ARM-software/arm-trusted-firmware/wiki/TF-A-Release-information#removal-of-deprecated-interfaces
 .. _tf-issue: https://github.com/ARM-software/tf-issues/issues

--- a/docs/porting-guide.rst
+++ b/docs/porting-guide.rst
@@ -2808,5 +2808,5 @@ amount of open resources per driver.
 .. _IMF Design Guide: interrupt-framework-design.rst
 .. _Arm Generic Interrupt Controller version 2.0 (GICv2): http://infocenter.arm.com/help/topic/com.arm.doc.ihi0048b/index.html
 .. _3.0 (GICv3): http://infocenter.arm.com/help/topic/com.arm.doc.ihi0069b/index.html
-.. _FreeBSD: http://www.freebsd.org
+.. _FreeBSD: https://www.freebsd.org
 .. _SCC: http://www.simple-cc.org/

--- a/docs/trusted-board-boot.rst
+++ b/docs/trusted-board-boot.rst
@@ -233,6 +233,6 @@ for building and using the tool can be found in the `User Guide`_.
 *Copyright (c) 2015-2018, Arm Limited and Contributors. All rights reserved.*
 
 .. _Firmware Update: firmware-update.rst
-.. _X.509 v3: http://www.ietf.org/rfc/rfc5280.txt
+.. _X.509 v3: https://tools.ietf.org/rfc/rfc5280.txt
 .. _User Guide: user-guide.rst
 .. _Auth Framework: auth-framework.rst

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -2060,11 +2060,11 @@ wakeup interrupt from RTC.
 
 .. _Linaro: `Linaro Release Notes`_
 .. _Linaro Release: `Linaro Release Notes`_
-.. _Linaro Release Notes: https://community.arm.com/dev-platforms/w/docs/226/old-linaro-release-notes
-.. _Linaro instructions: https://community.arm.com/dev-platforms/w/docs/304/linaro-software-deliverables
+.. _Linaro Release Notes: https://community.arm.com/dev-platforms/w/docs/226/old-release-notes
+.. _Linaro instructions: https://community.arm.com/dev-platforms/w/docs/304/arm-reference-platforms-deliverables
 .. _Instructions for using Linaro's deliverables on Juno: https://community.arm.com/dev-platforms/w/docs/303/juno
 .. _Arm Platforms Portal: https://community.arm.com/dev-platforms/
-.. _Development Studio 5 (DS-5): http://www.arm.com/products/tools/software-tools/ds-5/index.php
+.. _Development Studio 5 (DS-5): https://developer.arm.com/products/software-development-tools/ds-5-development-studio
 .. _`Linux Coding Style`: https://www.kernel.org/doc/html/latest/process/coding-style.html
 .. _Linux master tree: https://github.com/torvalds/linux/tree/master/
 .. _Dia: https://wiki.gnome.org/Apps/Dia/Download


### PR DESCRIPTION
Using Sphinx linkcheck on the TF-A docs revealed some broken
or permanently-redirected links. These have been updated where
possible.

Change-Id: Ie1fead47972ede3331973759b50ee466264bd2ee
Signed-off-by: Paul Beesley <paul.beesley@arm.com>