### PR TITLE
Correctly check for support of Address Authentication

### DIFF
--- a/common/bl_common.c
+++ b/common/bl_common.c
@@ -265,7 +265,7 @@ void bl_handle_pauth(void)
 	 * system registers. Pointer authentication can't be enabled here or the
 	 * authentication will fail when returning from this function.
 	 */
-	assert(is_armv8_3_pauth_api_present());
+	assert(is_armv8_3_pauth_apa_api_present());
 
 	uint64_t *apiakey = plat_init_apiakey();
 

--- a/include/arch/aarch64/arch_features.h
+++ b/include/arch/aarch64/arch_features.h
@@ -34,10 +34,12 @@ static inline bool is_armv8_3_pauth_present(void)
 	return (read_id_aa64isar1_el1() & mask) != 0U;
 }
 
-static inline bool is_armv8_3_pauth_api_present(void)
+static inline bool is_armv8_3_pauth_apa_api_present(void)
 {
-	return ((read_id_aa64isar1_el1() >> ID_AA64ISAR1_API_SHIFT) &
-		ID_AA64ISAR1_API_MASK) != 0U;
+	uint64_t mask = (ID_AA64ISAR1_API_MASK << ID_AA64ISAR1_API_SHIFT) |
+			(ID_AA64ISAR1_APA_MASK << ID_AA64ISAR1_APA_SHIFT);
+
+	return (read_id_aa64isar1_el1() & mask) != 0U;
 }
 
 static inline bool is_armv8_4_ttst_present(void)


### PR DESCRIPTION
Check for both IMPLEMENTATION_DEFINED and Architected algorithms of Address Authentication.