### PR TITLE
Apply variant 4 mitigation for Neoverse N1

### DIFF
--- a/include/arch/aarch64/arch.h
+++ b/include/arch/aarch64/arch.h
@@ -843,4 +843,9 @@
 #define DIT			S3_3_C4_C2_5
 #define DIT_BIT			BIT(24)
 
+/*******************************************************************************
+ * Armv8.5 - new MSR encoding to directly access PSTATE.SSBS field
+ ******************************************************************************/
+#define SSBS			S3_3_C4_C2_6
+
 #endif /* ARCH_H */

--- a/lib/cpus/aarch64/neoverse_n1.S
+++ b/lib/cpus/aarch64/neoverse_n1.S
@@ -46,6 +46,10 @@ endfunc check_errata_1043202
 
 func neoverse_n1_reset_func
 	mov	x19, x30
+
+	/* Disables speculative loads */
+	msr	SSBS, xzr
+
 	bl	cpu_get_rev_var
 	mov	x18, x0
 


### PR DESCRIPTION
This patch applies the new MSR instruction to directly set the
PSTATE.SSBS bit which controls speculative loads. This new instruction
is available on Neoverse N1 core so it's utilised.

Change-Id: Iee18a8b042c90fdb72d2b98f364dcfbb17510728
Signed-off-by: John Tsichritzis <john.tsichritzis@arm.com>