### PR TITLE
plat: allwinner: h6: add wdt_quirk to use r_wdt instead

### DIFF
--- a/plat/allwinner/common/sunxi_pm.c
+++ b/plat/allwinner/common/sunxi_pm.c
@@ -20,9 +20,15 @@
 #include <sunxi_mmap.h>
 #include <sunxi_private.h>
 
-#define SUNXI_WDOG0_CTRL_REG		(SUNXI_WDOG_BASE + 0x0010)
-#define SUNXI_WDOG0_CFG_REG		(SUNXI_WDOG_BASE + 0x0014)
-#define SUNXI_WDOG0_MODE_REG		(SUNXI_WDOG_BASE + 0x0018)
+#ifdef SUNXI_WDT_QUIRK
+#define SUNXI_WDT_BASE			SUNXI_R_WDOG_BASE
+#else
+#define SUNXI_WDT_BASE			SUNXI_WDOG_BASE
+#endif
+
+#define SUNXI_WDT_CTRL_REG		(SUNXI_WDT_BASE + 0x0010)
+#define SUNXI_WDT_CFG_REG		(SUNXI_WDT_BASE + 0x0014)
+#define SUNXI_WDT_MODE_REG		(SUNXI_WDT_BASE + 0x0018)
 
 #define mpidr_is_valid(mpidr) ( \
 	MPIDR_AFFLVL3_VAL(mpidr) == 0 && \
@@ -70,9 +76,9 @@ static void __dead2 sunxi_system_off(void)
 static void __dead2 sunxi_system_reset(void)
 {
 	/* Reset the whole system when the watchdog times out */
-	mmio_write_32(SUNXI_WDOG0_CFG_REG, 1);
+	mmio_write_32(SUNXI_WDT_CFG_REG, 1);
 	/* Enable the watchdog with the shortest timeout (0.5 seconds) */
-	mmio_write_32(SUNXI_WDOG0_MODE_REG, (0 << 4) | 1);
+	mmio_write_32(SUNXI_WDT_MODE_REG, (0 << 4) | 1);
 	/* Wait for twice the watchdog timeout before panicking */
 	mdelay(1000);
 

--- a/plat/allwinner/sun50i_h6/platform.mk
+++ b/plat/allwinner/sun50i_h6/platform.mk
@@ -8,3 +8,7 @@
 include plat/allwinner/common/allwinner-common.mk
 
 PLAT_BL_COMMON_SOURCES	+=	drivers/mentor/i2c/mi2cv.c
+
+# Broken Watchdog
+SUNXI_WDT_QUIRK := 1
+$(eval $(call add_define,SUNXI_WDT_QUIRK))


### PR DESCRIPTION
Allwinner H6 has a broken watchdog that doesn't make the soc reboot.

Implement a SUNXI_WDT_QUIRK to use the r_watchdog instead of watchdog.

Signed-off-by: Clément Péron <peron.clem@gmail.com>