### PR TITLE
driver: synosys: Fix SD MMC not initializing correctly

### DIFF
--- a/drivers/synopsys/emmc/dw_mmc.c
+++ b/drivers/synopsys/emmc/dw_mmc.c
@@ -426,8 +426,7 @@ void dw_mmc_init(dw_mmc_params_t *params, struct mmc_device_info *info)
 
 	memcpy(&dw_params, params, sizeof(dw_mmc_params_t));
 	mmio_write_32(dw_params.reg_base + DWMMC_FIFOTH, 0x103ff);
+	dw_params.mmc_dev_type = info->mmc_dev_type;
 	mmc_init(&dw_mmc_ops, params->clk_rate, params->bus_width,
 		 params->flags, info);
-
-	dw_params.mmc_dev_type = info->mmc_dev_type;
 }


### PR DESCRIPTION
dw_params.mmc_dev_type should be assigned before mmc_init, otherwise SDMMC
initialization will fail as the initialization treats the device as EMMC
instead of SD.

Signed-off-by: Tien Hock, Loh <tien.hock.loh@intel.com>