### PR TITLE
plat: imx8m: update OTP SIP

### DIFF
--- a/plat/imx/common/imx_sip_handler.c
+++ b/plat/imx/common/imx_sip_handler.c
@@ -109,18 +109,19 @@ int imx_wakeup_src_handler(uint32_t smc_fid,
 int imx_otp_handler(uint32_t smc_fid,
 		void *handle,
 		u_register_t x1,
-		u_register_t x2)
+		u_register_t x2,
+		u_register_t x3)
 {
 	int ret;
 	uint32_t fuse;
 
-	switch (smc_fid) {
+	switch (x1) {
 	case IMX_SIP_OTP_READ:
-		ret = sc_misc_otp_fuse_read(ipc_handle, x1, &fuse);
+		ret = sc_misc_otp_fuse_read(ipc_handle, x2, &fuse);
 		SMC_RET2(handle, ret, fuse);
 		break;
 	case IMX_SIP_OTP_WRITE:
-		ret = sc_misc_otp_fuse_write(ipc_handle, x1, x2);
+		ret = sc_misc_otp_fuse_write(ipc_handle, x2, x3);
 		SMC_RET1(handle, ret);
 		break;
 	default:

--- a/plat/imx/common/imx_sip_svc.c
+++ b/plat/imx/common/imx_sip_svc.c
@@ -39,9 +39,8 @@ static uintptr_t imx_sip_handler(unsigned int smc_fid,
 		break;
 	case  IMX_SIP_WAKEUP_SRC:
 		SMC_RET1(handle, imx_wakeup_src_handler(smc_fid, x1, x2, x3));
-	case IMX_SIP_OTP_READ:
-	case IMX_SIP_OTP_WRITE:
-		return imx_otp_handler(smc_fid, handle, x1, x2);
+	case IMX_SIP_OTP:
+		return imx_otp_handler(smc_fid, handle, x1, x2, x3);
 	case IMX_SIP_MISC_SET_TEMP:
 		SMC_RET1(handle, imx_misc_set_temp_handler(smc_fid, x1, x2, x3, x4));
 #endif

--- a/plat/imx/common/include/imx_sip_svc.h
+++ b/plat/imx/common/include/imx_sip_svc.h
@@ -23,8 +23,9 @@
 #define IMX_SIP_WAKEUP_SRC_SCU		0x1
 #define IMX_SIP_WAKEUP_SRC_IRQSTEER	0x2
 
-#define IMX_SIP_OTP_READ		0xC200000A
-#define IMX_SIP_OTP_WRITE		0xC200000B
+#define IMX_SIP_OTP			0xC200000A
+#define IMX_SIP_OTP_READ		0x1
+#define IMX_SIP_OTP_WRITE		0x2
 
 #define IMX_SIP_MISC_SET_TEMP		0xC200000C
 
@@ -41,7 +42,7 @@ int imx_srtc_handler(uint32_t smc_fid, void *handle, u_register_t x1,
 int imx_wakeup_src_handler(uint32_t smc_fid, u_register_t x1,
 			   u_register_t x2, u_register_t x3);
 int imx_otp_handler(uint32_t smc_fid, void *handle,
-		    u_register_t x1, u_register_t x2);
+		    u_register_t x1, u_register_t x2, u_register_t x3);
 int imx_misc_set_temp_handler(uint32_t smc_fid, u_register_t x1,
 			      u_register_t x2, u_register_t x3,
 			      u_register_t x4);


### PR DESCRIPTION
We could use one SIP function id for READ/WRITE,
no need use different function id.

Signed-off-by: Peng Fan <peng.fan@nxp.com>