### PR TITLE
Remove Mbed TLS dependency from plat_bl_common.c

### DIFF
--- a/drivers/auth/mbedtls/mbedtls_common.c
+++ b/drivers/auth/mbedtls/mbedtls_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -15,6 +15,8 @@
 #include <drivers/auth/mbedtls/mbedtls_common.h>
 #include <drivers/auth/mbedtls/mbedtls_config.h>
 #include <plat/common/platform.h>
+
+#pragma weak plat_get_mbedtls_heap
 
 static void cleanup(void)
 {
@@ -53,4 +55,20 @@ void mbedtls_init(void)
 #endif
 		ready = 1;
 	}
+}
+
+/*
+ * The following default implementation of the function simply returns the
+ * by default allocated heap.
+ */
+int plat_get_mbedtls_heap(void **heap_addr, size_t *heap_size)
+{
+	static unsigned char heap[TF_MBEDTLS_HEAP_SIZE];
+
+	assert(heap_addr != NULL);
+	assert(heap_size != NULL);
+
+	*heap_addr = heap;
+	*heap_size = sizeof(heap);
+	return 0;
 }

--- a/plat/common/plat_bl_common.c
+++ b/plat/common/plat_bl_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,9 +10,6 @@
 #include <arch_helpers.h>
 #include <common/bl_common.h>
 #include <common/debug.h>
-#if TRUSTED_BOARD_BOOT
-#include <drivers/auth/mbedtls/mbedtls_config.h>
-#endif
 #include <lib/xlat_tables/xlat_tables_compat.h>
 #include <plat/common/platform.h>
 
@@ -26,7 +23,6 @@
 #pragma weak bl2_plat_handle_pre_image_load
 #pragma weak bl2_plat_handle_post_image_load
 #pragma weak plat_try_next_boot_source
-#pragma weak plat_get_mbedtls_heap
 
 void bl2_el3_plat_prepare_exit(void)
 {
@@ -56,24 +52,6 @@ int plat_try_next_boot_source(void)
 {
 	return 0;
 }
-
-#if TRUSTED_BOARD_BOOT
-/*
- * The following default implementation of the function simply returns the
- * by-default allocated heap.
- */
-int plat_get_mbedtls_heap(void **heap_addr, size_t *heap_size)
-{
-	static unsigned char heap[TF_MBEDTLS_HEAP_SIZE];
-
-	assert(heap_addr != NULL);
-	assert(heap_size != NULL);
-
-	*heap_addr = heap;
-	*heap_size = sizeof(heap);
-	return 0;
-}
-#endif /* TRUSTED_BOARD_BOOT */
 
 /*
  * Set up the page tables for the generic and platform-specific memory regions.


### PR DESCRIPTION
Fixes https://github.com/ARM-software/tf-issues/issues/677

Due to the shared Mbed TLS heap optimisation introduced in 6d01a463,
common code files were depending on Mbed TLS specific headers. This
dependency is now removed by moving the default, unoptimised heap
implementation inside the Mbed TLS specific files.

Change-Id: I11ea3eb4474f0d9b6cb79a2afd73a51a4a9b8994
Signed-off-by: John Tsichritzis <john.tsichritzis@arm.com>