### PR TITLE
rockchip: add an fdt parsing stub for platform param

### DIFF
--- a/plat/rockchip/rk3328/platform.mk
+++ b/plat/rockchip/rk3328/platform.mk
@@ -8,6 +8,8 @@ RK_PLAT			:=	plat/rockchip
 RK_PLAT_SOC		:=	${RK_PLAT}/${PLAT}
 RK_PLAT_COMMON		:=	${RK_PLAT}/common
 
+include lib/libfdt/libfdt.mk
+
 PLAT_INCLUDES		:=	-Idrivers/arm/gic/common/			\
 				-Idrivers/arm/gic/v2/			\
 				-I${RK_PLAT_COMMON}/                            \
@@ -38,6 +40,7 @@ BL31_SOURCES		+=	${RK_GIC_SOURCES}				\
 				drivers/delay_timer/generic_delay_timer.c	\
 				lib/cpus/aarch64/aem_generic.S			\
 				lib/cpus/aarch64/cortex_a53.S			\
+				$(LIBFDT_SRCS)					\
 				${RK_PLAT_COMMON}/drivers/parameter/ddr_parameter.c	\
 				${RK_PLAT_COMMON}/aarch64/plat_helpers.S	\
 				${RK_PLAT_COMMON}/bl31_plat_setup.c		\

--- a/plat/rockchip/rk3368/platform.mk
+++ b/plat/rockchip/rk3368/platform.mk
@@ -8,6 +8,8 @@ RK_PLAT			:=	plat/rockchip
 RK_PLAT_SOC		:=	${RK_PLAT}/${PLAT}
 RK_PLAT_COMMON		:=	${RK_PLAT}/common
 
+include lib/libfdt/libfdt.mk
+
 PLAT_INCLUDES		:=	-I${RK_PLAT_COMMON}/				\
 				-I${RK_PLAT_COMMON}/include/			\
 				-I${RK_PLAT_COMMON}/pmusram			\
@@ -35,6 +37,7 @@ BL31_SOURCES		+=	${RK_GIC_SOURCES}				\
 				drivers/delay_timer/delay_timer.c		\
 				drivers/delay_timer/generic_delay_timer.c	\
 				lib/cpus/aarch64/cortex_a53.S			\
+				$(LIBFDT_SRCS)					\
 				${RK_PLAT_COMMON}/aarch64/plat_helpers.S	\
 				${RK_PLAT_COMMON}/bl31_plat_setup.c		\
 				${RK_PLAT_COMMON}/params_setup.c                \

--- a/plat/rockchip/rk3399/platform.mk
+++ b/plat/rockchip/rk3399/platform.mk
@@ -8,6 +8,8 @@ RK_PLAT		:=	plat/rockchip
 RK_PLAT_SOC	:=	${RK_PLAT}/${PLAT}
 RK_PLAT_COMMON	:=	${RK_PLAT}/common
 
+include lib/libfdt/libfdt.mk
+
 PLAT_INCLUDES		:=	-I${RK_PLAT_COMMON}/			\
 				-I${RK_PLAT_COMMON}/include/		\
 				-I${RK_PLAT_COMMON}/pmusram		\
@@ -43,6 +45,7 @@ BL31_SOURCES	+=	${RK_GIC_SOURCES}				\
 			drivers/gpio/gpio.c				\
 			lib/cpus/aarch64/cortex_a53.S			\
 			lib/cpus/aarch64/cortex_a72.S			\
+			$(LIBFDT_SRCS)					\
 			${RK_PLAT_COMMON}/aarch64/plat_helpers.S	\
 			${RK_PLAT_COMMON}/bl31_plat_setup.c		\
 			${RK_PLAT_COMMON}/params_setup.c		\


### PR DESCRIPTION
The Rockchip ATF platform can be entered from both Coreboot and U-Boot.
While Coreboot does submit the list of linked parameter structs as
platform param, upstream u-boot actually always provides a pointer
to a devicetree as parameter.
This results in current ATF not running at all when started from U-Boot.

To fix this, add a stub that checks if the parameter is a fdt so we
can at least boot and not get stuck. Later on we can extend this with
actual parsing of information from the devicetree.

Signed-off-by: Heiko Stuebner <heiko@sntech.de>
Cc: Philipp Tomsich <philipp.tomsich@theobroma-systems.com>