### PR TITLE
docs: Update documentation about ARMv8.2-TTCNP

### DIFF
--- a/docs/firmware-design.rst
+++ b/docs/firmware-design.rst
@@ -2544,10 +2544,8 @@ This Architecture Extension is targeted when ``ARM_ARCH_MAJOR`` >= 8, or when
 Armv8.2-A
 ~~~~~~~~~
 
-This Architecture Extension is targeted when ``ARM_ARCH_MAJOR`` == 8 and
-``ARM_ARCH_MINOR`` >= 2.
-
--  The Common not Private (CnP) bit is enabled to indicate that multiple
+-  The presence of ARMv8.2-TTCNP is detected at runtime. When it is present, the
+   Common not Private (TTBRn_ELx.CnP) bit is enabled to indicate that multiple
    Processing Elements in the same Inner Shareable domain use the same
    translation table entries for a given stage of translation for a particular
    translation regime.
@@ -2642,7 +2640,7 @@ References
 
 --------------
 
-*Copyright (c) 2013-2018, Arm Limited and Contributors. All rights reserved.*
+*Copyright (c) 2013-2019, Arm Limited and Contributors. All rights reserved.*
 
 .. _Reset Design: ./reset-design.rst
 .. _Porting Guide: ./porting-guide.rst


### PR DESCRIPTION
Commit 2559b2c8256f ("xlat v2: Dynamically detect need for CnP bit") modified the code to convert the compile-time check for ARMv8.2-TTCNP to a runtime check, but forgot to update the documentation associated to it.