### PR TITLE
stm32mp1: zeromem device_info struct

### DIFF
--- a/plat/st/common/bl2_io_storage.c
+++ b/plat/st/common/bl2_io_storage.c
@@ -194,7 +194,8 @@ void stm32mp_io_setup(void)
 	case BOOT_API_CTX_BOOT_INTERFACE_SEL_FLASH_EMMC:
 		dmbsy();
 
-		memset(&params, 0, sizeof(struct stm32_sdmmc2_params));
+		zeromem(&device_info, sizeof(struct mmc_device_info));
+		zeromem(&params, sizeof(struct stm32_sdmmc2_params));
 
 		if (boot_context->boot_interface_selected ==
 		    BOOT_API_CTX_BOOT_INTERFACE_SEL_FLASH_EMMC) {


### PR DESCRIPTION
The change of the structure highlighted the fact that all fields are not
correctly initialized with zeroes.

Replace the other memset in the function with zeromem, as it is faster.

Change-Id: I27f45a64e34637f79fa519f486bf5936721ef396
Signed-off-by: Yann Gautier <yann.gautier@st.com>