### PR TITLE
plat/meson/gxl: BL31: remove BL2 dependency

### DIFF
--- a/plat/meson/gxl/gxl_bl31_setup.c
+++ b/plat/meson/gxl/gxl_bl31_setup.c
@@ -70,12 +70,6 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 	/* Initialize the console to provide early debug support */
 	gxbb_console_init();
 
-	/*
-	 * In debug builds, we pass a special value in 'arg1' to verify platform
-	 * parameters from BL2 to BL31. In release builds it's not used.
-	 */
-	assert(arg1 == GXBB_BL31_PLAT_PARAM_VAL);
-
 	/* Check that params passed from BL2 are not NULL. */
 	from_bl2 = (struct gxl_bl31_param *) arg0;
 


### PR DESCRIPTION
Remove an assert() that assumes a specific value being passed from
BL2.  This value is dependent on BL2 version, so makes this assert()
not portable.

Suggested-by: Remi Pommarel <repk@triplefau.lt>
Signed-off-by: Kevin Hilman <khilman@baylibre.com>