### PR TITLE
RaspberryPi3 sdhost driver improvement.

### DIFF
--- a/include/drivers/rpi3/sdhost/rpi3_sdhost.h
+++ b/include/drivers/rpi3/sdhost/rpi3_sdhost.h
@@ -21,7 +21,6 @@ struct rpi3_sdhost_params {
 	uint8_t		cmdbusy;
 	uint8_t		mmc_app_cmd;
 	uint32_t	ns_per_fifo_word;
-	uint32_t	crc_err_retries;
 
 	uint32_t	sdcard_rca;
 	uint32_t	gpio48_pinselect[6];

--- a/plat/rpi3/rpi3_bl2_setup.c
+++ b/plat/rpi3/rpi3_bl2_setup.c
@@ -44,8 +44,8 @@ static void rpi3_sdhost_setup(void)
 
 	memset(&params, 0, sizeof(struct rpi3_sdhost_params));
 	params.reg_base = RPI3_SDHOST_BASE;
-	params.bus_width = MMC_BUS_WIDTH_4;
-	params.clk_rate = 392464;
+	params.bus_width = MMC_BUS_WIDTH_1;
+	params.clk_rate = 50000000;
 	mmc_info.mmc_dev_type = MMC_IS_SD_HC;
 	rpi3_sdhost_init(&params, &mmc_info);
 }


### PR DESCRIPTION
This commit improves the SDHost driver for RPi3 as following:
 * Unblock MMC_CMD(17). Using MMC_CMD(17) is more efficient on
   block reading.
 * In some low probability that SEND_OP_COND might results CRC7
   error. We can consider that the command runs correctly. We don't
   need to retry this command so removing the code for retry.
 * Using MMC_BUS_WIDTH_1 as MMC default value to improve the stability.
 * Increase the clock to 50Mhz in data mode to speed up the io.
 * Change the pull resistors configuration to gain more stability.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>