### PR TITLE
imx: Configure CAAM job rings master ID for i.MX8MQ

### DIFF
--- a/plat/imx/imx8m/imx8mq/imx8mq_bl31_setup.c
+++ b/plat/imx/imx8m/imx8mq/imx8mq_bl31_setup.c
@@ -84,6 +84,11 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 		mmio_write_32(IMX_CSU_BASE + i * 4, 0xffffffff);
 	}
 
+	/* config CAAM JRaMID set MID to Cortex A */
+	mmio_write_32(CAAM_JR0MID, CAAM_NS_MID);
+	mmio_write_32(CAAM_JR1MID, CAAM_NS_MID);
+	mmio_write_32(CAAM_JR2MID, CAAM_NS_MID);
+
 #if DEBUG_CONSOLE
 	static console_uart_t console;
 

--- a/plat/imx/imx8m/imx8mq/include/platform_def.h
+++ b/plat/imx/imx8m/imx8mq/include/platform_def.h
@@ -119,3 +119,8 @@
 #define DEBUG_CONSOLE			0
 #define IMX_WDOG_B_RESET
 #define PLAT_IMX8M			1
+
+#define CAAM_JR0MID			U(0x30900010)
+#define CAAM_JR1MID			U(0x30900018)
+#define CAAM_JR2MID			U(0x30900020)
+#define CAAM_NS_MID			U(0x1)


### PR DESCRIPTION
Derived from [this commit](https://source.codeaurora.org/external/imx/imx-atf/commit/plat/imx/imx8mq/imx8m_bl31_setup.c?h=imx_4.14.78_1.0.0_ga&id=6c485ce1f3e62723b1ac2a2b8385126ce8a4fe1d) in the NXP repo. The Linux CAAM driver is not able to initialise correctly without this.