### PR TITLE
drivers: mmc: Fix some issues with MMC stack

### DIFF
--- a/include/drivers/mmc.h
+++ b/include/drivers/mmc.h
@@ -220,6 +220,7 @@ struct mmc_device_info {
 	unsigned long long	device_size;	/* Size of device in bytes */
 	unsigned int		block_size;	/* Block size in bytes */
 	unsigned int		max_bus_freq;	/* Max bus freq in Hz */
+	unsigned int		ocr_voltage;	/* OCR voltage */
 	enum mmc_device_type	mmc_dev_type;	/* Type of MMC */
 };
 

--- a/plat/intel/soc/stratix10/bl2_plat_setup.c
+++ b/plat/intel/soc/stratix10/bl2_plat_setup.c
@@ -99,6 +99,7 @@ void bl2_el3_plat_arch_setup(void)
 	dw_mmc_params_t params = EMMC_INIT_PARAMS(0x100000);
 
 	info.mmc_dev_type = MMC_IS_SD;
+	info.ocr_voltage = OCR_3_3_3_4 | OCR_3_2_3_3;
 
 	switch (boot_source) {
 	case BOOT_SOURCE_SDMMC:


### PR DESCRIPTION
Some bugs in MMC stack needs to be fixed:
- scr cannot be local as this will cause cache issue when invalidating
after the read DMA transfer is completed
- ACMD41 needs to send voltage information in initialization, otherwise the
command is a query, thus will not initialize the controller
- when checking device state, retry until the retries counter goes to zero
before failing

Signed-off-by: Tien Hock, Loh <tien.hock.loh@intel.com>