### PR TITLE
driver: synosys: Do not change FIFO TH as this breaks some platforms

### DIFF
--- a/drivers/synopsys/emmc/dw_mmc.c
+++ b/drivers/synopsys/emmc/dw_mmc.c
@@ -425,7 +425,6 @@ void dw_mmc_init(dw_mmc_params_t *params, struct mmc_device_info *info)
 		(params->bus_width == MMC_BUS_WIDTH_8)));
 
 	memcpy(&dw_params, params, sizeof(dw_mmc_params_t));
-	mmio_write_32(dw_params.reg_base + DWMMC_FIFOTH, 0x103ff);
 	dw_params.mmc_dev_type = info->mmc_dev_type;
 	mmc_init(&dw_mmc_ops, params->clk_rate, params->bus_width,
 		 params->flags, info);


### PR DESCRIPTION
Designware DMA FIFO threshold shouldn't be changed as it broke Poplar
platform

Signed-off-by: Tien Hock, Loh <tien.hock.loh@intel.com>