### PR TITLE
plat/allwinner: do not setup without 'regulator-always-on'

### DIFF
--- a/drivers/allwinner/axp/common.c
+++ b/drivers/allwinner/axp/common.c
@@ -111,9 +111,6 @@ static bool should_enable_regulator(const void *fdt, int node)
 	if (is_node_disabled(fdt, node)) {
 		return false;
 	}
-	if (fdt_getprop(fdt, node, "phandle", NULL) != NULL) {
-		return true;
-	}
 	if (fdt_getprop(fdt, node, "regulator-always-on", NULL) != NULL) {
 		return true;
 	}


### PR DESCRIPTION
The code, commit https://github.com/ARM-software/arm-trusted-firmware/commit/9655a1f54bb6846fa680456b6586bc77404e2675 turns regulators on which have "phandle" *or* "regulator-always-on" property.

This means all regulators that have "phandle" property are always enabled by ATF.

This fix eliminates unwanted power supply at boot.