### PR TITLE
doc: Suggest to use the latest version of GCC 8.2

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -56,11 +56,12 @@ Install the required packages to build TF-A with the following command:
 
 TF-A has been tested with Linaro Release 18.04.
 
-Download and install the AArch32 or AArch64 little-endian GCC cross compiler.
-The `Linaro Release Notes`_ documents which version of the compiler to use for a
-given Linaro Release. Also, these `Linaro instructions`_ provide further
-guidance and a script, which can be used to download Linaro deliverables
-automatically.
+Download and install the AArch32 or AArch64 little-endian GCC cross compiler. If
+you would like to use the latest features available, download GCC 8.2-2019.01
+compiler from `arm Developer page`_. Otherwise, the `Linaro Release Notes`_
+documents which version of the compiler to use for a given Linaro Release. Also,
+these `Linaro instructions`_ provide further guidance and a script, which can be
+used to download Linaro deliverables automatically.
 
 Optionally, TF-A can be built using clang version 4.0 or newer or Arm
 Compiler 6. See instructions below on how to switch the default compiler.
@@ -2092,6 +2093,7 @@ wakeup interrupt from RTC.
 
 *Copyright (c) 2013-2019, Arm Limited and Contributors. All rights reserved.*
 
+.. _arm Developer page: https://developer.arm.com/open-source/gnu-toolchain/gnu-a/downloads
 .. _Linaro: `Linaro Release Notes`_
 .. _Linaro Release: `Linaro Release Notes`_
 .. _Linaro Release Notes: https://community.arm.com/dev-platforms/w/docs/226/old-release-notes


### PR DESCRIPTION
The latest version of GCC are required to use the new features of TF-A.
Suggest to use the latest version available on developer.arm.com instead
of the version specified on the Linaro Release notes.
At the time of writing, GCC 8.2-2019.01 is the latest version available.