### PR TITLE
fvp: Increase the size of the stack for FVP

### DIFF
--- a/plat/arm/board/fvp/include/platform_def.h
+++ b/plat/arm/board/fvp/include/platform_def.h
@@ -146,13 +146,7 @@
 #elif defined(IMAGE_BL2U)
 # define PLATFORM_STACK_SIZE		UL(0x400)
 #elif defined(IMAGE_BL31)
-# if ENABLE_SPM
-#  define PLATFORM_STACK_SIZE		UL(0x600)
-# elif PLAT_XLAT_TABLES_DYNAMIC
 #  define PLATFORM_STACK_SIZE		UL(0x800)
-# else
-#  define PLATFORM_STACK_SIZE		UL(0x400)
-# endif
 #elif defined(IMAGE_BL32)
 # define PLATFORM_STACK_SIZE		UL(0x440)
 #endif


### PR DESCRIPTION
When RECLAIM_INIT_CODE is 1, the stack is used to contain the .text.init
section. This is by default enable on FVP. Due to the size increase of
the .text.init section, the stack had to be adjusted contain it.

Change-Id: Ia392341970fb86c0426cf2229b1a7295453e2e32
Signed-off-by: Louis Mayencourt <louis.mayencourt@arm.com>