### PR TITLE
Fix extra compilation warnings

### DIFF
--- a/bl1/bl1_fwu.c
+++ b/bl1/bl1_fwu.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -105,7 +105,7 @@ register_t bl1_fwu_smc_handler(unsigned int smc_fid,
 #define FWU_MAX_SIMULTANEOUS_IMAGES	10
 #endif
 
-static int bl1_fwu_loaded_ids[FWU_MAX_SIMULTANEOUS_IMAGES] = {
+static unsigned int bl1_fwu_loaded_ids[FWU_MAX_SIMULTANEOUS_IMAGES] = {
 	[0 ... FWU_MAX_SIMULTANEOUS_IMAGES-1] = INVALID_IMAGE_ID
 };
 
@@ -113,7 +113,7 @@ static int bl1_fwu_loaded_ids[FWU_MAX_SIMULTANEOUS_IMAGES] = {
  * Adds an image_id to the bl1_fwu_loaded_ids array.
  * Returns 0 on success, 1 on error.
  */
-static int bl1_fwu_add_loaded_id(int image_id)
+static int bl1_fwu_add_loaded_id(unsigned int image_id)
 {
 	int i;
 
@@ -138,7 +138,7 @@ static int bl1_fwu_add_loaded_id(int image_id)
  * Removes an image_id from the bl1_fwu_loaded_ids array.
  * Returns 0 on success, 1 on error.
  */
-static int bl1_fwu_remove_loaded_id(int image_id)
+static int bl1_fwu_remove_loaded_id(unsigned int image_id)
 {
 	int i;
 
@@ -157,7 +157,7 @@ static int bl1_fwu_remove_loaded_id(int image_id)
  * This function checks if the specified image overlaps another image already
  * loaded. It returns 0 if there is no overlap, a negative error code otherwise.
  ******************************************************************************/
-static int bl1_fwu_image_check_overlaps(int image_id)
+static int bl1_fwu_image_check_overlaps(unsigned int image_id)
 {
 	const image_desc_t *image_desc, *checked_image_desc;
 	const image_info_t *info, *checked_info;

--- a/bl1/bl1_fwu.c
+++ b/bl1/bl1_fwu.c
@@ -52,9 +52,6 @@ __dead2 static void bl1_fwu_done(void *client_cookie, void *reserved);
  */
 static unsigned int sec_exec_image_id = INVALID_IMAGE_ID;
 
-/* Authentication status of each image. */
-extern unsigned int auth_img_flags[MAX_NUMBER_IDS];
-
 /*******************************************************************************
  * Top level handler for servicing FWU SMCs.
  ******************************************************************************/

--- a/drivers/arm/css/scmi/scmi_ap_core_proto.c
+++ b/drivers/arm/css/scmi/scmi_ap_core_proto.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -18,7 +18,8 @@
 int scmi_ap_core_set_reset_addr(void *p, uint64_t reset_addr, uint32_t attr)
 {
 	mailbox_mem_t *mbx_mem;
-	int token = 0, ret;
+	unsigned int token = 0;
+	int ret;
 	scmi_channel_t *ch = (scmi_channel_t *)p;
 
 	validate_scmi_channel(ch);
@@ -51,7 +52,8 @@ int scmi_ap_core_set_reset_addr(void *p, uint64_t reset_addr, uint32_t attr)
 int scmi_ap_core_get_reset_addr(void *p, uint64_t *reset_addr, uint32_t *attr)
 {
 	mailbox_mem_t *mbx_mem;
-	int token = 0, ret;
+	unsigned int token = 0;
+	int ret;
 	scmi_channel_t *ch = (scmi_channel_t *)p;
 	uint32_t lo_addr, hi_addr;
 

--- a/drivers/arm/css/scmi/scmi_common.c
+++ b/drivers/arm/css/scmi/scmi_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -90,7 +90,8 @@ void scmi_put_channel(scmi_channel_t *ch)
 int scmi_proto_version(void *p, uint32_t proto_id, uint32_t *version)
 {
 	mailbox_mem_t *mbx_mem;
-	int token = 0, ret;
+	unsigned int token = 0;
+	int ret;
 	scmi_channel_t *ch = (scmi_channel_t *)p;
 
 	validate_scmi_channel(ch);
@@ -122,7 +123,8 @@ int scmi_proto_msg_attr(void *p, uint32_t proto_id,
 		uint32_t command_id, uint32_t *attr)
 {
 	mailbox_mem_t *mbx_mem;
-	int token = 0, ret;
+	unsigned int token = 0;
+	int ret;
 	scmi_channel_t *ch = (scmi_channel_t *)p;
 
 	validate_scmi_channel(ch);

--- a/drivers/arm/css/scmi/scmi_pwr_dmn_proto.c
+++ b/drivers/arm/css/scmi/scmi_pwr_dmn_proto.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -19,7 +19,8 @@ int scmi_pwr_state_set(void *p, uint32_t domain_id,
 					uint32_t scmi_pwr_state)
 {
 	mailbox_mem_t *mbx_mem;
-	int token = 0, ret;
+	unsigned int token = 0;
+	int ret;
 
 	/*
 	 * Only asynchronous mode of `set power state` command is allowed on
@@ -59,7 +60,8 @@ int scmi_pwr_state_get(void *p, uint32_t domain_id,
 					uint32_t *scmi_pwr_state)
 {
 	mailbox_mem_t *mbx_mem;
-	int token = 0, ret;
+	unsigned int token = 0;
+	int ret;
 	scmi_channel_t *ch = (scmi_channel_t *)p;
 
 	validate_scmi_channel(ch);

--- a/drivers/arm/css/scmi/scmi_sys_pwr_proto.c
+++ b/drivers/arm/css/scmi/scmi_sys_pwr_proto.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -18,7 +18,8 @@
 int scmi_sys_pwr_state_set(void *p, uint32_t flags, uint32_t system_state)
 {
 	mailbox_mem_t *mbx_mem;
-	int token = 0, ret;
+	unsigned int token = 0;
+	int ret;
 	scmi_channel_t *ch = (scmi_channel_t *)p;
 
 	validate_scmi_channel(ch);
@@ -50,7 +51,8 @@ int scmi_sys_pwr_state_set(void *p, uint32_t flags, uint32_t system_state)
 int scmi_sys_pwr_state_get(void *p, uint32_t *system_state)
 {
 	mailbox_mem_t *mbx_mem;
-	int token = 0, ret;
+	unsigned int token = 0;
+	int ret;
 	scmi_channel_t *ch = (scmi_channel_t *)p;
 
 	validate_scmi_channel(ch);

--- a/drivers/arm/css/scp/css_pm_scmi.c
+++ b/drivers/arm/css/scp/css_pm_scmi.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -99,7 +99,7 @@ void css_scp_suspend(const struct psci_power_state *target_state)
 		return;
 	}
 #if !HW_ASSISTED_COHERENCY
-	int lvl;
+	unsigned int lvl;
 	uint32_t scmi_pwr_state = 0;
 	/*
 	 * If we reach here, then assert that power down at system power domain
@@ -145,7 +145,8 @@ void css_scp_suspend(const struct psci_power_state *target_state)
  */
 void css_scp_off(const struct psci_power_state *target_state)
 {
-	int lvl = 0, ret;
+	unsigned int lvl = 0;
+	int ret;
 	uint32_t scmi_pwr_state = 0;
 
 	/* At-least the CPU level should be specified to be OFF */
@@ -184,7 +185,8 @@ void css_scp_off(const struct psci_power_state *target_state)
  */
 void css_scp_on(u_register_t mpidr)
 {
-	int lvl = 0, ret, core_pos;
+	unsigned int lvl = 0;
+	int ret, core_pos;
 	uint32_t scmi_pwr_state = 0;
 
 	for (; lvl <= PLAT_MAX_PWR_LVL; lvl++)

--- a/drivers/arm/sp804/sp804_delay_timer.c
+++ b/drivers/arm/sp804/sp804_delay_timer.c
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <assert.h>
 
+#include <drivers/arm/sp804_delay_timer.h>
 #include <drivers/delay_timer.h>
 #include <lib/mmio.h>
 

--- a/drivers/auth/auth_mod.c
+++ b/drivers/auth/auth_mod.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -29,10 +29,6 @@
 	} while (0)
 
 #pragma weak plat_set_nv_ctr2
-
-/* Pointer to CoT */
-extern const auth_img_desc_t *const cot_desc_ptr;
-extern unsigned int auth_img_flags[MAX_NUMBER_IDS];
 
 static int cmp_auth_param_type_desc(const auth_param_type_desc_t *a,
 		const auth_param_type_desc_t *b)

--- a/drivers/console/multi_console.c
+++ b/drivers/console/multi_console.c
@@ -13,11 +13,11 @@
 console_t *console_list;
 uint8_t console_state = CONSOLE_FLAG_BOOT;
 
+IMPORT_SYM(console_t *, __STACKS_START__, stacks_start)
+IMPORT_SYM(console_t *, __STACKS_END__, stacks_end)
+
 int console_register(console_t *console)
 {
-	IMPORT_SYM(console_t *, __STACKS_START__, stacks_start)
-	IMPORT_SYM(console_t *, __STACKS_END__, stacks_end)
-
 	/* Assert that the struct is not on the stack (common mistake). */
 	assert((console < stacks_start) || (console >= stacks_end));
 	/* Assert that we won't make a circle in the list. */

--- a/drivers/io/io_fip.c
+++ b/drivers/io/io_fip.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -48,7 +48,7 @@ typedef struct {
 	uintptr_t dev_spec;
 } fip_dev_state_t;
 
-static const uuid_t uuid_null = { {0} };
+static const uuid_t uuid_null;
 /*
  * Only one file can be open across all FIP device
  * as backends like io_memmap don't support

--- a/include/drivers/arm/css/scmi.h
+++ b/include/drivers/arm/css/scmi.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -162,7 +162,7 @@ int scmi_ap_core_set_reset_addr(void *p, uint64_t reset_addr, uint32_t attr);
 int scmi_ap_core_get_reset_addr(void *p, uint64_t *reset_addr, uint32_t *attr);
 
 /* API to get the platform specific SCMI channel information. */
-scmi_channel_plat_info_t *plat_css_get_scmi_info();
+scmi_channel_plat_info_t *plat_css_get_scmi_info(void);
 
 /* API to override default PSCI callbacks for platforms that support SCMI. */
 const plat_psci_ops_t *css_scmi_override_pm_ops(plat_psci_ops_t *ops);

--- a/include/drivers/console.h
+++ b/include/drivers/console.h
@@ -49,11 +49,12 @@ typedef struct console {
 #include <drivers/console_assertions.h>
 
 /*
- * NOTE: There is no publicly accessible console_register() function. Consoles
- * are registered by directly calling the register function of a specific
- * implementation, e.g. console_16550_register() from <uart_16550.h>. Consoles
- * registered that way can be unregistered/reconfigured with below functions.
+ * Add a console_t instance to the console list. This should only be called by
+ * console drivers after they have initialized all fields in the console
+ * structure. Platforms seeking to register a new console need to call the
+ * respective console__register() function instead.
  */
+int console_register(console_t *console);
 /* Remove a single console_t instance from the console list. Return a pointer to
  * the console that was removed if it was found, or NULL if not. */
 console_t *console_unregister(console_t *console);

--- a/include/plat/arm/common/plat_arm.h
+++ b/include/plat/arm/common/plat_arm.h
@@ -187,6 +187,7 @@ void arm_bl2_platform_setup(void);
 void arm_bl2_plat_arch_setup(void);
 uint32_t arm_get_spsr_for_bl32_entry(void);
 uint32_t arm_get_spsr_for_bl33_entry(void);
+int arm_bl2_plat_handle_post_image_load(unsigned int image_id);
 int arm_bl2_handle_post_image_load(unsigned int image_id);
 struct bl_params *arm_get_next_bl_params(void);
 

--- a/lib/libc/memchr.c
+++ b/lib/libc/memchr.c
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <stddef.h>
+#include <string.h>
 
 void *memchr(const void *src, int c, size_t len)
 {

--- a/lib/libc/memcmp.c
+++ b/lib/libc/memcmp.c
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <stddef.h>
+#include <string.h>
 
 int memcmp(const void *s1, const void *s2, size_t len)
 {

--- a/lib/libc/memcpy.c
+++ b/lib/libc/memcpy.c
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <stddef.h>
+#include <string.h>
 
 void *memcpy(void *dst, const void *src, size_t len)
 {

--- a/lib/libc/memset.c
+++ b/lib/libc/memset.c
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2013-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <stddef.h>
+#include <string.h>
 
 void *memset(void *dst, int val, size_t count)
 {

--- a/lib/semihosting/semihosting.c
+++ b/lib/semihosting/semihosting.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -160,7 +160,7 @@ long semihosting_system(char *command_line)
 long semihosting_get_flen(const char *file_name)
 {
 	long file_handle;
-	size_t length;
+	long length;
 
 	assert(semihosting_connection_supported());
 

--- a/plat/arm/board/fvp/fvp_pm.c
+++ b/plat/arm/board/fvp/fvp_pm.c
@@ -20,6 +20,7 @@
 #include <platform_def.h>
 
 #include "fvp_private.h"
+#include "../drivers/arm/gic/v3/gicv3_private.h"
 
 
 #if ARM_RECOM_STATE_ID_ENC

--- a/plat/arm/board/fvp/fvp_private.h
+++ b/plat/arm/board/fvp/fvp_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -19,6 +19,5 @@ void fvp_interconnect_init(void);
 void fvp_interconnect_enable(void);
 void fvp_interconnect_disable(void);
 void tsp_early_platform_setup(void);
-
 
 #endif /* FVP_PRIVATE_H */

--- a/plat/arm/board/juno/juno_bl1_setup.c
+++ b/plat/arm/board/juno/juno_bl1_setup.c
@@ -61,7 +61,7 @@ static int is_watchdog_reset(void)
  ******************************************************************************/
 int plat_arm_bl1_fwu_needed(void)
 {
-	const uint32_t *nv_flags_ptr = (const uint32_t *)V2M_SYS_NVFLAGS_ADDR;
+	const int32_t *nv_flags_ptr = (const int32_t *)V2M_SYS_NVFLAGS_ADDR;
 
 	/* Check if TOC is invalid or watchdog reset happened. */
 	if ((arm_io_is_toc_valid() != 1) ||

--- a/plat/arm/board/juno/juno_err.c
+++ b/plat/arm/board/juno/juno_err.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -7,6 +7,7 @@
 #include <errno.h>
 
 #include <arch_helpers.h>
+#include <plat/arm/common/plat_arm.h>
 #include <plat/common/platform.h>
 #include <platform_def.h>
 

--- a/plat/arm/board/juno/juno_topology.c
+++ b/plat/arm/board/juno/juno_topology.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -20,7 +20,7 @@ static scmi_channel_plat_info_t juno_scmi_plat_info = {
 		.ring_doorbell = &mhu_ring_doorbell,
 };
 
-scmi_channel_plat_info_t *plat_css_get_scmi_info()
+scmi_channel_plat_info_t *plat_css_get_scmi_info(void)
 {
 	return &juno_scmi_plat_info;
 }

--- a/plat/arm/board/sgi575/sgi575_plat.c
+++ b/plat/arm/board/sgi575/sgi575_plat.c
@@ -1,10 +1,12 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <plat/common/platform.h>
+
+#include <sgi_variant.h>
 
 unsigned int plat_arm_sgi_get_platform_id(void)
 {

--- a/plat/arm/board/sgi575/sgi575_security.c
+++ b/plat/arm/board/sgi575/sgi575_security.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -8,6 +8,7 @@
 
 #include <common/debug.h>
 #include <drivers/arm/tzc_dmc620.h>
+#include <plat/arm/common/plat_arm.h>
 
 uintptr_t sgi575_dmc_base[] = {
 	SGI575_DMC620_BASE0,

--- a/plat/arm/css/sgi/sgi_bl31_setup.c
+++ b/plat/arm/css/sgi/sgi_bl31_setup.c
@@ -13,6 +13,7 @@
 #include <drivers/arm/css/css_mhu_doorbell.h>
 #include <drivers/arm/css/scmi.h>
 #include <plat/arm/common/plat_arm.h>
+#include <plat/common/platform.h>
 
 #include <sgi_ras.h>
 #include <sgi_variant.h>
@@ -35,7 +36,7 @@ static scmi_channel_plat_info_t rd_n1e1_edge_scmi_plat_info = {
 		.ring_doorbell = &mhuv2_ring_doorbell,
 };
 
-scmi_channel_plat_info_t *plat_css_get_scmi_info()
+scmi_channel_plat_info_t *plat_css_get_scmi_info(void)
 {
 	if (sgi_plat_info.platform_id == RD_N1E1_EDGE_SID_VER_PART_NUM)
 		return &rd_n1e1_edge_scmi_plat_info;
@@ -43,7 +44,7 @@ scmi_channel_plat_info_t *plat_css_get_scmi_info()
 		return &sgi575_scmi_plat_info;
 	else
 		panic();
-};
+}
 
 void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 				u_register_t arg2, u_register_t arg3)

--- a/plat/arm/css/sgi/sgi_interconnect.c
+++ b/plat/arm/css/sgi/sgi_interconnect.c
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
 #include <arch_helpers.h>
 #include <common/debug.h>
+#include <plat/arm/common/plat_arm.h>
 
 /*
  * For SGI575 which support FCM (with automatic interconnect enter/exit),

--- a/plat/arm/css/sgi/sgi_topology.c
+++ b/plat/arm/css/sgi/sgi_topology.c
@@ -5,6 +5,7 @@
  */
 
 #include <plat/arm/common/plat_arm.h>
+#include <plat/common/platform.h>
 
 #include <sgi_variant.h>
 

--- a/plat/common/plat_spm_rd.c
+++ b/plat/common/plat_spm_rd.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Arm Limited. All rights reserved.
+ * Copyright (c) 2018-2019, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -14,6 +14,7 @@
 #include <common/debug.h>
 #include <common/fdt_wrappers.h>
 #include <lib/object_pool.h>
+#include <plat/common/platform.h>
 #include <services/sp_res_desc.h>
 
 /*******************************************************************************

--- a/plat/common/plat_spm_sp.c
+++ b/plat/common/plat_spm_sp.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Arm Limited. All rights reserved.
+ * Copyright (c) 2018-2019, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -9,6 +9,7 @@
 #include <platform_def.h>
 
 #include <common/debug.h>
+#include <plat/common/platform.h>
 #include <tools_share/sptool.h>
 
 static unsigned int sp_next;

--- a/services/std_svc/spm/spci.c
+++ b/services/std_svc/spm/spci.c
@@ -380,6 +380,41 @@ static uint64_t spci_service_request_blocking(void *handle,
 }
 
 /*******************************************************************************
+ * This function handles the returned values from the Secure Partition.
+ ******************************************************************************/
+static void spci_handle_returned_values(const cpu_context_t *cpu_ctx,
+					uint64_t ret)
+{
+	if (ret == SPRT_PUT_RESPONSE_AARCH64) {
+		uint32_t token;
+		uint64_t x3, x4, x5, x6;
+
+		token = read_ctx_reg(get_gpregs_ctx(cpu_ctx), CTX_GPREG_X1);
+		x3 = read_ctx_reg(get_gpregs_ctx(cpu_ctx), CTX_GPREG_X3);
+		x4 = read_ctx_reg(get_gpregs_ctx(cpu_ctx), CTX_GPREG_X4);
+		x5 = read_ctx_reg(get_gpregs_ctx(cpu_ctx), CTX_GPREG_X5);
+		x6 = read_ctx_reg(get_gpregs_ctx(cpu_ctx), CTX_GPREG_X6);
+
+		uint16_t client_id = x6 & 0xFFFFU;
+		uint16_t service_handle = x6 >> 16;
+
+		int rc = spm_response_add(client_id, service_handle, token,
+					  x3, x4, x5);
+		if (rc != 0) {
+			/*
+			 * This is error fatal because we can't return to the SP
+			 * from this SMC. The SP has crashed.
+			 */
+			panic();
+		}
+	} else if ((ret != SPRT_YIELD_AARCH64) &&
+		   (ret != SPM_SECURE_PARTITION_PREEMPTED)) {
+		ERROR("SPM: %s: Unexpected x0 value 0x%llx\n", __func__, ret);
+		panic();
+	}
+}
+
+/*******************************************************************************
  * This function requests a Secure Service from a given handle and client ID.
  ******************************************************************************/
 static uint64_t spci_service_request_start(void *handle,
@@ -465,34 +500,8 @@ static uint64_t spci_service_request_start(void *handle,
 	/* Jump to the Secure Partition. */
 	uint64_t ret = spm_sp_synchronous_entry(sp_ctx, 1);
 
-	/* Verify returned values */
-	if (ret == SPRT_PUT_RESPONSE_AARCH64) {
-		uint32_t token;
-		uint64_t rx1, rx2, rx3, x6;
-
-		token = read_ctx_reg(get_gpregs_ctx(cpu_ctx), CTX_GPREG_X1);
-		rx1 = read_ctx_reg(get_gpregs_ctx(cpu_ctx), CTX_GPREG_X3);
-		rx2 = read_ctx_reg(get_gpregs_ctx(cpu_ctx), CTX_GPREG_X4);
-		rx3 = read_ctx_reg(get_gpregs_ctx(cpu_ctx), CTX_GPREG_X5);
-		x6 = read_ctx_reg(get_gpregs_ctx(cpu_ctx), CTX_GPREG_X6);
-
-		uint16_t client_id = x6 & 0xFFFFU;
-		uint16_t service_handle = x6 >> 16;
-
-		int rc = spm_response_add(client_id, service_handle, token,
-					  rx1, rx2, rx3);
-		if (rc != 0) {
-			/*
-			 * This is error fatal because we can't return to the SP
-			 * from this SMC. The SP has crashed.
-			 */
-			panic();
-		}
-	} else if ((ret != SPRT_YIELD_AARCH64) &&
-		   (ret != SPM_SECURE_PARTITION_PREEMPTED)) {
-		ERROR("SPM: %s: Unexpected x0 value 0x%llx\n", __func__, ret);
-		panic();
-	}
+	/* Handle returned values */
+	spci_handle_returned_values(cpu_ctx, ret);
 
 	/* Flag Secure Partition as idle. */
 	assert(sp_ctx->state == SP_STATE_BUSY);
@@ -572,34 +581,8 @@ static uint64_t spci_service_request_resume(void *handle, u_register_t x1,
 	/* Jump to the Secure Partition. */
 	uint64_t ret = spm_sp_synchronous_entry(sp_ctx, 1);
 
-	/* Verify returned values */
-	if (ret == SPRT_PUT_RESPONSE_AARCH64) {
-		uint32_t token;
-		uint64_t rx1, rx2, rx3, x6;
-
-		token = read_ctx_reg(get_gpregs_ctx(cpu_ctx), CTX_GPREG_X1);
-		rx1 = read_ctx_reg(get_gpregs_ctx(cpu_ctx), CTX_GPREG_X3);
-		rx2 = read_ctx_reg(get_gpregs_ctx(cpu_ctx), CTX_GPREG_X4);
-		rx3 = read_ctx_reg(get_gpregs_ctx(cpu_ctx), CTX_GPREG_X5);
-		x6 = read_ctx_reg(get_gpregs_ctx(cpu_ctx), CTX_GPREG_X6);
-
-		uint16_t client_id = x6 & 0xFFFFU;
-		uint16_t service_handle = x6 >> 16;
-
-		int rc = spm_response_add(client_id, service_handle, token,
-					  rx1, rx2, rx3);
-		if (rc != 0) {
-			/*
-			 * This is error fatal because we can't return to the SP
-			 * from this SMC. The SP has crashed.
-			 */
-			panic();
-		}
-	} else if ((ret != SPRT_YIELD_AARCH64) &&
-		   (ret != SPM_SECURE_PARTITION_PREEMPTED)) {
-		ERROR("SPM: %s: Unexpected x0 value 0x%llx\n", __func__, ret);
-		panic();
-	}
+	/* Handle returned values */
+	spci_handle_returned_values(cpu_ctx, ret);
 
 	/* Flag Secure Partition as idle. */
 	assert(sp_ctx->state == SP_STATE_BUSY);

--- a/services/std_svc/spm/spm_buffers.c
+++ b/services/std_svc/spm/spm_buffers.c
@@ -42,7 +42,7 @@ int spm_response_add(uint16_t client_id, uint16_t handle, uint32_t token,
 		}
 	}
 
-	for (int i = 0; i < ARRAY_SIZE(responses); i++) {
+	for (unsigned int i = 0U; i < ARRAY_SIZE(responses); i++) {
 		struct sprt_response *resp = &(responses[i]);
 
 		if (resp->is_valid == 0) {

--- a/services/std_svc/spm/spm_buffers.c
+++ b/services/std_svc/spm/spm_buffers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Arm Limited. All rights reserved.
+ * Copyright (c) 2018-2019, Arm Limited. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -8,6 +8,8 @@
 #include <lib/spinlock.h>
 #include <lib/utils_def.h>
 #include <platform_def.h>
+
+#include "./spm_private.h"
 
 /*******************************************************************************
  * Secure Service response global array. All the responses to the requests done

--- a/services/std_svc/spm/spm_main.c
+++ b/services/std_svc/spm/spm_main.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -20,6 +20,7 @@
 #include <lib/utils.h>
 #include <lib/xlat_tables/xlat_tables_v2.h>
 #include <plat/common/platform.h>
+#include <services/spm_svc.h>
 #include <services/sprt_svc.h>
 #include <smccc_helpers.h>
 


### PR DESCRIPTION
Fix some warnings when compiling the ARM reference platform with extra compiler warning flags enabled (W={1,2,3} in the makefile).