### PR TITLE
allwinner: A few minor improvements

### DIFF
--- a/plat/allwinner/common/include/sunxi_private.h
+++ b/plat/allwinner/common/include/sunxi_private.h
@@ -9,9 +9,9 @@
 
 void sunxi_configure_mmu_el3(int flags);
 
-void sunxi_cpu_on(unsigned int cluster, unsigned int core);
-void sunxi_cpu_off(unsigned int cluster, unsigned int core);
-void sunxi_disable_secondary_cpus(unsigned int primary_cpu);
+void sunxi_cpu_on(u_register_t mpidr);
+void sunxi_cpu_off(u_register_t mpidr);
+void sunxi_disable_secondary_cpus(u_register_t primary_mpidr);
 void __dead2 sunxi_power_down(void);
 
 int sunxi_pmic_setup(uint16_t socid, const void *fdt);

--- a/plat/allwinner/common/sunxi_bl31_setup.c
+++ b/plat/allwinner/common/sunxi_bl31_setup.c
@@ -11,6 +11,7 @@
 #include <platform_def.h>
 
 #include <arch.h>
+#include <arch_helpers.h>
 #include <common/debug.h>
 #include <drivers/arm/gicv2.h>
 #include <drivers/console.h>
@@ -101,7 +102,7 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 	SET_SECURITY_STATE(bl33_image_ep_info.h.attr, NON_SECURE);
 
 	/* Turn off all secondary CPUs */
-	sunxi_disable_secondary_cpus(plat_my_core_pos());
+	sunxi_disable_secondary_cpus(read_mpidr());
 }
 
 void bl31_plat_arch_setup(void)

--- a/plat/allwinner/common/sunxi_common.c
+++ b/plat/allwinner/common/sunxi_common.c
@@ -18,7 +18,7 @@
 #include <sunxi_mmap.h>
 #include <sunxi_private.h>
 
-static mmap_region_t sunxi_mmap[PLATFORM_MMAP_REGIONS + 1] = {
+static const mmap_region_t sunxi_mmap[PLATFORM_MMAP_REGIONS + 1] = {
 	MAP_REGION_FLAT(SUNXI_SRAM_BASE, SUNXI_SRAM_SIZE,
 			MT_MEMORY | MT_RW | MT_SECURE),
 	MAP_REGION_FLAT(SUNXI_DEV_BASE, SUNXI_DEV_SIZE,

--- a/plat/allwinner/common/sunxi_pm.c
+++ b/plat/allwinner/common/sunxi_pm.c
@@ -35,7 +35,7 @@ static int sunxi_pwr_domain_on(u_register_t mpidr)
 	if (mpidr_is_valid(mpidr) == 0)
 		return PSCI_E_INTERN_FAIL;
 
-	sunxi_cpu_on(MPIDR_AFFLVL1_VAL(mpidr), MPIDR_AFFLVL0_VAL(mpidr));
+	sunxi_cpu_on(mpidr);
 
 	return PSCI_E_SUCCESS;
 }
@@ -47,9 +47,7 @@ static void sunxi_pwr_domain_off(const psci_power_state_t *target_state)
 
 static void __dead2 sunxi_pwr_down_wfi(const psci_power_state_t *target_state)
 {
-	u_register_t mpidr = read_mpidr();
-
-	sunxi_cpu_off(MPIDR_AFFLVL1_VAL(mpidr), MPIDR_AFFLVL0_VAL(mpidr));
+	sunxi_cpu_off(read_mpidr());
 
 	while (1)
 		wfi();
@@ -64,7 +62,7 @@ static void sunxi_pwr_domain_on_finish(const psci_power_state_t *target_state)
 static void __dead2 sunxi_system_off(void)
 {
 	/* Turn off all secondary CPUs */
-	sunxi_disable_secondary_cpus(plat_my_core_pos());
+	sunxi_disable_secondary_cpus(read_mpidr());
 
 	sunxi_power_down();
 }

--- a/plat/allwinner/common/sunxi_topology.c
+++ b/plat/allwinner/common/sunxi_topology.c
@@ -9,7 +9,7 @@
 #include <arch.h>
 #include <plat/common/platform.h>
 
-static unsigned char plat_power_domain_tree_desc[PLAT_MAX_PWR_LVL + 1] = {
+static const unsigned char plat_power_domain_tree_desc[PLAT_MAX_PWR_LVL + 1] = {
 	/* One root node for the SoC */
 	1,
 	/* One node for each cluster */

--- a/plat/allwinner/sun50i_a64/sunxi_power.c
+++ b/plat/allwinner/sun50i_a64/sunxi_power.c
@@ -175,7 +175,7 @@ static int fdt_get_regulator_millivolt(const void *fdt, int node)
 
 #define NO_SPLIT 0xff
 
-struct axp_regulator {
+static const struct axp_regulator {
 	char *dt_name;
 	uint16_t min_volt;
 	uint16_t max_volt;
@@ -247,7 +247,7 @@ static void setup_axp803_rails(const void *fdt)
 	for (node = fdt_first_subnode(fdt, node);
 	     node != -FDT_ERR_NOTFOUND;
 	     node = fdt_next_subnode(fdt, node)) {
-		struct axp_regulator *reg;
+		const struct axp_regulator *reg;
 		const char *name;
 		int length;
 


### PR DESCRIPTION
In the process of [developing SCPI support](https://github.com/smaeul/arm-trusted-firmware/commits/crust) for the Allwinner platforms, I came up with a few small improvements that are independent of the PSCI changes.

* ~~Make indentation/alignment consistent (though the only really "wrong" indentation was the `NOTICE` in sunxi_bl31_setup.c).~~
* Constify data structures where possible, so they get put in `.rodata`
* Make the CPU ops functions simpler to call, saving about 50 bytes. This will also save some line wrapping when the SCPI case is added.