### PR TITLE
Pointer authentication fixes

### DIFF
--- a/lib/el3_runtime/aarch64/context.S
+++ b/lib/el3_runtime/aarch64/context.S
@@ -356,7 +356,7 @@ func pauth_context_restore
 	msr	APIAKeyLo_EL1, x9
 	msr	APIAKeyHi_EL1, x10
 
-	ldp	x9, x10, [x11, #CTX_PACIAKEY_LO]
+	ldp	x9, x10, [x11, #CTX_PACIBKEY_LO]
 	msr	APIBKeyLo_EL1, x9
 	msr	APIBKeyHi_EL1, x10
 

--- a/plat/arm/common/aarch64/arm_pauth.c
+++ b/plat/arm/common/aarch64/arm_pauth.c
@@ -9,11 +9,9 @@
 
 /*
  * Instruction pointer authentication key A. The low 64-bit are at [0], and the
- * high bits at [1]. They are run-time constants so they are placed in the
- * rodata section. They are written before MMU is turned on and the permissions
- * are effective.
+ * high bits at [1].
  */
-uint64_t plat_apiakey[2] __section("rodata.apiakey");
+uint64_t plat_apiakey[2];
 
 /*
  * This is only a toy implementation to generate a seemingly random 128-bit key


### PR DESCRIPTION
- Fix restoring APIBKey registers
- Put Pointer Authentication key value in BSS section
