### PR TITLE
plat: intel: Add MMC OCR voltage information for initialization

### DIFF
--- a/plat/intel/soc/stratix10/bl2_plat_setup.c
+++ b/plat/intel/soc/stratix10/bl2_plat_setup.c
@@ -99,6 +99,7 @@ void bl2_el3_plat_arch_setup(void)
 	dw_mmc_params_t params = EMMC_INIT_PARAMS(0x100000);
 
 	info.mmc_dev_type = MMC_IS_SD;
+	info.ocr_voltage = OCR_3_3_3_4 | OCR_3_2_3_3;
 
 	switch (boot_source) {
 	case BOOT_SOURCE_SDMMC:


### PR DESCRIPTION
MMC stack needs OCR voltage information for the platform to initialize
MMC controller correctly.

Signed-off-by: Tien Hock, Loh <tien.hock.loh@intel.com>