### PR TITLE
plat: imx8m: fix build error when 'ERROR_DEPRECATED' set

### DIFF
--- a/plat/imx/imx8m/imx8mm/platform.mk
+++ b/plat/imx/imx8m/imx8mm/platform.mk
@@ -28,7 +28,6 @@ BL31_SOURCES		+=	plat/imx/common/imx8_helpers.S			\
 				lib/xlat_tables/aarch64/xlat_tables.c		\
 				lib/xlat_tables/xlat_tables_common.c		\
 				lib/cpus/aarch64/cortex_a53.S			\
-				drivers/console/aarch64/console.S		\
 				drivers/arm/tzc/tzc380.c			\
 				drivers/delay_timer/delay_timer.c		\
 				drivers/delay_timer/generic_delay_timer.c	\

--- a/plat/imx/imx8m/imx8mq/platform.mk
+++ b/plat/imx/imx8m/imx8mq/platform.mk
@@ -28,7 +28,6 @@ BL31_SOURCES		+=	plat/imx/common/imx8_helpers.S			\
 				lib/xlat_tables/aarch64/xlat_tables.c		\
 				lib/xlat_tables/xlat_tables_common.c		\
 				lib/cpus/aarch64/cortex_a53.S			\
-				drivers/console/aarch64/console.S		\
 				drivers/arm/tzc/tzc380.c			\
 				drivers/delay_timer/delay_timer.c		\
 				drivers/delay_timer/generic_delay_timer.c	\


### PR DESCRIPTION
Fix the build error when 'ERROR_DEPRECATED'set. The
'drivers/console/aarch64/console.S' is not needed, so
remove it from build.

Signed-off-by: Jacky Bai <ping.bai@nxp.com>