### PR TITLE
hikey960: Fix the issue for asynchronously powering up 4 upper cores …

### DIFF
--- a/plat/hisilicon/hikey960/hikey960_pm.c
+++ b/plat/hisilicon/hikey960/hikey960_pm.c
@@ -65,8 +65,6 @@ static int hikey960_pwr_domain_on(u_register_t mpidr)
 		(mpidr & MPIDR_CLUSTER_MASK) >> MPIDR_AFFINITY_BITS;
 	int cluster_stat = cluster_is_powered_on(cluster);
 
-	hisi_set_cpu_boot_flag(cluster, core);
-
 	mmio_write_32(CRG_REG_BASE + CRG_RVBAR(cluster, core),
 		      hikey960_sec_entrypoint >> 2);
 
@@ -81,6 +79,12 @@ static int hikey960_pwr_domain_on(u_register_t mpidr)
 static void
 hikey960_pwr_domain_on_finish(const psci_power_state_t *target_state)
 {
+    unsigned long mpidr = read_mpidr_el1();
+    unsigned int core = mpidr & MPIDR_CPU_MASK;
+    unsigned int cluster =
+        (mpidr & MPIDR_CLUSTER_MASK) >> MPIDR_AFFINITY_BITS;
+    hisi_set_cpu_boot_flag(cluster, core);
+
 	if (CLUSTER_PWR_STATE(target_state) == PLAT_MAX_OFF_STATE)
 		cci_enable_snoop_dvm_reqs(MPIDR_AFFLVL1_VAL(read_mpidr_el1()));
 


### PR DESCRIPTION
hikey960: Move CPU boot flag to the end of powering-up process. 

HiKey960 has two clusters of cores - cluster 0 of 4 Cortex-A53 cores, and
cluster 1 of 4 Cortex-A73 cores. Cores are powered up when cluster is up.

When powering up the cores in the second cluster asynchronously, the cores
5, 6, and 7 always fail to be up, because the cpu boot flag is already set
although the second cluster is not up yet. This patch changes the place
from where the cpu boot flag is set, so that the power on state of the
second cluster is guaranteed before powering up the secondary (5-7th) cores.