### PR TITLE
SPM: Some improvements to xlat handling code

### DIFF
--- a/include/arch/aarch64/arch.h
+++ b/include/arch/aarch64/arch.h
@@ -433,6 +433,9 @@
 #define TCR_TxSZ_MAX		ULL(39)
 #define TCR_TxSZ_MAX_TTST	ULL(48)
 
+#define TCR_T0SZ_SHIFT		U(0)
+#define TCR_T1SZ_SHIFT		U(16)
+
 /* (internal) physical address size bits in EL3/EL1 */
 #define TCR_PS_BITS_4GB		ULL(0x0)
 #define TCR_PS_BITS_64GB	ULL(0x1)
@@ -462,11 +465,31 @@
 #define TCR_SH_OUTER_SHAREABLE	(ULL(0x2) << 12)
 #define TCR_SH_INNER_SHAREABLE	(ULL(0x3) << 12)
 
+#define TCR_RGN1_INNER_NC	(ULL(0x0) << 24)
+#define TCR_RGN1_INNER_WBA	(ULL(0x1) << 24)
+#define TCR_RGN1_INNER_WT	(ULL(0x2) << 24)
+#define TCR_RGN1_INNER_WBNA	(ULL(0x3) << 24)
+
+#define TCR_RGN1_OUTER_NC	(ULL(0x0) << 26)
+#define TCR_RGN1_OUTER_WBA	(ULL(0x1) << 26)
+#define TCR_RGN1_OUTER_WT	(ULL(0x2) << 26)
+#define TCR_RGN1_OUTER_WBNA	(ULL(0x3) << 26)
+
+#define TCR_SH1_NON_SHAREABLE	(ULL(0x0) << 28)
+#define TCR_SH1_OUTER_SHAREABLE	(ULL(0x2) << 28)
+#define TCR_SH1_INNER_SHAREABLE	(ULL(0x3) << 28)
+
 #define TCR_TG0_SHIFT		U(14)
 #define TCR_TG0_MASK		ULL(3)
 #define TCR_TG0_4K		(ULL(0) << TCR_TG0_SHIFT)
 #define TCR_TG0_64K		(ULL(1) << TCR_TG0_SHIFT)
 #define TCR_TG0_16K		(ULL(2) << TCR_TG0_SHIFT)
+
+#define TCR_TG1_SHIFT		U(30)
+#define TCR_TG1_MASK		ULL(3)
+#define TCR_TG1_16K		(ULL(1) << TCR_TG1_SHIFT)
+#define TCR_TG1_4K		(ULL(2) << TCR_TG1_SHIFT)
+#define TCR_TG1_64K		(ULL(3) << TCR_TG1_SHIFT)
 
 #define TCR_EPD0_BIT		(ULL(1) << 7)
 #define TCR_EPD1_BIT		(ULL(1) << 23)

--- a/lib/xlat_tables/aarch64/xlat_tables.c
+++ b/lib/xlat_tables/aarch64/xlat_tables.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2014-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -174,12 +174,12 @@ void init_xlat_tables(void)
 			/* Inner & outer non-cacheable non-shareable. */\
 			tcr = TCR_SH_NON_SHAREABLE |			\
 				TCR_RGN_OUTER_NC | TCR_RGN_INNER_NC |	\
-				(uint64_t) t0sz;			\
+				((uint64_t)t0sz << TCR_T0SZ_SHIFT);	\
 		} else {						\
 			/* Inner & outer WBWA & shareable. */		\
 			tcr = TCR_SH_INNER_SHAREABLE |			\
 				TCR_RGN_OUTER_WBA | TCR_RGN_INNER_WBA |	\
-				(uint64_t) t0sz;			\
+				((uint64_t)t0sz << TCR_T0SZ_SHIFT);	\
 		}							\
 		tcr |= _tcr_extra;					\
 		write_tcr_el##_el(tcr);					\

--- a/lib/xlat_tables_v2/aarch64/xlat_tables_arch.c
+++ b/lib/xlat_tables_v2/aarch64/xlat_tables_arch.c
@@ -248,7 +248,7 @@ void setup_mmu_cfg(uint64_t *params, unsigned int flags,
 	 */
 	int t0sz = 64 - __builtin_ctzll(virtual_addr_space_size);
 
-	tcr = (uint64_t) t0sz;
+	tcr = (uint64_t)t0sz << TCR_T0SZ_SHIFT;
 
 	/*
 	 * Set the cacheability and shareability attributes for memory

--- a/services/std_svc/spm/spm_main.c
+++ b/services/std_svc/spm/spm_main.c
@@ -300,6 +300,9 @@ int32_t spm_setup(void)
 		panic();
 	}
 
+	/* Setup shim layer */
+	spm_exceptions_xlat_init_context();
+
 	/*
 	 * Setup all Secure Partitions.
 	 */

--- a/services/std_svc/spm/spm_main.c
+++ b/services/std_svc/spm/spm_main.c
@@ -328,9 +328,6 @@ int32_t spm_setup(void)
 		/* Initialize context of the SP */
 		INFO("Secure Partition %u context setup start...\n", i);
 
-		/* Assign translation tables context. */
-		ctx->xlat_ctx_handle = spm_sp_xlat_context_alloc();
-
 		/* Save location of the image in physical memory */
 		ctx->image_base = (uintptr_t)sp_base;
 		ctx->image_size = sp_size;

--- a/services/std_svc/spm/spm_private.h
+++ b/services/std_svc/spm/spm_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -94,6 +94,10 @@ int sp_state_try_switch(sp_context_t *sp_ptr, sp_state_t from, sp_state_t to);
 void spm_sp_request_increase(sp_context_t *sp_ctx);
 void spm_sp_request_decrease(sp_context_t *sp_ctx);
 int spm_sp_request_increase_if_zero(sp_context_t *sp_ctx);
+
+/* Functions related to the shim layer translation tables */
+void spm_exceptions_xlat_init_context(void);
+uint64_t *spm_exceptions_xlat_get_base_table(void);
 
 /* Functions related to the translation tables management */
 xlat_ctx_t *spm_sp_xlat_context_alloc(void);

--- a/services/std_svc/spm/spm_private.h
+++ b/services/std_svc/spm/spm_private.h
@@ -100,7 +100,7 @@ void spm_exceptions_xlat_init_context(void);
 uint64_t *spm_exceptions_xlat_get_base_table(void);
 
 /* Functions related to the translation tables management */
-xlat_ctx_t *spm_sp_xlat_context_alloc(void);
+void spm_sp_xlat_context_alloc(sp_context_t *sp_ctx);
 void sp_map_memory_regions(sp_context_t *sp_ctx);
 
 /* Functions to handle Secure Partition contexts */

--- a/services/std_svc/spm/spm_setup.c
+++ b/services/std_svc/spm/spm_setup.c
@@ -60,6 +60,9 @@ void spm_sp_setup(sp_context_t *sp_ctx)
 	 * ------------------------
 	 */
 
+	/* Assign translation tables context. */
+	spm_sp_xlat_context_alloc(sp_ctx);
+
 	sp_map_memory_regions(sp_ctx);
 
 	/*

--- a/services/std_svc/spm/spm_setup.c
+++ b/services/std_svc/spm/spm_setup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -77,11 +77,23 @@ void spm_sp_setup(sp_context_t *sp_ctx)
 	write_ctx_reg(get_sysregs_ctx(ctx), CTX_MAIR_EL1,
 		      mmu_cfg_params[MMU_CFG_MAIR]);
 
+	/* Enable translations using TTBR1_EL1 */
+	int t1sz = 64 - __builtin_ctzll(SPM_SHIM_XLAT_VIRT_ADDR_SPACE_SIZE);
+	mmu_cfg_params[MMU_CFG_TCR] &= ~TCR_EPD1_BIT;
+	mmu_cfg_params[MMU_CFG_TCR] |=
+		((uint64_t)t1sz << TCR_T1SZ_SHIFT) |
+		TCR_SH1_INNER_SHAREABLE |
+		TCR_RGN1_OUTER_WBA | TCR_RGN1_INNER_WBA |
+		TCR_TG1_4K;
+
 	write_ctx_reg(get_sysregs_ctx(ctx), CTX_TCR_EL1,
 		      mmu_cfg_params[MMU_CFG_TCR]);
 
 	write_ctx_reg(get_sysregs_ctx(ctx), CTX_TTBR0_EL1,
 		      mmu_cfg_params[MMU_CFG_TTBR0]);
+
+	write_ctx_reg(get_sysregs_ctx(ctx), CTX_TTBR1_EL1,
+		      (uint64_t)spm_exceptions_xlat_get_base_table());
 
 	/* Setup SCTLR_EL1 */
 	u_register_t sctlr_el1 = read_ctx_reg(get_sysregs_ctx(ctx), CTX_SCTLR_EL1);
@@ -122,9 +134,14 @@ void spm_sp_setup(sp_context_t *sp_ctx)
 	 * ----------------------------
 	 */
 
-	/* Shim Exception Vector Base Address */
+	/*
+	 * Shim exception vector base address. It is mapped at the start of the
+	 * address space accessed by TTBR1_EL1, which means that the base
+	 * address of the exception vectors depends on the size of the address
+	 * space specified in TCR_EL1.T1SZ.
+	 */
 	write_ctx_reg(get_sysregs_ctx(ctx), CTX_VBAR_EL1,
-			SPM_SHIM_EXCEPTIONS_PTR);
+		      UINT64_MAX - (SPM_SHIM_XLAT_VIRT_ADDR_SPACE_SIZE - 1ULL));
 
 	/*
 	 * FPEN: Allow the Secure Partition to access FP/SIMD registers.

--- a/services/std_svc/spm/spm_shim_private.h
+++ b/services/std_svc/spm/spm_shim_private.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -22,5 +22,13 @@ IMPORT_SYM(uintptr_t, __SPM_SHIM_EXCEPTIONS_END__,	SPM_SHIM_EXCEPTIONS_END);
 
 #define SPM_SHIM_EXCEPTIONS_SIZE	\
 	(SPM_SHIM_EXCEPTIONS_END - SPM_SHIM_EXCEPTIONS_START)
+
+/*
+ * Use the smallest virtual address space size allowed in ARMv8.0 for
+ * compatibility.
+ */
+#define SPM_SHIM_XLAT_VIRT_ADDR_SPACE_SIZE	(1ULL << 25)
+#define SPM_SHIM_MMAP_REGIONS	1
+#define SPM_SHIM_XLAT_TABLES	1
 
 #endif /* SPM_SHIM_PRIVATE_H */

--- a/services/std_svc/spm/spm_xlat.c
+++ b/services/std_svc/spm/spm_xlat.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -158,6 +158,11 @@ static void map_rdmem(sp_context_t *sp_ctx, struct sp_rd_sect_mem_region *rdmem)
 	unsigned long long rd_base_pa;
 
 	unsigned int memtype = rdmem->attr & RD_MEM_MASK;
+
+	if (rd_size == 0U) {
+		VERBOSE("Memory region '%s' is empty. Ignored.\n", rdmem->name);
+		return;
+	}
 
 	VERBOSE("Adding memory region '%s'\n", rdmem->name);
 


### PR DESCRIPTION
Move shim layer mapping to TTBR1_EL1 to allow partitions to reduce the address space size in TBBR0_EL0. This way they need less memory for translation tables as there can be less levels of translation.

Check the individual commits for more information.