### PR TITLE
SPM: Remove unnecessary register save

### DIFF
--- a/services/std_svc/spm/sprt.c
+++ b/services/std_svc/spm/sprt.c
@@ -178,14 +178,6 @@ static uintptr_t sprt_smc_handler(uint32_t smc_fid, u_register_t x1,
 		SMC_RET1(handle, SPRT_VERSION_COMPILED);
 
 	case SPRT_PUT_RESPONSE_AARCH64:
-		/*
-		 * Registers x1-x3 aren't saved by default to the context,
-		 * but they are needed after spm_sp_synchronous_exit() because
-		 * they hold return values.
-		 */
-		SMC_SET_GP(handle, CTX_GPREG_X1, x1);
-		SMC_SET_GP(handle, CTX_GPREG_X2, x2);
-		SMC_SET_GP(handle, CTX_GPREG_X3, x3);
 		spm_sp_synchronous_exit(SPRT_PUT_RESPONSE_AARCH64);
 
 	case SPRT_YIELD_AARCH64:


### PR DESCRIPTION
Since commit 01fc1c24b9a0 ("BL31: Use helper function to save registers in SMC handler") all the general-purpose registers are saved when entering EL3. It isn't needed to save them here.