### PR TITLE
Disable processor Cycle Counting in Secure state

### DIFF
--- a/include/arch/aarch32/arch.h
+++ b/include/arch/aarch32/arch.h
@@ -153,6 +153,7 @@
 #define SDCR_SPD_LEGACY		U(0x0)
 #define SDCR_SPD_DISABLE	U(0x2)
 #define SDCR_SPD_ENABLE		U(0x3)
+#define SDCR_SCCD_BIT		(U(1) << 23)
 #define SDCR_RESET_VAL		U(0x0)
 
 /* HSCTLR definitions */

--- a/include/arch/aarch32/el3_common_macros.S
+++ b/include/arch/aarch32/el3_common_macros.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -103,10 +103,15 @@
 	 * Initialise SDCR, setting all the fields rather than relying on hw.
 	 *
 	 * SDCR.SPD: Disable AArch32 privileged debug. Debug exceptions from
-	 * Secure EL1 are disabled.
+	 *  Secure EL1 are disabled.
+	 *
+	 * SDCR: Set to one so that cycle counting by PMCCNTR is prohibited in
+	 *  Secure state. This bit is RES0 in versions of the architecture
+	 *  earlier than ARMv8.5, setting it to 1 doesn't have any effect on
+	 *  them.
 	 * ---------------------------------------------------------------------
 	 */
-	ldr	r0, =(SDCR_RESET_VAL | SDCR_SPD(SDCR_SPD_DISABLE))
+	ldr	r0, =(SDCR_RESET_VAL | SDCR_SPD(SDCR_SPD_DISABLE) | SDCR_SCCD_BIT)
 	stcopr	r0, SDCR
 #endif
 

--- a/include/arch/aarch64/arch.h
+++ b/include/arch/aarch64/arch.h
@@ -291,16 +291,17 @@
 
 /* MDCR_EL3 definitions */
 #define MDCR_SPD32(x)		((x) << 14)
-#define MDCR_SPD32_LEGACY	U(0x0)
-#define MDCR_SPD32_DISABLE	U(0x2)
-#define MDCR_SPD32_ENABLE	U(0x3)
-#define MDCR_SDD_BIT		(U(1) << 16)
+#define MDCR_SPD32_LEGACY	ULL(0x0)
+#define MDCR_SPD32_DISABLE	ULL(0x2)
+#define MDCR_SPD32_ENABLE	ULL(0x3)
+#define MDCR_SDD_BIT		(ULL(1) << 16)
 #define MDCR_NSPB(x)		((x) << 12)
-#define MDCR_NSPB_EL1		U(0x3)
-#define MDCR_TDOSA_BIT		(U(1) << 10)
-#define MDCR_TDA_BIT		(U(1) << 9)
-#define MDCR_TPM_BIT		(U(1) << 6)
-#define MDCR_EL3_RESET_VAL	U(0x0)
+#define MDCR_NSPB_EL1		ULL(0x3)
+#define MDCR_TDOSA_BIT		(ULL(1) << 10)
+#define MDCR_TDA_BIT		(ULL(1) << 9)
+#define MDCR_TPM_BIT		(ULL(1) << 6)
+#define MDCR_SCCD_BIT		(ULL(1) << 23)
+#define MDCR_EL3_RESET_VAL	ULL(0x0)
 
 /* MDCR_EL2 definitions */
 #define MDCR_EL2_TPMS		(U(1) << 14)

--- a/include/arch/aarch64/el3_common_macros.S
+++ b/include/arch/aarch64/el3_common_macros.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -101,10 +101,17 @@
 	 *
 	 * MDCR_EL3.TPM: Set to zero so that EL0, EL1, and EL2 System register
 	 *  accesses to all Performance Monitors registers do not trap to EL3.
+	 *
+	 * MDCR_EL3.SCCD: Set to one so that cycle counting by PMCCNTR_EL0 is
+	 *  prohibited in Secure state. This bit is RES0 in versions of the
+	 *  architecture earlier than ARMv8.5, setting it to 1 doesn't have any
+	 *  effect on them.
 	 * ---------------------------------------------------------------------
 	 */
-	mov_imm	x0, ((MDCR_EL3_RESET_VAL | MDCR_SDD_BIT | MDCR_SPD32(MDCR_SPD32_DISABLE)) \
-			& ~(MDCR_TDOSA_BIT | MDCR_TDA_BIT | MDCR_TPM_BIT))
+	mov_imm	x0, ((MDCR_EL3_RESET_VAL | MDCR_SDD_BIT | \
+		      MDCR_SPD32(MDCR_SPD32_DISABLE) | MDCR_SCCD_BIT) \
+		    & ~(MDCR_TDOSA_BIT | MDCR_TDA_BIT | MDCR_TPM_BIT))
+
 	msr	mdcr_el3, x0
 
 	/* ---------------------------------------------------------------------


### PR DESCRIPTION
In a system with ARMv8.5-PMU implemented:

- If ``EL3`` is using AArch32, setting ``MDCR_EL3.SCCD`` to 1 disables counting in Secure state in ``PMCCNTR``.

- If ``EL3`` is using AArch64, setting ``SDCR.SCCD`` to 1 disables counting in Secure state in ``PMCCNTR_EL0``.

So far this effect has been achieved by setting ``PMCR_EL0.DP`` (in AArch64) or ``PMCR.DP`` (in AArch32) to 1 instead, but this isn't considered secure as any EL can change that value.