### PR TITLE
Fix for PRI*PTR (inttypes.h)

### DIFF
--- a/include/lib/libc/aarch32/inttypes_.h
+++ b/include/lib/libc/aarch32/inttypes_.h
@@ -18,4 +18,11 @@
 #define PRIx64		"llx"	/* uint64_t */
 #define PRIX64		"llX"	/* uint64_t */
 
+#define PRIdPTR         "d"     /* intptr_t */
+#define PRIiPTR         "i"     /* intptr_t */
+#define PRIoPTR         "o"     /* intptr_t */
+#define PRIuPTR         "u"     /* uintptr_t */
+#define PRIxPTR         "x"     /* uintptr_t */
+#define PRIXPTR         "X"     /* uintptr_t */
+
 #endif /* INTTYPES__H */

--- a/include/lib/libc/aarch64/inttypes_.h
+++ b/include/lib/libc/aarch64/inttypes_.h
@@ -18,4 +18,11 @@
 #define PRIx64		"lx"	/* uint64_t */
 #define PRIX64		"lX"	/* uint64_t */
 
+#define PRIdPTR         "ld"    /* intptr_t */
+#define PRIiPTR         "li"    /* intptr_t */
+#define PRIoPTR         "lo"    /* intptr_t */
+#define PRIuPTR         "lu"    /* uintptr_t */
+#define PRIxPTR         "lx"    /* uintptr_t */
+#define PRIXPTR         "lX"    /* uintptr_t */
+
 #endif /* INTTYPES__H */

--- a/include/lib/libc/inttypes.h
+++ b/include/lib/libc/inttypes.h
@@ -17,31 +17,25 @@
 #define PRId8		"d"	/* int8_t */
 #define PRId16		"d"	/* int16_t */
 #define PRId32		"d"	/* int32_t */
-#define PRIdPTR		"d"	/* intptr_t */
 
 #define PRIi8		"i"	/* int8_t */
 #define PRIi16		"i"	/* int16_t */
 #define PRIi32		"i"	/* int32_t */
-#define PRIiPTR		"i"	/* intptr_t */
 
 #define PRIo8		"o"	/* int8_t */
 #define PRIo16		"o"	/* int16_t */
 #define PRIo32		"o"	/* int32_t */
-#define PRIoPTR		"o"	/* intptr_t */
 
 #define PRIu8		"u"	/* uint8_t */
 #define PRIu16		"u"	/* uint16_t */
 #define PRIu32		"u"	/* uint32_t */
-#define PRIuPTR		"u"	/* uintptr_t */
 
 #define PRIx8		"x"	/* uint8_t */
 #define PRIx16		"x"	/* uint16_t */
 #define PRIx32		"x"	/* uint32_t */
-#define PRIxPTR		"x"	/* uintptr_t */
 
 #define PRIX8		"X"	/* uint8_t */
 #define PRIX16		"X"	/* uint16_t */
 #define PRIX32		"X"	/* uint32_t */
-#define PRIXPTR		"X"	/* uintptr_t */
 
 #endif


### PR DESCRIPTION
This fix solves problems with using PRI*PTR on aarch64 like the following:
```
error: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'uintptr_t' {aka 'long unsigned int'}
```