### PR TITLE
plat: intel: Improve ECC scrubbing performance

### DIFF
--- a/plat/intel/soc/stratix10/soc/s10_memory_controller.c
+++ b/plat/intel/soc/stratix10/soc/s10_memory_controller.c
@@ -8,6 +8,7 @@
 #include <arch_helpers.h>
 #include <errno.h>
 #include <lib/mmio.h>
+#include <lib/utils.h>
 #include <common/debug.h>
 #include <drivers/delay_timer.h>
 #include <platform_def.h>
@@ -403,7 +404,7 @@ void configure_hmc_adaptor_regs(void)
 		INFO("Scrubbing ECC\n");
 
 		/* ECC Scrubbing */
-		memset(DRAM_BASE, 0, DRAM_SIZE);
+		zeromem(DRAM_BASE, DRAM_SIZE);
 	} else {
 		INFO("ECC is disabled.\n");
 	}


### PR DESCRIPTION
We should be using zeromem to scrub memory instead of memset. This would
improve the performance by 200x

Signed-off-by: Tien Hock, Loh <tien.hock.loh@intel.com>