### PR TITLE
fix(auth): update with mbedtls development branch

### DIFF
--- a/drivers/auth/mbedtls/mbedtls_common.mk
+++ b/drivers/auth/mbedtls/mbedtls_common.mk
@@ -45,7 +45,6 @@ LIBMBEDTLS_SRCS		:= $(addprefix ${MBEDTLS_DIR}/library/,	\
 					ecp_curves.c				\
 					ecp.c					\
 					rsa.c					\
-					rsa_internal.c				\
 					x509.c 					\
 					x509_crt.c 				\
 					)

--- a/include/drivers/auth/mbedtls/mbedtls_config.h
+++ b/include/drivers/auth/mbedtls/mbedtls_config.h
@@ -71,6 +71,10 @@
 #endif
 
 #define MBEDTLS_SHA256_C
+/* in mbedtls latest version, the SHA256 relies on SHA224 */
+#ifdef MBEDTLS_SHA256_C
+#define MBEDTLS_SHA224_C
+#endif
 #if (TF_MBEDTLS_HASH_ALG_ID != TF_MBEDTLS_SHA256)
 #define MBEDTLS_SHA512_C
 #endif


### PR DESCRIPTION
the latest version of mbedtls implement sha256 based on sha224 and del rsa_internal.c