### PR TITLE
PIE: Fix reloc at the beginning of bl31 entrypoint

### DIFF
--- a/bl31/aarch64/bl31_entrypoint.S
+++ b/bl31/aarch64/bl31_entrypoint.S
@@ -23,7 +23,6 @@
 	 */
 
 func bl31_entrypoint
-#if !RESET_TO_BL31
 	/* ---------------------------------------------------------------
 	 * Stash the previous bootloader arguments x0 - x3 for later use.
 	 * ---------------------------------------------------------------
@@ -33,6 +32,18 @@ func bl31_entrypoint
 	mov	x22, x2
 	mov	x23, x3
 
+	/* --------------------------------------------------------------------
+	 * If PIE is enabled, fixup the Global descriptor Table and dynamic
+	 * relocations
+	 * --------------------------------------------------------------------
+	 */
+#if ENABLE_PIE
+	mov_imm	x0, BL31_BASE
+	mov_imm	x1, BL31_LIMIT
+	bl	fixup_gdt_reloc
+#endif /* ENABLE_PIE */
+
+#if !RESET_TO_BL31
 	/* ---------------------------------------------------------------------
 	 * For !RESET_TO_BL31 systems, only the primary CPU ever reaches
 	 * bl31_entrypoint() during the cold boot flow, so the cold/warm boot
@@ -50,6 +61,7 @@ func bl31_entrypoint
 		_init_c_runtime=1				\
 		_exception_vectors=runtime_exceptions
 #else
+
 	/* ---------------------------------------------------------------------
 	 * For RESET_TO_BL31 systems which have a programmable reset address,
 	 * bl31_entrypoint() is executed only on the cold boot path so we can
@@ -75,17 +87,6 @@ func bl31_entrypoint
 	mov	x22, 0
 	mov	x23, 0
 #endif /* RESET_TO_BL31 */
-
-	/* --------------------------------------------------------------------
-	 * If PIE is enabled, fixup the Global descriptor Table and dynamic
-	 * relocations
-	 * --------------------------------------------------------------------
-	 */
-#if ENABLE_PIE
-	mov_imm	x0, BL31_BASE
-	mov_imm	x1, BL31_LIMIT
-	bl	fixup_gdt_reloc
-#endif /* ENABLE_PIE */
 
 	/* --------------------------------------------------------------------
 	 * Perform BL31 setup


### PR DESCRIPTION
The relocation fixup code must be called at the beginning of bl31
entrypoint to ensure that CPU specific reset handlers are fixed up for
relocations.