### PR TITLE
Tegra: dummy support for the io_storage backend

### DIFF
--- a/plat/nvidia/tegra/common/tegra_common.mk
+++ b/plat/nvidia/tegra/common/tegra_common.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2015-2019, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -22,6 +22,7 @@ TEGRA_GICv2_SOURCES	:=	drivers/arm/gic/common/gic_common.c		\
 
 BL31_SOURCES		+=	drivers/console/aarch64/console.S		\
 				drivers/delay_timer/delay_timer.c		\
+				drivers/io/io_storage.c				\
 				${TEGRA_GICv2_SOURCES}				\
 				${COMMON_DIR}/aarch64/tegra_helpers.S		\
 				${COMMON_DIR}/drivers/pmc/pmc.c			\
@@ -29,6 +30,7 @@ BL31_SOURCES		+=	drivers/console/aarch64/console.S		\
 				${COMMON_DIR}/tegra_bl31_setup.c		\
 				${COMMON_DIR}/tegra_delay_timer.c		\
 				${COMMON_DIR}/tegra_fiq_glue.c			\
+				${COMMON_DIR}/tegra_io_storage.c		\
 				${COMMON_DIR}/tegra_platform.c			\
 				${COMMON_DIR}/tegra_pm.c			\
 				${COMMON_DIR}/tegra_sip_calls.c			\

--- a/plat/nvidia/tegra/common/tegra_io_storage.c
+++ b/plat/nvidia/tegra/common/tegra_io_storage.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2019, NVIDIA Corporation. All rights reserved.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <errno.h>
+#include <plat/common/platform.h>
+
+/*
+ * Return an IO device handle and specification which can be used to access
+ * an image. Use this to enforce platform load policy.
+ *
+ * This function is not supported at this time
+ */
+int plat_get_image_source(unsigned int image_id, uintptr_t *dev_handle,
+			  uintptr_t *image_spec)
+{
+	return -ENOTSUP;
+}

--- a/plat/nvidia/tegra/include/platform_def.h
+++ b/plat/nvidia/tegra/include/platform_def.h
@@ -66,4 +66,10 @@
 #define CACHE_WRITEBACK_SHIFT		6
 #define CACHE_WRITEBACK_GRANULE		(0x40) /* (U(1) << CACHE_WRITEBACK_SHIFT) */
 
+/*******************************************************************************
+ * Dummy macros to compile io_storage support
+ ******************************************************************************/
+#define MAX_IO_DEVICES			U(0)
+#define MAX_IO_HANDLES			U(0)
+
 #endif /* PLATFORM_DEF_H */

--- a/plat/nvidia/tegra/platform.mk
+++ b/plat/nvidia/tegra/platform.mk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2015-2019, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -68,7 +68,6 @@ ifneq ($(findstring armlink,$(notdir $(LD))),)
 # o resolve undefined symbols to el3_panic
 # o include only required sections
 TF_LDFLAGS	+= --diag_suppress=L6314,L6332 --no_scanlib --callgraph
-TF_LDFLAGS	+= --unresolved=el3_panic
 TF_LDFLAGS	+= --keep="*(__pubsub*)" --keep="*(rt_svc_descs*)" --keep="*(*cpu_ops)"
 ifeq (${ENABLE_PMF},1)
 TF_LDFLAGS	+= --keep="*(*pmf_svc_descs*)"


### PR DESCRIPTION
This patch provides dummy macros and platform files to compile
the io_storage driver backend. This patch is necessary to
remove the "--unresolved=el3_panic" linker flag from Tegra's
makefiles and allow us to revert this workaround, previously
suggested by the ARM toolchain team.

The "--unresolved=el3_panic" flag actually was a big hammer that
allowed Tegra platforms to work with armlink previously but it
masks legit errors with the code as well.

Change-Id: I0421d35657823215229f84231896b84167f90548
Signed-off-by: Varun Wadekar <vwadekar@nvidia.com>