### PR TITLE
Pb/todo removal

### DIFF
--- a/drivers/io/io_fip.c
+++ b/drivers/io/io_fip.c
@@ -85,7 +85,6 @@ static inline int compare_uuids(const uuid_t *uuid1, const uuid_t *uuid2)
 }
 
 
-/* TODO: We could check version numbers or do a package checksum? */
 static inline int is_valid_header(fip_toc_header_t *header)
 {
 	if ((header->name == TOC_HEADER_NAME) && (header->serial_number != 0)) {

--- a/drivers/io/io_storage.c
+++ b/drivers/io/io_storage.c
@@ -189,9 +189,6 @@ int io_dev_init(uintptr_t dev_handle, const uintptr_t init_params)
 	return result;
 }
 
-
-/* TODO: Consider whether an explicit "shutdown" API should be included */
-
 /* Close a connection to a device */
 int io_dev_close(uintptr_t dev_handle)
 {

--- a/include/drivers/io/io_storage.h
+++ b/include/drivers/io/io_storage.h
@@ -79,8 +79,6 @@ int io_dev_open(const struct io_dev_connector *dev_con,
  * re-initialisation */
 int io_dev_init(uintptr_t dev_handle, const uintptr_t init_params);
 
-/* TODO: Consider whether an explicit "shutdown" API should be included */
-
 /* Close a connection to a device */
 int io_dev_close(uintptr_t dev_handle);
 

--- a/tools/cert_create/src/tbbr/tbb_ext.c
+++ b/tools/cert_create/src/tbbr/tbb_ext.c
@@ -19,10 +19,6 @@
 #include "tbbr/tbb_ext.h"
 #include "tbbr/tbb_key.h"
 
-/* TODO: get these values from the command line */
-#define TRUSTED_WORLD_NVCTR_VALUE	0
-#define NORMAL_WORLD_NVCTR_VALUE	0
-
 static ext_t tbb_ext[] = {
 	[TRUSTED_FW_NVCOUNTER_EXT] = {
 		.oid = TRUSTED_FW_NVCOUNTER_OID,

--- a/tools/fiptool/tbbr_config.h
+++ b/tools/fiptool/tbbr_config.h
@@ -11,7 +11,6 @@
 
 #include <uuid.h>
 
-/* TODO: Update this number as required */
 #define TOC_HEADER_SERIAL_NUMBER 0x12345678
 
 typedef struct toc_entry {


### PR DESCRIPTION
Removes some TODO comments in the cases where the TODO is outdated or no longer relevant. In one patch a pair of #defines that are associated with a TODO are also removed.