### PR TITLE
mmc: stm32_sdmmc2: fill ocr_voltage

### DIFF
--- a/drivers/st/mmc/stm32_sdmmc2.c
+++ b/drivers/st/mmc/stm32_sdmmc2.c
@@ -723,6 +723,7 @@ int stm32_sdmmc2_mmc_init(struct stm32_sdmmc2_params *params)
 	mdelay(1);
 
 	sdmmc2_params.clk_rate = stm32mp_clk_get_rate(sdmmc2_params.clock_id);
+	sdmmc2_params.device_info->ocr_voltage = OCR_3_2_3_3 | OCR_3_3_3_4;
 
 	return mmc_init(&stm32_sdmmc2_ops, sdmmc2_params.clk_rate,
 			sdmmc2_params.bus_width, sdmmc2_params.flags,


### PR DESCRIPTION
STM32MP1 SDMMC device voltage is 3.3V. We should then precise the 2 ranges
3.2 to 3.3V and 3.3 to 3.4V in ocr_voltage field.

Change-Id: I88e479f8f16bfe608a7808eace0df3fdec48deab
Signed-off-by: Yann Gautier <yann.gautier@st.com>