### PR TITLE
aarch32: Allow compiling with soft-float toolchain

### DIFF
--- a/include/arch/aarch32/el3_common_macros.S
+++ b/include/arch/aarch32/el3_common_macros.S
@@ -94,7 +94,7 @@
 	 *  from all exception levels.
 	 * ---------------------------------------------------------------------
 	 */
-#if (ARM_ARCH_MAJOR > 7) || defined(ARMV7_SUPPORTS_VFP)
+#if ((ARM_ARCH_MAJOR > 7) || defined(ARMV7_SUPPORTS_VFP)) && !(__SOFTFP__)
 	ldr	r0, =(FPEXC_RESET_VAL | FPEXC_EN_BIT)
 	vmsr	FPEXC, r0
 	isb


### PR DESCRIPTION
TF-A documentation recommends to use hard-float toolchain for aarch32 but build
should not fail when compiling with soft-float toolchain as it is a valid
scenario.
Current TF-A source fails to build with soft-float because assembler complains
for "vmsr" instruction which is required to enable floating point unit.

To avoid this piece of code being compiled with soft-float toolchain add
predefined macro guard " __SOFTFP__" exposed by soft-float toolchain.

Change-Id: I76ba40906a8d622dcd476dd36ab4d277a925996c
Signed-off-by: Manish Pandey <manish.pandey2@arm.com>