### PR TITLE
rcar_gen3: plat: Set M3W ULCB DRAM size to 2 GiB

### DIFF
--- a/plat/renesas/rcar/bl2_plat_setup.c
+++ b/plat/renesas/rcar/bl2_plat_setup.c
@@ -568,9 +568,15 @@ static void bl2_advertise_dram_size(uint32_t product)
 		break;
 
 	case RCAR_PRODUCT_M3:
+#if (RCAR_GEN3_ULCB == 1)
+		/* 2GB(1GBx2 2ch split) */
+		dram_config[1] = 0x40000000ULL;
+		dram_config[5] = 0x40000000ULL;
+#else
 		/* 4GB(2GBx2 2ch split) */
 		dram_config[1] = 0x80000000ULL;
 		dram_config[5] = 0x80000000ULL;
+#endif
 		break;
 
 	case RCAR_PRODUCT_M3N:


### PR DESCRIPTION
The M3W ULCB board has 2 GiB of DRAM, set it so.