### PR TITLE
ROMLIB bug fixes

### DIFF
--- a/docs/romlib-design.rst
+++ b/docs/romlib-design.rst
@@ -85,12 +85,12 @@ ROM" to work:
 1. ``gentbl.sh`` - Generates the jump table by parsing the index file.
 
 2. ``genvar.sh`` - Generates the jump table global variable (**not** the jump
-table itself) with the absolute address in ROM. This global variable is,
-basically, a pointer to the jump table.
+   table itself) with the absolute address in ROM. This global variable is,
+   basically, a pointer to the jump table.
 
 3. ``genwrappers.sh`` - Generates a wrapper function for each entry in the index
-file except for the ones that contain the keyword ``patch``. The generated
-wrapper file is called ``<lib>_<fn_name>.S``.
+   file except for the ones that contain the keyword ``patch``. The generated
+   wrapper file is called ``<lib>_<fn_name>.S``.
 
 Patching of functions in library at ROM
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -108,6 +108,8 @@ Build library at ROM
 ~~~~~~~~~~~~~~~~~~~~~
 
 The environment variable ``CROSS_COMPILE`` must be set as per the user guide.
+In the below example the usage of ROMLIB together with mbed TLS is demonstrated
+to showcase the benefits of library at ROM - it's not mandatory.
 
 ::
 
@@ -119,6 +121,12 @@ The environment variable ``CROSS_COMPILE`` must be set as per the user guide.
     BL33=</path/to/bl33.bin>                                        \
     USE_ROMLIB=1                                                    \
     all fip
+
+Known issue
+-----------
+When building library at ROM, a clean build is always required. This is
+necessary when changes are made to the index files, e.g. adding new functions,
+patching existing ones etc.
 
 --------------
 

--- a/lib/romlib/Makefile
+++ b/lib/romlib/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -58,18 +58,15 @@ $(WRAPPER_DIR)/jmpvar.s: $(BUILD_DIR)/romlib.elf
 	@echo "  VAR     $@"
 	$(Q)./genvar.sh -o $@ $(BUILD_DIR)/romlib.elf
 
-$(LIB_DIR)/libwrappers.a: jmptbl.i $(WRAPPER_DIR)/jmpvar.o
+$(LIB_DIR)/libwrappers.a: $(BUILD_DIR)/jmptbl.i $(WRAPPER_DIR)/jmpvar.o
 	@echo "  AR      $@"
 	$(Q)./genwrappers.sh -b $(WRAPPER_DIR) -o $@ $(BUILD_DIR)/jmptbl.i
 
-$(BUILD_DIR)/jmptbl.s: jmptbl.i
+$(BUILD_DIR)/jmptbl.i: $(BUILD_DIR)/jmptbl.s
+
+$(BUILD_DIR)/jmptbl.s: ../../$(PLAT_DIR)/jmptbl.i
 	@echo "  TBL     $@"
-	if [ -e "../../$(PLAT_DIR)/jmptbl.i" ] ; \
-	then \
-		$(Q)./gentbl.sh -o $@ -b $(BUILD_DIR) ../../$(PLAT_DIR)/jmptbl.i; \
-	else \
-		@echo "USE_ROMLIB=1 requires jump table list file: jmptbl.i in platform directory"; \
-	fi
+	$(Q)./gentbl.sh -o $@ -b $(BUILD_DIR) ../../$(PLAT_DIR)/jmptbl.i
 
 clean:
 	@rm -f $(BUILD_DIR)/*

--- a/lib/romlib/genwrappers.sh
+++ b/lib/romlib/genwrappers.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
@@ -31,7 +31,7 @@ do
 done
 
 awk  '{sub(/[:blank:]*#.*/,"")}
-!/^$/ && !/\\tpatch$/ !/\\treserved$/ {print $1*4, $2, $3}' "$@" |
+!/^$/ && $NF != "patch" && $NF != "reserved" {print $1*4, $2, $3}' "$@" |
 while read idx lib sym
 do
 	file=$build/${lib}_$sym
@@ -41,7 +41,7 @@ do
 $sym:
 	ldr	x17, =jmptbl
 	ldr	x17, [x17]
-	mov	x16, $idx
+	mov	x16, #$idx
 	add	x16, x16, x17
 	br	x16
 EOF

--- a/plat/arm/board/fvp/jmptbl.i
+++ b/plat/arm/board/fvp/jmptbl.i
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -14,4 +14,32 @@
 # rom	rom_lib_init
 # fdt	fdt_getprop_namelen	patch
 
-include ../../lib/romlib/jmptbl.i
+rom     rom_lib_init
+fdt     fdt_getprop_namelen
+fdt     fdt_setprop_inplace
+fdt     fdt_check_header
+fdt     fdt_node_offset_by_compatible
+mbedtls mbedtls_asn1_get_alg
+mbedtls mbedtls_asn1_get_alg_null
+mbedtls mbedtls_asn1_get_bitstring_null
+mbedtls mbedtls_asn1_get_bool
+mbedtls mbedtls_asn1_get_int
+mbedtls mbedtls_asn1_get_tag
+mbedtls mbedtls_free
+mbedtls mbedtls_md
+mbedtls mbedtls_md_get_size
+mbedtls mbedtls_memory_buffer_alloc_init
+mbedtls mbedtls_oid_get_md_alg
+mbedtls mbedtls_oid_get_numeric_string
+mbedtls mbedtls_oid_get_pk_alg
+mbedtls mbedtls_oid_get_sig_alg
+mbedtls mbedtls_pk_free
+mbedtls mbedtls_pk_init
+mbedtls mbedtls_pk_parse_subpubkey
+mbedtls mbedtls_pk_verify_ext
+mbedtls mbedtls_platform_set_snprintf
+mbedtls mbedtls_x509_get_rsassa_pss_params
+mbedtls mbedtls_x509_get_sig_alg
+mbedtls mbedtls_md_info_from_type
+c       exit
+c       atexit

--- a/plat/arm/board/juno/jmptbl.i
+++ b/plat/arm/board/juno/jmptbl.i
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
@@ -14,4 +14,32 @@
 # rom	rom_lib_init
 # fdt	fdt_getprop_namelen	patch
 
-include ../../lib/romlib/jmptbl.i
+rom     rom_lib_init
+fdt     fdt_getprop_namelen
+fdt     fdt_setprop_inplace
+fdt     fdt_check_header
+fdt     fdt_node_offset_by_compatible
+mbedtls mbedtls_asn1_get_alg
+mbedtls mbedtls_asn1_get_alg_null
+mbedtls mbedtls_asn1_get_bitstring_null
+mbedtls mbedtls_asn1_get_bool
+mbedtls mbedtls_asn1_get_int
+mbedtls mbedtls_asn1_get_tag
+mbedtls mbedtls_free
+mbedtls mbedtls_md
+mbedtls mbedtls_md_get_size
+mbedtls mbedtls_memory_buffer_alloc_init
+mbedtls mbedtls_oid_get_md_alg
+mbedtls mbedtls_oid_get_numeric_string
+mbedtls mbedtls_oid_get_pk_alg
+mbedtls mbedtls_oid_get_sig_alg
+mbedtls mbedtls_pk_free
+mbedtls mbedtls_pk_init
+mbedtls mbedtls_pk_parse_subpubkey
+mbedtls mbedtls_pk_verify_ext
+mbedtls mbedtls_platform_set_snprintf
+mbedtls mbedtls_x509_get_rsassa_pss_params
+mbedtls mbedtls_x509_get_sig_alg
+mbedtls mbedtls_md_info_from_type
+c       exit
+c       atexit


### PR DESCRIPTION
Fixed the below bugs:
1) Bug related to build flag V=1: if the flag is V=0, building with
ROMLIB fails.
2) Due to a syntax bug in genwrappers.sh, index file entries marked as
"patch" or "reserved" were ignored.
3) Added a prepending hash to constants that genwrappers.sh is generating.
4) Due to broken dependencies, currently the inclusion functionality is
intentionally not utilised. This is why the contents of romlib/jmptbl.i
have been copied to platform specific jmptbl.i files. As a result of the
broken dependencies, when changing the index files (e.g. when patching
functions) a clean build is always required. This is a known issue that
will be fixed in the future.

Change-Id: I9d92aa9724e86d8f90fcd3e9f66a27aa3cab7aaa
Signed-off-by: John Tsichritzis <john.tsichritzis@arm.com>