### PR TITLE
BL31: Enable pointer authentication support in warm boot path

### DIFF
--- a/bl31/aarch64/bl31_entrypoint.S
+++ b/bl31/aarch64/bl31_entrypoint.S
@@ -201,6 +201,19 @@ func bl31_warm_entrypoint
 #endif
 	bl	bl31_plat_enable_mmu
 
+	/* --------------------------------------------------------------------
+	 * Enable pointer authentication
+	 * --------------------------------------------------------------------
+	 */
+#if ENABLE_PAUTH
+	bl	pauth_load_bl_apiakey
+
+	mrs	x0, sctlr_el3
+	orr	x0, x0, #SCTLR_EnIA_BIT
+	msr	sctlr_el3, x0
+	isb
+#endif /* ENABLE_PAUTH */
+
 	bl	psci_warmboot_entrypoint
 
 #if ENABLE_RUNTIME_INSTRUMENTATION


### PR DESCRIPTION
In the current Pointer Authentication support added in
commit b86048c
PAuth gets enabled in BL31 cold boot entrypoint only,
(see bl31_entrypoint() in bl31\aarch64\bl31_entrypoint.S)
but not in bl31_warm_entrypoint().
This results in EnIA bit [31] in SCTLR_EL3 not being set
and pointer authentication disabled after CPU wake-up event.

Fixes ARM-software/tf-issues#684

Change-Id: I27a67804764dfba2a6d72ca119ca2bcff4f536d6
Signed-off-by: Alexei Fedorov <Alexei.Fedorov@arm.com>