### PR TITLE
trusty: Include file with GIC definitions

### DIFF
--- a/services/spd/trusty/generic-arm64-smcall.c
+++ b/services/spd/trusty/generic-arm64-smcall.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -8,6 +8,7 @@
 
 #include <common/debug.h>
 #include <common/runtime_svc.h>
+#include <platform_def.h>
 
 #include "generic-arm64-smcall.h"
 


### PR DESCRIPTION
The GIC definitions used in this file have to be provided by the platform but ``platform_def.h`` wasn't included.