### PR TITLE
css/sgi: replace all uses of Clark with new product names

### DIFF
--- a/plat/arm/css/sgi/include/sgi_variant.h
+++ b/plat/arm/css/sgi/include/sgi_variant.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,9 +10,9 @@
 /* SSC_VERSION values for SGI575 */
 #define SGI575_SSC_VER_PART_NUM		0x0783
 
-/* SID Version values for SGI-Clark */
-#define SGI_CLARK_SID_VER_PART_NUM		0x0786
-#define SGI_CLARK_HELIOS_CONFIG_ID		0x2
+/* SID Version values for RD-N1E1-Edge */
+#define RD_N1E1_EDGE_SID_VER_PART_NUM		0x0786
+#define RD_E1_EDGE_CONFIG_ID			0x2
 
 /* Structure containing SGI platform variant information */
 typedef struct sgi_platform_info {

--- a/plat/arm/css/sgi/sgi_bl31_setup.c
+++ b/plat/arm/css/sgi/sgi_bl31_setup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -27,7 +27,7 @@ static scmi_channel_plat_info_t sgi575_scmi_plat_info = {
 		.ring_doorbell = &mhu_ring_doorbell,
 };
 
-static scmi_channel_plat_info_t sgi_clark_scmi_plat_info = {
+static scmi_channel_plat_info_t rd_n1e1_edge_scmi_plat_info = {
 		.scmi_mbx_mem = CSS_SCMI_PAYLOAD_BASE,
 		.db_reg_addr = PLAT_CSS_MHU_BASE + SENDER_REG_SET(0),
 		.db_preserve_mask = 0xfffffffe,
@@ -37,8 +37,8 @@ static scmi_channel_plat_info_t sgi_clark_scmi_plat_info = {
 
 scmi_channel_plat_info_t *plat_css_get_scmi_info()
 {
-	if (sgi_plat_info.platform_id == SGI_CLARK_SID_VER_PART_NUM)
-		return &sgi_clark_scmi_plat_info;
+	if (sgi_plat_info.platform_id == RD_N1E1_EDGE_SID_VER_PART_NUM)
+		return &rd_n1e1_edge_scmi_plat_info;
 	else if (sgi_plat_info.platform_id == SGI575_SSC_VER_PART_NUM)
 		return &sgi575_scmi_plat_info;
 	else
@@ -65,9 +65,9 @@ void bl31_platform_setup(void)
 
 const plat_psci_ops_t *plat_arm_psci_override_pm_ops(plat_psci_ops_t *ops)
 {
-	/* For SGI-Clark.Helios platform only CPU ON/OFF is supported */
-	if ((sgi_plat_info.platform_id == SGI_CLARK_SID_VER_PART_NUM) &&
-	    (sgi_plat_info.config_id == SGI_CLARK_HELIOS_CONFIG_ID)) {
+	/* For RD-E1-Edge platform only CPU ON/OFF is supported */
+	if ((sgi_plat_info.platform_id == RD_N1E1_EDGE_SID_VER_PART_NUM) &&
+	    (sgi_plat_info.config_id == RD_E1_EDGE_CONFIG_ID)) {
 		ops->cpu_standby = NULL;
 		ops->system_off = NULL;
 		ops->system_reset = NULL;

--- a/plat/arm/css/sgi/sgi_topology.c
+++ b/plat/arm/css/sgi/sgi_topology.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -21,8 +21,8 @@ const unsigned char sgi_pd_tree_desc[] = {
 	CSS_SGI_MAX_CPUS_PER_CLUSTER
 };
 
-/* SGI-Clark.Helios platform consists of 16 physical CPUS and 32 threads */
-const unsigned char sgi_clark_helios_pd_tree_desc[] = {
+/* RD-E1-Edge platform consists of 16 physical CPUS and 32 threads */
+const unsigned char rd_e1_edge_pd_tree_desc[] = {
 	PLAT_ARM_CLUSTER_COUNT,
 	CSS_SGI_MAX_CPUS_PER_CLUSTER,
 	CSS_SGI_MAX_CPUS_PER_CLUSTER,
@@ -49,9 +49,9 @@ const unsigned char sgi_clark_helios_pd_tree_desc[] = {
  ******************************************************************************/
 const unsigned char *plat_get_power_domain_tree_desc(void)
 {
-	if (sgi_plat_info.platform_id == SGI_CLARK_SID_VER_PART_NUM &&
-	    sgi_plat_info.config_id == SGI_CLARK_HELIOS_CONFIG_ID)
-		return sgi_clark_helios_pd_tree_desc;
+	if (sgi_plat_info.platform_id == RD_N1E1_EDGE_SID_VER_PART_NUM &&
+	    sgi_plat_info.config_id == RD_E1_EDGE_CONFIG_ID)
+		return rd_e1_edge_pd_tree_desc;
 	else
 		return sgi_pd_tree_desc;
 }


### PR DESCRIPTION
Replace all uses of 'SGI_CLARK' with 'RD_N1E1_EDGE' and
'SGI_CLARK_HELIOS' with 'RD_E1_EDGE' as per the updated product
names

Change-Id: Ib8136e421b1a46da1e5df58c6b1432d5c78d279b
Signed-off-by: Chandni Cherukuri <chandni.cherukuri@arm.com>