### PR TITLE
Fixup register handling in aarch32 reset_handler

### DIFF
--- a/lib/cpus/aarch32/cpu_helpers.S
+++ b/lib/cpus/aarch32/cpu_helpers.S
@@ -21,9 +21,9 @@
 	 */
 	.globl	reset_handler
 func reset_handler
-	mov	r10, lr
+	mov	r8, lr
 
-	/* The plat_reset_handler can clobber r0 - r9 */
+	/* The plat_reset_handler can clobber r0 - r7 */
 	bl	plat_reset_handler
 
 	/* Get the matching cpu_ops pointer (clobbers: r0 - r5) */
@@ -37,7 +37,7 @@ func reset_handler
 	/* Get the cpu_ops reset handler */
 	ldr	r1, [r0, #CPU_RESET_FUNC]
 	cmp	r1, #0
-	mov	lr, r10
+	mov	lr, r8
 	bxne	r1
 	bx	lr
 endfunc reset_handler


### PR DESCRIPTION
The BL handover interface stores the bootloader arguments in
registers r9-r12, so when the reset_handler stores the lr pointer
in r10 it clobers one of the arguments.

Adapt to use r8 and adapt the comment about registers allowed
to clober.

I've checked aarch32 reset_handlers and none seem to use higher
registers as far as I can tell.

Fixes: a6f340fe58b9 ("Introduce the new BL handover interface")
Cc: Soby Mathew <soby.mathew@arm.com>
Signed-off-by: Heiko Stuebner <heiko@sntech.de>