### PR TITLE
bl2-el3: Fix exit to bl32 by ensuring full write to SPSR

### DIFF
--- a/bl1/aarch32/bl1_exceptions.S
+++ b/bl1/aarch32/bl1_exceptions.S
@@ -71,7 +71,7 @@ debug_loop:
 	 */
 	ldr	lr, [r8, #ENTRY_POINT_INFO_PC_OFFSET]
 	ldr	r1, [r8, #(ENTRY_POINT_INFO_PC_OFFSET + 4)]
-	msr	spsr, r1
+	msr	spsr_xc, r1
 
 	/* Some BL32 stages expect lr_svc to provide the BL33 entry address */
 	cps	#MODE32_svc

--- a/bl2/aarch32/bl2_el3_entrypoint.S
+++ b/bl2/aarch32/bl2_el3_entrypoint.S
@@ -78,7 +78,7 @@ func bl2_run_next_image
 	 */
 	ldr	lr, [r8, #ENTRY_POINT_INFO_PC_OFFSET]
 	ldr	r1, [r8, #(ENTRY_POINT_INFO_PC_OFFSET + 4)]
-	msr	spsr, r1
+	msr	spsr_xc, r1
 
 	/* Some BL32 stages expect lr_svc to provide the BL33 entry address */
 	cps	#MODE32_svc


### PR DESCRIPTION
We are observing a failure mode on a small minority of i.MX7 boards we have in our ATF setup.

Investigating this issue shows that the failure point is when 'eret' is executed to switch from BL2 to BL3.

On first blush, I thought it was down to misuse of eret intself for the particular mode the processor was in. With feedback from @Yann-lms though it was apparent my fix and diagnosis were wrong.

https://github.com/ARM-software/arm-trusted-firmware/pull/1876

Looking at OP-TEE and indeed other parts of the ATF codebase though we can see that the error is mis-setting of the SPSR, in the current case only setting bits 31:24 and 7:0 respectively.

Setting the full SPSR value though will negate the failure for me and ought to be correct for anybody else interested in bits 23:8 of the SPSR on eret.