### PR TITLE
fvp: trusty: Move dynamic xlat enable to platform

### DIFF
--- a/plat/arm/board/fvp/platform.mk
+++ b/plat/arm/board/fvp/platform.mk
@@ -236,7 +236,7 @@ ifeq (${ARCH},aarch32)
     ifeq (${RESET_TO_SP_MIN},1)
         BL32_CFLAGS	+=	-DPLAT_XLAT_TABLES_DYNAMIC=1
     endif
-else
+else # if AArch64
     ifeq (${RESET_TO_BL31},1)
         BL31_CFLAGS	+=	-DPLAT_XLAT_TABLES_DYNAMIC=1
     endif
@@ -244,6 +244,9 @@ else
         ifeq (${SPM_MM},0)
             BL31_CFLAGS	+=	-DPLAT_XLAT_TABLES_DYNAMIC=1
         endif
+    endif
+    ifeq (${SPD},trusty)
+        BL31_CFLAGS	+=	-DPLAT_XLAT_TABLES_DYNAMIC=1
     endif
 endif
 

--- a/services/spd/trusty/trusty.mk
+++ b/services/spd/trusty/trusty.mk
@@ -13,8 +13,6 @@ ifeq (${TRUSTY_SPD_WITH_GENERIC_SERVICES},1)
 SPD_SOURCES		+=	services/spd/trusty/generic-arm64-smcall.c
 endif
 
-BL31_CFLAGS	+=		-DPLAT_XLAT_TABLES_DYNAMIC=1
-
 NEED_BL32		:=	yes
 
 CTX_INCLUDE_FPREGS	:=	1


### PR DESCRIPTION
Rather than letting the Trusty makefile set the option to enable dynamic translation tables, make platforms do it themselves.

This also allows platforms to replace the implementation of the translation tables library as long as they use the same function prototypes.