### PR TITLE
Update macro to check need for CVE-2017-5715 mitigation

### DIFF
--- a/include/lib/cpus/aarch64/cpu_macros.S
+++ b/include/lib/cpus/aarch64/cpu_macros.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,6 +7,7 @@
 #define CPU_MACROS_S
 
 #include <arch.h>
+#include <assert_macros.S>
 #include <lib/cpus/errata_report.h>
 
 #define CPU_IMPL_PN_MASK	(MIDR_IMPL_MASK << MIDR_IMPL_SHIFT) | \
@@ -263,11 +264,22 @@
 	mrs	\_reg, id_aa64pfr0_el1
 	ubfx	\_reg, \_reg, #ID_AA64PFR0_CSV2_SHIFT, #ID_AA64PFR0_CSV2_LENGTH
 	/*
-	 * If the field equals to 1 then branch targets trained in one
-	 * context cannot affect speculative execution in a different context.
+	 * If the field equals 1, branch targets trained in one context cannot
+	 * affect speculative execution in a different context.
+	 *
+	 * If the field equals 2, it means that the system is also aware of
+	 * SCXTNUM_ELx register contexts. We aren't using them in the TF, so we
+	 * expect users of the registers to do the right thing.
+	 *
+	 * Only apply mitigations if the value of this field is 0.
 	 */
-	cmp	\_reg, #1
-	beq	\_label
+#if ENABLE_ASSERTIONS
+	cmp	\_reg, #3 /* Only values 0 to 2 are expected */
+	ASM_ASSERT(lo)
+#endif
+
+	cmp	\_reg, #0
+	bne	\_label
 	.endm
 
 	/*


### PR DESCRIPTION
Armv8.5 introduces the field ``CSV2`` to register ``ID_AA64PFR0_EL1``. It can have the following 3 values:

- 0: Branch targets trained in one hardware described context may affect speculative execution in a different hardware described context. In some CPUs it may be needed to apply mitigations.

- 1: Branch targets trained in one hardware described context can only affect speculative execution in a different hardware described context in a hard-to-determine way. No mitigation required.

- 2: Same as 1, but the device is also aware of ``SCXTNUM_ELx`` register contexts. The TF doesn't use the registers, so there is no difference with 1.

The field CSV2 was originally introduced in the TRM of the Cortex-A76 before the release of the Armv8.5 architecture. That TRM only mentions the meaning of values 0 and 1. Because of this, the code only checks if the field has value 1 to know whether to enable or disable the mitigations.

This patch makes it aware of value 2 as well. Both values 1 and 2 disable the mitigation, and 0 enables it.