### PR TITLE
cpus: Fix Cortex-A12 MIDR mask

### DIFF
--- a/include/lib/cpus/aarch32/cortex_a12.h
+++ b/include/lib/cpus/aarch32/cortex_a12.h
@@ -12,7 +12,7 @@
 /*******************************************************************************
  * Cortex-A12 midr with version/revision set to 0
  ******************************************************************************/
-#define CORTEX_A12_MIDR			U(0x410FC0C0)
+#define CORTEX_A12_MIDR			U(0x410FC0D0)
 
 /*******************************************************************************
  * CPU Auxiliary Control register specific definitions.


### PR DESCRIPTION
The Cortex-A12's primary part number is 0xC0D not 0xC0C, so
fix that to make the A12's cpu operations findable.

Signed-off-by: Heiko Stuebner <heiko@sntech.de>