### PR TITLE
Remove deprecated interfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -285,28 +285,6 @@ INCLUDES		+=	-Iinclude				\
 				${PLAT_INCLUDES}			\
 				${SPD_INCLUDES}
 
-ifeq (${ERROR_DEPRECATED},0)
-INCLUDES		+=	-Iinclude/bl1				\
-				-Iinclude/bl2				\
-				-Iinclude/bl2u				\
-				-Iinclude/bl31				\
-				-Iinclude/drivers			\
-				-Iinclude/drivers/arm			\
-				-Iinclude/drivers/auth			\
-				-Iinclude/drivers/io			\
-				-Iinclude/drivers/ti/uart		\
-				-Iinclude/lib				\
-				-Iinclude/lib/cpus			\
-				-Iinclude/lib/el3_runtime		\
-				-Iinclude/lib/extensions		\
-				-Iinclude/lib/pmf			\
-				-Iinclude/lib/psci			\
-				-Iinclude/lib/xlat_tables		\
-				-Iinclude/plat/common			\
-				-Iinclude/services			\
-				-Iinclude/tools_share
-endif
-
 include common/backtrace/backtrace.mk
 
 ################################################################################

--- a/drivers/arm/pl011/aarch32/pl011_console.S
+++ b/drivers/arm/pl011/aarch32/pl011_console.S
@@ -6,7 +6,6 @@
 #include <arch.h>
 #include <asm_macros.S>
 #include <assert_macros.S>
-#define USE_FINISH_CONSOLE_REG_2
 #include <console_macros.S>
 #include <drivers/arm/pl011.h>
 

--- a/drivers/arm/pl011/aarch64/pl011_console.S
+++ b/drivers/arm/pl011/aarch64/pl011_console.S
@@ -6,7 +6,6 @@
 #include <arch.h>
 #include <asm_macros.S>
 #include <assert_macros.S>
-#define USE_FINISH_CONSOLE_REG_2
 #include <console_macros.S>
 #include <drivers/arm/pl011.h>
 

--- a/drivers/arm/tzc/tzc380.c
+++ b/drivers/arm/tzc/tzc380.c
@@ -24,7 +24,7 @@ static unsigned int tzc380_read_build_config(uintptr_t base)
 	return mmio_read_32(base + TZC380_CONFIGURATION_OFF);
 }
 
-static void tzc380_write_action(uintptr_t base, tzc_action_t action)
+static void tzc380_write_action(uintptr_t base, unsigned int action)
 {
 	mmio_write_32(base + ACTION_OFF, action);
 }
@@ -91,7 +91,7 @@ void tzc380_configure_region(uint8_t region, uintptr_t region_base, unsigned int
 	tzc380_write_region_attributes(tzc380.base, region, attr);
 }
 
-void tzc380_set_action(tzc_action_t action)
+void tzc380_set_action(unsigned int action)
 {
 	assert(tzc380.base != 0U);
 

--- a/drivers/cadence/uart/aarch64/cdns_console.S
+++ b/drivers/cadence/uart/aarch64/cdns_console.S
@@ -6,7 +6,6 @@
 #include <arch.h>
 #include <asm_macros.S>
 #include <assert_macros.S>
-#define USE_FINISH_CONSOLE_REG_2
 #include <console_macros.S>
 #include <drivers/cadence/cdns_uart.h>
 

--- a/drivers/console/aarch64/skeleton_console.S
+++ b/drivers/console/aarch64/skeleton_console.S
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 #include <asm_macros.S>
-#define USE_FINISH_CONSOLE_REG_2
 #include <console_macros.S>
 
 	/*

--- a/drivers/coreboot/cbmem_console/aarch64/cbmem_console.S
+++ b/drivers/coreboot/cbmem_console/aarch64/cbmem_console.S
@@ -5,7 +5,6 @@
  */
 
 #include <asm_macros.S>
-#define USE_FINISH_CONSOLE_REG_2
 #include <console_macros.S>
 #include <drivers/coreboot/cbmem_console.h>
 

--- a/drivers/marvell/uart/a3700_console.S
+++ b/drivers/marvell/uart/a3700_console.S
@@ -7,7 +7,6 @@
 
 #include <arch.h>
 #include <asm_macros.S>
-#define USE_FINISH_CONSOLE_REG_2
 #include <console_macros.S>
 #include <drivers/marvell/uart/a3700_console.h>
 

--- a/drivers/meson/console/aarch64/meson_console.S
+++ b/drivers/meson/console/aarch64/meson_console.S
@@ -6,7 +6,6 @@
 
 #include <asm_macros.S>
 #include <assert_macros.S>
-#define USE_FINISH_CONSOLE_REG_2
 #include <console_macros.S>
 #include <drivers/meson/meson_console.h>
 

--- a/drivers/st/uart/aarch32/stm32_console.S
+++ b/drivers/st/uart/aarch32/stm32_console.S
@@ -5,7 +5,6 @@
  */
 #include <asm_macros.S>
 #include <assert_macros.S>
-#define USE_FINISH_CONSOLE_REG_2
 #include <console_macros.S>
 #include <drivers/st/stm32_console.h>
 #include <drivers/st/stm32_uart_regs.h>

--- a/drivers/staging/renesas/rcar/ddr/ddr_a/ddr_init_d3.c
+++ b/drivers/staging/renesas/rcar/ddr/ddr_a/ddr_init_d3.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdint.h>
-#include <mmio.h>
+#include <lib/mmio.h>
 #include <common/debug.h>
 
 #include "boot_init_dram_regdef_d3.h"
@@ -193,7 +193,7 @@ static void init_ddr_d3_1866(void)
          RegVal_R2 = (ReadReg_32(DBSC_D3_DBPDRGD0) & 0xFFFFFF00);
          WriteReg_32(DBSC_D3_DBPDRGA0,0x000000B0 + i*0x20);
          WriteReg_32(DBSC_D3_DBPDRGD0,RegVal_R2 | RegVal_R6);
-      } else 
+      } else
       {
          WriteReg_32(DBSC_D3_DBPDRGA0,0x000000B2 + i*0x20);
          RegVal_R2 = (ReadReg_32(DBSC_D3_DBPDRGD0) & 0xFFFFFFF8);
@@ -508,7 +508,7 @@ static void init_ddr_d3_1600(void)
          RegVal_R2 = (ReadReg_32(DBSC_D3_DBPDRGD0) & 0xFFFFFF00);
          WriteReg_32(DBSC_D3_DBPDRGA0,0x000000B0 + i*0x20);
          WriteReg_32(DBSC_D3_DBPDRGD0,RegVal_R2 | RegVal_R6);
-      } else 
+      } else
       {
          WriteReg_32(DBSC_D3_DBPDRGA0,0x000000B2 + i*0x20);
          RegVal_R2 = (ReadReg_32(DBSC_D3_DBPDRGD0) & 0xFFFFFFF8);

--- a/drivers/staging/renesas/rcar/pfc/D3/pfc_init_d3.c
+++ b/drivers/staging/renesas/rcar/pfc/D3/pfc_init_d3.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdint.h>
-#include <mmio.h>
+#include <lib/mmio.h>
 #include "pfc_init_d3.h"
 #include "rcar_def.h"
 
@@ -896,7 +896,7 @@ void pfc_init_d3(void)
 	pfc_reg_write(PFC_PUD3, 0xFF0FFFFFU);
 	pfc_reg_write(PFC_PUD4, 0xE0000000U);
 	pfc_reg_write(PFC_PUD5, 0x60000000U);
-                            
+
 	/* initialize LSI pin pull-enable register */
 	pfc_reg_write(PFC_PUEN0, 0x00000000U);
 	pfc_reg_write(PFC_PUEN1, 0x00000000U);
@@ -904,7 +904,7 @@ void pfc_init_d3(void)
 	pfc_reg_write(PFC_PUEN3, 0x000F008CU);
 	pfc_reg_write(PFC_PUEN4, 0x00000000U);
 	pfc_reg_write(PFC_PUEN5, 0x00000000U);
-                             
+
 	/* initialize positive/negative logic select */
 	mmio_write_32(GPIO_POSNEG0, 0x00000000U);
 	mmio_write_32(GPIO_POSNEG1, 0x00000000U);

--- a/drivers/staging/renesas/rcar/pfc/V3M/pfc_init_v3m.c
+++ b/drivers/staging/renesas/rcar/pfc/V3M/pfc_init_v3m.c
@@ -6,7 +6,7 @@
  */
 
 #include <stdint.h>		/* for uint32_t */
-#include <mmio.h>
+#include <lib/mmio.h>
 #include "pfc_init_v3m.h"
 #include "include/rcar_def.h"
 #include "rcar_private.h"

--- a/drivers/ti/uart/aarch64/16550_console.S
+++ b/drivers/ti/uart/aarch64/16550_console.S
@@ -7,7 +7,6 @@
 #include <arch.h>
 #include <asm_macros.S>
 #include <assert_macros.S>
-#define USE_FINISH_CONSOLE_REG_2
 #include <console_macros.S>
 #include <drivers/ti/uart/uart_16550.h>
 

--- a/include/arch/aarch32/console_macros.S
+++ b/include/arch/aarch32/console_macros.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -17,39 +17,6 @@
  * with a tail call that will include return to the caller.
  * REQUIRES console_t pointer in x0 and a valid return address in x30.
  */
-/*
- * The USE_FINISH_CONSOLE_REG_2 guard is introduced to allow selection between
- * the 2 variants of the finish_console_register macro and will be removed
- * once the deprecated variant is removed.
- */
-#ifndef USE_FINISH_CONSOLE_REG_2
-#if !ERROR_DEPRECATED
-	/* This version of the macro is deprecated. Use the new version */
-	.macro	finish_console_register _driver
-	/*
-	 * Add these weak definitions so we will automatically write a 0 if the
-	 * function doesn't exist. I'd rather use .ifdef but that only works if
-	 * the function was defined (not just declared .global) above this point
-	 * in the file, which we can't guarantee.
-	 */
-	.weak console_\_driver\()_putc
-	.weak console_\_driver\()_getc
-	.weak console_\_driver\()_flush
-
-	/* Don't use adrp on weak funcs! See GNU ld bugzilla issue 22589. */
-	ldr	r1, =console_\_driver\()_putc
-	str	r1, [r0, #CONSOLE_T_PUTC]
-	ldr	r1, =console_\_driver\()_getc
-	str	r1, [r0, #CONSOLE_T_GETC]
-	ldr	r1, =console_\_driver\()_flush
-	str	r1, [r0, #CONSOLE_T_FLUSH]
-	mov	r1, #(CONSOLE_FLAG_BOOT | CONSOLE_FLAG_CRASH)
-	str	r1, [r0, #CONSOLE_T_FLAGS]
-	b	console_register
-	.endm
-#endif /* ERROR_DEPRECATED */
-#else /* USE_FINISH_CONSOLE_REG_2 */
-	/* The new version of the macro not using weak references */
 	.macro	finish_console_register _driver, putc=0, getc=0, flush=0
 	/*
 	 * If any of the callback is not specified or set as 0, then the
@@ -80,5 +47,5 @@
 	str	r1, [r0, #CONSOLE_T_FLAGS]
 	b	console_register
 	.endm
-#endif /* USE_FINISH_CONSOLE_REG_2 */
+
 #endif /* CONSOLE_MACROS_S */

--- a/include/arch/aarch64/arch_helpers.h
+++ b/include/arch/aarch64/arch_helpers.h
@@ -310,13 +310,6 @@ static inline void disable_debug_exceptions(void)
 	isb();
 }
 
-#if !ERROR_DEPRECATED
-uint32_t get_afflvl_shift(uint32_t);
-uint32_t mpidr_mask_lower_afflvls(uint64_t, uint32_t);
-
-void __dead2 eret(uint64_t x0, uint64_t x1, uint64_t x2, uint64_t x3,
-		  uint64_t x4, uint64_t x5, uint64_t x6, uint64_t x7);
-#endif
 void __dead2 smc(uint64_t x0, uint64_t x1, uint64_t x2, uint64_t x3,
 		 uint64_t x4, uint64_t x5, uint64_t x6, uint64_t x7);
 
@@ -507,10 +500,6 @@ static inline uint64_t el_implemented(unsigned int el)
 		return (read_id_aa64pfr0_el1() >> shift) & ID_AA64PFR0_ELX_MASK;
 	}
 }
-
-#if !ERROR_DEPRECATED
-#define EL_IMPLEMENTED(_el)	el_implemented(_el)
-#endif
 
 /* Previously defined accesor functions with incomplete register names  */
 

--- a/include/arch/aarch64/console_macros.S
+++ b/include/arch/aarch64/console_macros.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2017-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -17,39 +17,6 @@
  * with a tail call that will include return to the caller.
  * REQUIRES console_t pointer in x0 and a valid return address in x30.
  */
-/*
- * The USE_FINISH_CONSOLE_REG_2 guard is introduced to allow selection between
- * the 2 variants of the finish_console_register macro and will be removed
- * once the deprecated variant is removed.
- */
-#ifndef USE_FINISH_CONSOLE_REG_2
-#if !ERROR_DEPRECATED
-	/* This version of the macro is deprecated. Use the new version */
-	.macro	finish_console_register _driver
-	/*
-	 * Add these weak definitions so we will automatically write a 0 if the
-	 * function doesn't exist. I'd rather use .ifdef but that only works if
-	 * the function was defined (not just declared .global) above this point
-	 * in the file, which we can't guarantee.
-	 */
-	.weak console_\_driver\()_putc
-	.weak console_\_driver\()_getc
-	.weak console_\_driver\()_flush
-
-	/* Don't use adrp on weak funcs! See GNU ld bugzilla issue 22589. */
-	ldr	x1, =console_\_driver\()_putc
-	str	x1, [x0, #CONSOLE_T_PUTC]
-	ldr	x1, =console_\_driver\()_getc
-	str	x1, [x0, #CONSOLE_T_GETC]
-	ldr	x1, =console_\_driver\()_flush
-	str	x1, [x0, #CONSOLE_T_FLUSH]
-	mov	x1, #(CONSOLE_FLAG_BOOT | CONSOLE_FLAG_CRASH)
-	str	x1, [x0, #CONSOLE_T_FLAGS]
-	b	console_register
-	.endm
-#endif /* ERROR_DEPRECATED */
-#else /* USE_FINISH_CONSOLE_REG_2 */
-	/* The new version of the macro not using weak references */
 	.macro	finish_console_register _driver, putc=0, getc=0, flush=0
 	/*
 	 * If any of the callback is not specified or set as 0, then the
@@ -83,6 +50,5 @@
 	str	x1, [x0, #CONSOLE_T_FLAGS]
 	b	console_register
 	.endm
-#endif /* USE_FINISH_CONSOLE_REG_2 */
 
 #endif /* CONSOLE_MACROS_S */

--- a/include/drivers/arm/tzc380.h
+++ b/include/drivers/arm/tzc380.h
@@ -138,7 +138,7 @@ void tzc380_init(uintptr_t base);
 void tzc380_configure_region(uint8_t region,
 			     uintptr_t region_base,
 			     unsigned int attr);
-void tzc380_set_action(tzc_action_t action);
+void tzc380_set_action(unsigned int action);
 static inline void tzc_init(uintptr_t base)
 {
 	tzc380_init(base);
@@ -151,7 +151,7 @@ static inline void tzc_configure_region(uint8_t region,
 	tzc380_configure_region(region, region_base, attr);
 }
 
-static inline void tzc_set_action(tzc_action_t action)
+static inline void tzc_set_action(unsigned int action)
 {
 	tzc380_set_action(action);
 }

--- a/include/drivers/arm/tzc_common.h
+++ b/include/drivers/arm/tzc_common.h
@@ -86,12 +86,4 @@
 #define TZC_REGION_OFFSET(region_size, region_no)	\
 				((region_size) * (region_no))
 
-#ifndef __ASSEMBLY__
-
-#if !ERROR_DEPRECATED
-typedef unsigned int tzc_action_t;
-typedef unsigned int tzc_region_attributes_t;
-#endif
-
-#endif /* __ASSEMBLY__ */
 #endif /* TZC_COMMON_H */

--- a/lib/aarch64/misc_helpers.S
+++ b/lib/aarch64/misc_helpers.S
@@ -10,11 +10,6 @@
 #include <common/bl_common.h>
 #include <lib/xlat_tables/xlat_tables_defs.h>
 
-#if !ERROR_DEPRECATED
-	.globl	get_afflvl_shift
-	.globl	mpidr_mask_lower_afflvls
-	.globl	eret
-#endif /* ERROR_DEPRECATED */
 	.globl	smc
 
 	.globl	zero_normalmem
@@ -29,31 +24,6 @@
 #if SUPPORT_VFP
 	.globl	enable_vfp
 #endif
-
-#if !ERROR_DEPRECATED
-func get_afflvl_shift
-	cmp	x0, #3
-	cinc	x0, x0, eq
-	mov	x1, #MPIDR_AFFLVL_SHIFT
-	lsl	x0, x0, x1
-	ret
-endfunc get_afflvl_shift
-
-func mpidr_mask_lower_afflvls
-	cmp	x1, #3
-	cinc	x1, x1, eq
-	mov	x2, #MPIDR_AFFLVL_SHIFT
-	lsl	x2, x1, x2
-	lsr	x0, x0, x2
-	lsl	x0, x0, x2
-	ret
-endfunc mpidr_mask_lower_afflvls
-
-
-func eret
-	eret
-endfunc eret
-#endif /* ERROR_DEPRECATED */
 
 func smc
 	smc	#0

--- a/plat/common/aarch32/platform_helpers.S
+++ b/plat/common/aarch32/platform_helpers.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -8,11 +8,6 @@
 #include <asm_macros.S>
 
 	.weak	plat_report_exception
-#if !ERROR_DEPRECATED
-	.weak	plat_crash_console_init
-	.weak	plat_crash_console_putc
-	.weak	plat_crash_console_flush
-#endif
 	.weak	plat_reset_handler
 	.weak	plat_disable_acp
 	.weak	bl1_plat_prepare_exit
@@ -27,37 +22,6 @@
 func plat_report_exception
 	bx	lr
 endfunc plat_report_exception
-
-#if !ERROR_DEPRECATED
-	/* -----------------------------------------------------
-	 * Placeholder function which should be redefined by
-	 * each platform.
-	 * -----------------------------------------------------
-	 */
-func plat_crash_console_init
-	mov	r0, #0
-	bx	lr
-endfunc plat_crash_console_init
-
-	/* -----------------------------------------------------
-	 * Placeholder function which should be redefined by
-	 * each platform.
-	 * -----------------------------------------------------
-	 */
-func plat_crash_console_putc
-	bx	lr
-endfunc plat_crash_console_putc
-
-	/* -----------------------------------------------------
-	 * Placeholder function which should be redefined by
-	 * each platform.
-	 * -----------------------------------------------------
-	 */
-func plat_crash_console_flush
-	mov	r0, #0
-	bx	lr
-endfunc plat_crash_console_flush
-#endif
 
 	/* -----------------------------------------------------
 	 * Placeholder function which should be redefined by

--- a/plat/common/aarch64/platform_helpers.S
+++ b/plat/common/aarch64/platform_helpers.S
@@ -10,11 +10,6 @@
 #include <platform_def.h>
 
 	.weak	plat_report_exception
-#if !ERROR_DEPRECATED
-	.weak	plat_crash_console_init
-	.weak	plat_crash_console_putc
-	.weak	plat_crash_console_flush
-#endif
 	.weak	plat_reset_handler
 	.weak	plat_disable_acp
 	.weak	bl1_plat_prepare_exit
@@ -36,21 +31,6 @@
 func plat_report_exception
 	ret
 endfunc plat_report_exception
-
-#if !ERROR_DEPRECATED
-func plat_crash_console_init
-	mov	x0, #0
-	ret
-endfunc plat_crash_console_init
-
-func plat_crash_console_putc
-	ret
-endfunc plat_crash_console_putc
-
-func plat_crash_console_flush
-	ret
-endfunc plat_crash_console_flush
-#endif /* ERROR_DEPRECATED */
 
 	/* -----------------------------------------------------
 	 * Placeholder function which should be redefined by

--- a/plat/imx/common/aarch32/imx_uart_console.S
+++ b/plat/imx/common/aarch32/imx_uart_console.S
@@ -6,7 +6,6 @@
 
 #include <arch.h>
 #include <asm_macros.S>
-#define USE_FINISH_CONSOLE_REG_2
 #include <console_macros.S>
 #include <assert_macros.S>
 #include "imx_uart.h"

--- a/plat/imx/common/imx_sip_handler.c
+++ b/plat/imx/common/imx_sip_handler.c
@@ -6,7 +6,7 @@
 
 #include <stdlib.h>
 #include <stdint.h>
-#include <std_svc.h>
+#include <services/std_svc.h>
 #include <string.h>
 #include <platform_def.h>
 #include <common/debug.h>

--- a/plat/imx/common/imx_uart_console.S
+++ b/plat/imx/common/imx_uart_console.S
@@ -6,7 +6,6 @@
 
 #include <arch.h>
 #include <asm_macros.S>
-#define USE_FINISH_CONSOLE_REG_2
 #include <console_macros.S>
 #include <assert_macros.S>
 #include "imx_uart.h"

--- a/plat/imx/common/lpuart_console.S
+++ b/plat/imx/common/lpuart_console.S
@@ -6,7 +6,6 @@
 
 #include <arch.h>
 #include <asm_macros.S>
-#define USE_FINISH_CONSOLE_REG_2
 #include <console_macros.S>
 #include <assert_macros.S>
 #include "imx8_lpuart.h"

--- a/plat/layerscape/common/aarch64/ls_console.S
+++ b/plat/layerscape/common/aarch64/ls_console.S
@@ -6,7 +6,6 @@
 
 #include <arch.h>
 #include <asm_macros.S>
-#define USE_FINISH_CONSOLE_REG_2
 #include <console_macros.S>
 #include <assert_macros.S>
 #include "ls_16550.h"

--- a/plat/mediatek/mt6795/aarch64/plat_helpers.S
+++ b/plat/mediatek/mt6795/aarch64/plat_helpers.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2016-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -12,6 +12,7 @@
 	.globl	platform_is_primary_cpu
 	.globl	plat_crash_console_init
 	.globl	plat_crash_console_putc
+	.globl	plat_crash_console_flush
 	.globl	platform_mem_init
 
 
@@ -120,6 +121,19 @@ func plat_crash_console_putc
 	b	console_core_putc
 	ret
 endfunc plat_crash_console_putc
+
+	/* ---------------------------------------------
+	 * int plat_crash_console_flush(int c)
+	 * Function to force a write of all buffered
+	 * data that hasn't been output.
+	 * Out : return -1 on error else return 0.
+	 * Clobber list : x0, x1
+	 * ---------------------------------------------
+	 */
+func plat_crash_console_flush
+	mov_imm	x0, UART0_BASE
+	b	console_core_flush
+endfunc plat_crash_console_flush
 
 	/* --------------------------------------------------------
 	 * void platform_mem_init (void);

--- a/plat/mediatek/mt8173/aarch64/plat_helpers.S
+++ b/plat/mediatek/mt8173/aarch64/plat_helpers.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2015, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2013-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -13,6 +13,7 @@
 	.globl  plat_my_core_pos
 	.globl	plat_crash_console_init
 	.globl	plat_crash_console_putc
+	.globl	plat_crash_console_flush
 
 	/* -----------------------------------------------------
 	 * void plat_secondary_cold_boot_setup (void);
@@ -75,3 +76,16 @@ func plat_crash_console_putc
 	mov_imm x1, MT8173_UART0_BASE
 	b	console_core_putc
 endfunc plat_crash_console_putc
+
+	/* ---------------------------------------------
+	 * int plat_crash_console_flush(int c)
+	 * Function to force a write of all buffered
+	 * data that hasn't been output.
+	 * Out : return -1 on error else return 0.
+	 * Clobber list : x0, x1
+	 * ---------------------------------------------
+	 */
+func plat_crash_console_flush
+	mov_imm	x0, MT8173_UART0_BASE
+	b	console_core_flush
+endfunc plat_crash_console_flush

--- a/plat/nvidia/tegra/common/drivers/bpmp/bpmp.c
+++ b/plat/nvidia/tegra/common/drivers/bpmp/bpmp.c
@@ -8,10 +8,10 @@
 #include <assert.h>
 #include <bpmp.h>
 #include <common/debug.h>
-#include <delay_timer.h>
+#include <drivers/delay_timer.h>
 #include <errno.h>
-#include <mmio.h>
-#include <platform.h>
+#include <lib/mmio.h>
+#include <plat/common/platform.h>
 #include <stdbool.h>
 #include <string.h>
 #include <tegra_def.h>

--- a/plat/nvidia/tegra/common/drivers/bpmp_ipc/intf.c
+++ b/plat/nvidia/tegra/common/drivers/bpmp_ipc/intf.c
@@ -7,13 +7,13 @@
 #include <assert.h>
 #include <bpmp_ipc.h>
 #include <debug.h>
-#include <delay_timer.h>
+#include <drivers/delay_timer.h>
 #include <errno.h>
-#include <mmio.h>
+#include <lib/mmio.h>
+#include <lib/utils_def.h>
 #include <stdbool.h>
 #include <string.h>
 #include <tegra_def.h>
-#include <utils_def.h>
 
 #include "intf.h"
 #include "ivc.h"

--- a/plat/nvidia/tegra/common/drivers/bpmp_ipc/ivc.h
+++ b/plat/nvidia/tegra/common/drivers/bpmp_ipc/ivc.h
@@ -7,9 +7,9 @@
 #ifndef IVC_H
 #define IVC_H
 
+#include <lib/utils_def.h>
 #include <stdint.h>
 #include <stddef.h>
-#include <utils_def.h>
 
 #define IVC_ALIGN		U(64)
 #define IVC_CHHDR_TX_FIELDS	U(16)

--- a/plat/nvidia/tegra/common/drivers/flowctrl/flowctrl.c
+++ b/plat/nvidia/tegra/common/drivers/flowctrl/flowctrl.c
@@ -13,9 +13,9 @@
 #include <lib/mmio.h>
 
 #include <flowctrl.h>
+#include <lib/utils_def.h>
 #include <pmc.h>
 #include <tegra_def.h>
-#include <utils_def.h>
 
 #define CLK_RST_DEV_L_SET		0x300
 #define CLK_RST_DEV_L_CLR		0x304

--- a/plat/nvidia/tegra/common/drivers/gpcdma/gpcdma.c
+++ b/plat/nvidia/tegra/common/drivers/gpcdma/gpcdma.c
@@ -6,14 +6,14 @@
 
 #include <arch_helpers.h>
 #include <common/debug.h>
-#include <delay_timer.h>
+#include <drivers/delay_timer.h>
 #include <errno.h>
 #include <gpcdma.h>
-#include <mmio.h>
+#include <lib/mmio.h>
+#include <lib/utils_def.h>
 #include <platform_def.h>
 #include <stdbool.h>
 #include <tegra_def.h>
-#include <utils_def.h>
 
 /* DMA channel registers */
 #define DMA_CH_CSR				U(0x0)

--- a/plat/nvidia/tegra/common/lib/debug/profiler.c
+++ b/plat/nvidia/tegra/common/lib/debug/profiler.c
@@ -23,12 +23,12 @@
 #include <arch.h>
 #include <arch_helpers.h>
 #include <assert.h>
-#include <mmio.h>
+#include <lib/mmio.h>
+#include <lib/utils_def.h>
+#include <lib/xlat_tables/xlat_tables_v2.h>
 #include <profiler.h>
 #include <stdbool.h>
 #include <string.h>
-#include <utils_def.h>
-#include <xlat_tables_v2.h>
 
 static uint64_t shmem_base_addr;
 

--- a/plat/nvidia/tegra/common/tegra_topology.c
+++ b/plat/nvidia/tegra/common/tegra_topology.c
@@ -7,8 +7,8 @@
 #include <platform_def.h>
 
 #include <arch.h>
-#include <platform.h>
 #include <lib/psci/psci.h>
+#include <plat/common/platform.h>
 
 #pragma weak plat_core_pos_by_mpidr
 

--- a/plat/nvidia/tegra/include/drivers/bpmp_ipc.h
+++ b/plat/nvidia/tegra/include/drivers/bpmp_ipc.h
@@ -7,9 +7,9 @@
 #ifndef __BPMP_IPC_H__
 #define __BPMP_IPC_H__
 
+#include <lib/utils_def.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <utils_def.h>
 
 /**
  * Currently supported reset identifiers

--- a/plat/nvidia/tegra/include/drivers/memctrl_v2.h
+++ b/plat/nvidia/tegra/include/drivers/memctrl_v2.h
@@ -11,7 +11,7 @@
 
 #ifndef __ASSEMBLY__
 
-#include <mmio.h>
+#include <lib/mmio.h>
 #include <stdint.h>
 
 /*******************************************************************************

--- a/plat/nvidia/tegra/include/plat_macros.S
+++ b/plat/nvidia/tegra/include/plat_macros.S
@@ -7,7 +7,7 @@
 #ifndef PLAT_MACROS_S
 #define PLAT_MACROS_S
 
-#include <gicv2.h>
+#include <drivers/arm/gicv2.h>
 #include <tegra_def.h>
 
 .section .rodata.gic_reg_name, "aS"

--- a/plat/nvidia/tegra/include/tegra_platform.h
+++ b/plat/nvidia/tegra/include/tegra_platform.h
@@ -8,8 +8,8 @@
 #define TEGRA_PLATFORM_H
 
 #include <cdefs.h>
+#include <lib/utils_def.h>
 #include <stdbool.h>
-#include <utils_def.h>
 
 /*******************************************************************************
  * Tegra major, minor version helper macros

--- a/plat/nvidia/tegra/soc/t132/plat_setup.c
+++ b/plat/nvidia/tegra/soc/t132/plat_setup.c
@@ -7,7 +7,7 @@
 #include <arch_helpers.h>
 #include <common/bl_common.h>
 #include <lib/xlat_tables/xlat_tables_v2.h>
-#include <platform.h>
+#include <plat/common/platform.h>
 #include <tegra_def.h>
 #include <tegra_private.h>
 

--- a/plat/nvidia/tegra/soc/t210/drivers/se/security_engine.c
+++ b/plat/nvidia/tegra/soc/t210/drivers/se/security_engine.c
@@ -8,10 +8,10 @@
 #include <arch_helpers.h>
 #include <assert.h>
 #include <common/debug.h>
-#include <delay_timer.h>
+#include <drivers/delay_timer.h>
 #include <errno.h>
-#include <mmio.h>
-#include <psci.h>
+#include <lib/mmio.h>
+#include <lib/psci/psci.h>
 #include <se_private.h>
 #include <security_engine.h>
 #include <tegra_platform.h>

--- a/plat/nvidia/tegra/soc/t210/plat_psci_handlers.c
+++ b/plat/nvidia/tegra/soc/t210/plat_psci_handlers.c
@@ -15,6 +15,7 @@
 
 #include <bpmp.h>
 #include <flowctrl.h>
+#include <lib/utils.h>
 #include <memctrl.h>
 #include <pmc.h>
 #include <platform_def.h>
@@ -22,7 +23,6 @@
 #include <tegra_def.h>
 #include <tegra_private.h>
 #include <tegra_platform.h>
-#include <utils.h>
 
 /*
  * Register used to clear CPU reset signals. Each CPU has two reset

--- a/plat/nvidia/tegra/soc/t210/plat_setup.c
+++ b/plat/nvidia/tegra/soc/t210/plat_setup.c
@@ -19,7 +19,7 @@
 #include <bpmp.h>
 #include <flowctrl.h>
 #include <memctrl.h>
-#include <platform.h>
+#include <plat/common/platform.h>
 #include <security_engine.h>
 #include <tegra_def.h>
 #include <tegra_platform.h>

--- a/plat/nvidia/tegra/soc/t210/plat_sip_calls.c
+++ b/plat/nvidia/tegra/soc/t210/plat_sip_calls.c
@@ -11,8 +11,8 @@
 #include <common/debug.h>
 #include <common/runtime_svc.h>
 #include <errno.h>
-#include <mmio.h>
-#include <utils_def.h>
+#include <lib/mmio.h>
+#include <lib/utils_def.h>
 
 #include <memctrl.h>
 #include <pmc.h>

--- a/plat/qemu/aarch32/plat_helpers.S
+++ b/plat/qemu/aarch32/plat_helpers.S
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016, ARM Limited and Contributors. All rights reserved.
+ * Copyright (c) 2015-2019, ARM Limited and Contributors. All rights reserved.
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -15,6 +15,7 @@
 	.globl	plat_qemu_calc_core_pos
 	.globl	plat_crash_console_init
 	.globl	plat_crash_console_putc
+	.globl	plat_crash_console_flush
 	.globl  plat_secondary_cold_boot_setup
 	.globl  plat_get_my_entrypoint
 	.globl  plat_is_my_cpu_primary
@@ -116,4 +117,17 @@ func plat_crash_console_putc
 	mov_imm	r1, PLAT_QEMU_CRASH_UART_BASE
 	b	console_core_putc
 endfunc plat_crash_console_putc
+
+	/* ---------------------------------------------
+	 * int plat_crash_console_flush(int c)
+	 * Function to force a write of all buffered
+	 * data that hasn't been output.
+	 * Out : return -1 on error else return 0.
+	 * Clobber list : x0, x1
+	 * ---------------------------------------------
+	 */
+func plat_crash_console_flush
+	mov_imm	r0, PLAT_QEMU_CRASH_UART_BASE
+	b	console_core_flush
+endfunc plat_crash_console_flush
 

--- a/plat/xilinx/versal/platform.mk
+++ b/plat/xilinx/versal/platform.mk
@@ -1,4 +1,4 @@
-# Copyright (c) 2018, ARM Limited and Contributors. All rights reserved.
+# Copyright (c) 2018-2019, ARM Limited and Contributors. All rights reserved.
 #
 # SPDX-License-Identifier: BSD-3-Clause
 
@@ -48,6 +48,7 @@ PLAT_BL_COMMON_SOURCES	:=	lib/xlat_tables/xlat_tables_common.c		\
 				drivers/arm/gic/v3/gicv3_main.c			\
 				drivers/arm/gic/v3/gicv3_helpers.c		\
 				drivers/arm/pl011/aarch64/pl011_console.S	\
+				plat/common/aarch64/crash_console_helpers.S	\
 				plat/common/plat_gicv3.c			\
 				plat/xilinx/versal/aarch64/versal_helpers.S	\
 				plat/xilinx/versal/aarch64/versal_common.c

--- a/services/spd/trusty/trusty.c
+++ b/services/spd/trusty/trusty.c
@@ -5,9 +5,9 @@
  */
 
 #include <assert.h>
+#include <lib/xlat_tables/xlat_tables_v2.h>
 #include <stdbool.h>
 #include <string.h>
-#include <xlat_tables_v2.h>
 
 #include <arch_helpers.h>
 #include <bl31/bl31.h>


### PR DESCRIPTION
Remove some of the deprecated interfaces listed in the "TF-A Release Information" document.