### PR TITLE
plat/allwinner: don't enable regulators disabled in DT

### DIFF
--- a/drivers/allwinner/axp/common.c
+++ b/drivers/allwinner/axp/common.c
@@ -96,8 +96,19 @@ static int setup_regulator(const void *fdt, int node,
 	return 0;
 }
 
+static int is_node_disabled(const void *fdt, int node)
+{
+	const char *cell;
+	cell = fdt_getprop(fdt, node, "status", NULL);
+	if (cell)
+		return strcmp(cell, "okay") != 0;
+	return 0;
+}
+
 static bool should_enable_regulator(const void *fdt, int node)
 {
+	if (is_node_disabled(fdt, node))
+		return false;
 	if (fdt_getprop(fdt, node, "phandle", NULL) != NULL)
 		return true;
 	if (fdt_getprop(fdt, node, "regulator-always-on", NULL) != NULL)


### PR DESCRIPTION
Since July 2020 (36766d39e8), u-boot began building all device trees
with symbols unless OF_LIBFDT_OVERLAY is explicitly disabled.

Consequentially, each node in a device tree is assigned a phandle,
regardless of it being actually referenced anywhere. This change made
the selective enablement of only those regulators for which a phandle
is present by the axp driver effectively useless.

In order to reinstate a way of achieving selectivity in what regulators
get enabled, check for a non-'okay' value of the 'status' property.