### PR TITLE
doc: Remove todo from example code

### DIFF
--- a/docs/firmware-design.rst
+++ b/docs/firmware-design.rst
@@ -2031,7 +2031,6 @@ accessed by multiple CPUs, either with caches enabled or disabled.
 
         /*
          * Index of the parent power domain node.
-         * TODO: Figure out whether to whether using pointer is more efficient.
          */
         unsigned int parent_node;
 


### PR DESCRIPTION
While the TODO might be relevant in the codebase itself, keeping
it in the example code is a bit untidy.

Change-Id: Ia95246208cee48df1536b4317a8c896ab2c84fc2
Signed-off-by: Paul Beesley <paul.beesley@arm.com>