### PR TITLE
zynqmp: pm: Add support for setting PMU configuration object

### DIFF
--- a/plat/xilinx/zynqmp/pm_service/pm_api_sys.c
+++ b/plat/xilinx/zynqmp/pm_service/pm_api_sys.c
@@ -356,7 +356,10 @@ enum pm_ret_status pm_get_api_version(unsigned int *version)
  */
 enum pm_ret_status pm_set_configuration(unsigned int phys_addr)
 {
-	return PM_RET_ERROR_NOTSUPPORTED;
+	uint32_t payload[PAYLOAD_ARG_CNT];
+
+	PM_PACK_PAYLOAD2(payload, PM_SET_CONFIGURATION, phys_addr);
+	return pm_ipi_send_sync(primary_proc, payload, NULL, 0);
 }
 
 /**


### PR DESCRIPTION
Allow EL2 (e.g. U-Boot) to load the configuration object at runtime
into the Xilinx ZynqMP PMU firmware. This allows booting with U-Boot
and U-Boot SPL with PMU FW without hard-coding the configuration
object.

fixes arm-software/tf-issues#678

Signed-off-by: Luca Ceresoli <luca@lucaceresoli.net>