### PR TITLE
add asp dma non-secure mode setting

### DIFF
--- a/plat/hisilicon/hikey960/hikey960_bl31_setup.c
+++ b/plat/hisilicon/hikey960/hikey960_bl31_setup.c
@@ -156,6 +156,19 @@ static void hikey960_iomcu_dma_init(void)
 	}
 }
 
+static void hikey960_asp_dma_init(void)
+{
+	int i;
+	uint32_t non_secure;
+
+	non_secure = ASP_DMAC_SEC_CTRL_INTR_SEC | ASP_DMAC_CTRL_GLOBAL_SEC;
+	mmio_write_32(ASP_DMAC_SEC_CTRL, non_secure);
+
+	for (i = 0; i < ASP_DMAC_CHANNEL_NUMS; i++) {
+		mmio_write_32(ASP_DMAC_AXI_CONF(i), (1 << 6) | (1 << 18));
+	}
+}
+
 void bl31_platform_setup(void)
 {
 	/* Initialize the GIC driver, cpu and distributor interfaces */
@@ -166,6 +179,7 @@ void bl31_platform_setup(void)
 
 	hikey960_edma_init();
 	hikey960_iomcu_dma_init();
+	hikey960_asp_dma_init();
 
 	hisi_ipc_init();
 }

--- a/plat/hisilicon/hikey960/include/hi3660.h
+++ b/plat/hisilicon/hikey960/include/hi3660.h
@@ -382,4 +382,11 @@
 #define IOMCU_DMAC_SEC_CTRL_GLOBAL_SEC	(1 << 0)
 #define IOMCU_DMAC_CHANNEL_NUMS			8
 
+#define ASP_DMAC_BASE				0xe804b000
+#define ASP_DMAC_SEC_CTRL			(EDMAC_BASE + 0x694)
+#define ASP_DMAC_AXI_CONF(x)			(EDMAC_BASE + 0x820 + ((x) << 6))
+#define ASP_DMAC_SEC_CTRL_INTR_SEC		(1 << 1)
+#define ASP_DMAC_SEC_CTRL_GLOBAL_SEC		(1 << 0)
+#define ASP_DMAC_CHANNEL_NUMS			16
+
 #endif /* HI3660_H */


### PR DESCRIPTION
already verified locally, the hikey960 board can boot to kernel.