### PR TITLE
MPAM: enable MPAM EL2 traps

### DIFF
--- a/include/arch/aarch64/arch.h
+++ b/include/arch/aarch64/arch.h
@@ -782,6 +782,10 @@
 
 /* MPAM register definitions */
 #define MPAM3_EL3_MPAMEN_BIT		(ULL(1) << 63)
+#define MPAMHCR_EL2_TRAP_MPAMIDR_EL1	(ULL(1) << 31)
+
+#define MPAM2_EL2_TRAPMPAM0EL1		(ULL(1) << 49)
+#define MPAM2_EL2_TRAPMPAM1EL1		(ULL(1) << 48)
 
 #define MPAMIDR_HAS_HCR_BIT		(ULL(1) << 17)
 

--- a/lib/extensions/mpam/mpam.c
+++ b/lib/extensions/mpam/mpam.c
@@ -31,11 +31,19 @@ void mpam_enable(bool el2_unused)
 	/*
 	 * If EL2 is implemented but unused, disable trapping to EL2 when lower
 	 * ELs access their own MPAM registers.
+	 * If EL2 is implemented and used, enable trapping to EL2.
 	 */
 	if (el2_unused) {
 		write_mpam2_el2(0);
 
 		if ((read_mpamidr_el1() & MPAMIDR_HAS_HCR_BIT) != 0U)
 			write_mpamhcr_el2(0);
+	} else {
+		write_mpam2_el2(MPAM2_EL2_TRAPMPAM0EL1 |
+				MPAM2_EL2_TRAPMPAM1EL1);
+
+		if ((read_mpamidr_el1() & MPAMIDR_HAS_HCR_BIT) != 0U) {
+			write_mpamhcr_el2(MPAMHCR_EL2_TRAP_MPAMIDR_EL1);
+		}
 	}
 }


### PR DESCRIPTION
Complete the MPAM enablement in TF-A for lower ELs by enabling the EL2
traps in MPAMHCR_EL2 and MPAM2_EL2.This prevents an
MPAM-unaware-hypervisor to be restricted by an MPAM-aware-guest.