### PR TITLE
Integration+bl2 el3 eret fix

### DIFF
--- a/bl2/aarch32/bl2_el3_entrypoint.S
+++ b/bl2/aarch32/bl2_el3_entrypoint.S
@@ -74,11 +74,10 @@ func bl2_run_next_image
 
 	/*
 	 * Extract PC and SPSR based on struct `entry_point_info_t`
-	 * and load it in LR and SPSR registers respectively.
+	 * and load it in to the LR.
 	 */
 	ldr	lr, [r8, #ENTRY_POINT_INFO_PC_OFFSET]
-	ldr	r1, [r8, #(ENTRY_POINT_INFO_PC_OFFSET + 4)]
-	msr	spsr, r1
+	ldr	r4, [r8, #(ENTRY_POINT_INFO_PC_OFFSET + 4)]
 
 	/* Some BL32 stages expect lr_svc to provide the BL33 entry address */
 	cps	#MODE32_svc
@@ -87,5 +86,7 @@ func bl2_run_next_image
 
 	add	r8, r8, #ENTRY_POINT_INFO_ARGS_OFFSET
 	ldm	r8, {r0, r1, r2, r3}
+	/* Load CPSR with target mode prior to eret */
+	msr	cpsr, r4
 	eret
 endfunc bl2_run_next_image

--- a/drivers/st/mmc/stm32_sdmmc2.c
+++ b/drivers/st/mmc/stm32_sdmmc2.c
@@ -723,6 +723,7 @@ int stm32_sdmmc2_mmc_init(struct stm32_sdmmc2_params *params)
 	mdelay(1);
 
 	sdmmc2_params.clk_rate = stm32mp_clk_get_rate(sdmmc2_params.clock_id);
+	sdmmc2_params.device_info->ocr_voltage = OCR_3_2_3_3 | OCR_3_3_3_4;
 
 	return mmc_init(&stm32_sdmmc2_ops, sdmmc2_params.clk_rate,
 			sdmmc2_params.bus_width, sdmmc2_params.flags,


### PR DESCRIPTION
On a subset of our Arm-v7 boards we have observed a failure at the final instruction "eret" to switch to OPTEE.

Drilling down into this it appears as if the usage of eret in bl2_el3_entrypoint.S relies on an undefined behavior.

The Arm documentation states the following with respect to the behaviour of the eret instruction:

>> http://infocenter.arm.com/help/topic/com.arm.doc.dui0588b/CJAEEEJG.html
>> ERET
>> When executed in **Hyp mode**, Exception Return loads the PC from ELR_hyp and loads the CPSR from SPSR_hyp.
>> When executed in a Secure or Non-secure PL1 mode, ERET behaves as:
>> •MOVS PC, LR in the ARM instruction set, see SUBS PC, LR and related instructions (ARM) on page B9-2010

And similarly states the following with respect to Hyp mode

>>https://static.docs.arm.com/ddi0406/c/DDI0406C_C_arm_architecture_reference_manual.pdf
>>**Hyp mode** is implemented only as part of the Virtualization Extensions, and **only in Non-secure state**. This means that:
>>
>>• implementations that do not include the Virtualization Extensions have only two privilege
levels, PL0 and PL1
>>
>>• execution in Secure state has only two privilege levels, PL0 and PL1.
>>In an implementation that includes the Security Extensions, the execution privilege levels are defined independently
in each security state, and there is no relationship between the Secure and Non-secure privilege levels.

Therefore relying on 'eret' to populate the CPSR on an 'eret' when in secure monitor mode is not architecturally valid since the defined behavior for populating CPSR in this fashion applies only to Hyp Mode, not to secure monitor mode.

This patch fixes the issue we have seen with this behavior by specifically setting the CPSR with the required value prior to executing eret, since in secure monitor mode, CPSR may not in fact be updated by the relevant micro-operations.