### PR TITLE
plat: versal: support raw.bin 

### DIFF
--- a/plat/xilinx/versal/bl31_versal_setup.c
+++ b/plat/xilinx/versal/bl31_versal_setup.c
@@ -136,6 +136,12 @@ void bl31_early_platform_setup2(u_register_t arg0, u_register_t arg1,
 		INFO("BL31: fsbl-atf handover success %u\n", ret);
 	}
 
+	if (!bl32_image_ep_info.pc) {
+		WARN("BL31: use built-in BL32 config data\n");
+		bl32_image_ep_info.pc = BL32_BASE;
+		bl32_image_ep_info.spsr = arm_get_spsr_for_bl32_entry();
+	}
+
 	NOTICE("BL31: Secure code at 0x%lx\n", bl32_image_ep_info.pc);
 	NOTICE("BL31: Non secure code at 0x%lx\n", bl33_image_ep_info.pc);
 }


### PR DESCRIPTION
This commit adds support for BL32 TEE-RAW.BIN by defaulting
to built-time addresses when FSBL fails at providing a valid
jump address.

By default, BL32 is expected at 0x60000000.
The BIF file to use would be something like this

the_ROM_image:
{
	image {
	      { type=bootimage, file=vpl_gen_fixed.pdi }
	      { type=bootloader, file=plm.elf }
	      { core=psm, file=psmfw.elf }
	}

	image {
	      id = 0x1c000000, name=apu_subsystem
	      { type=raw, load=0x00001000, file=versal-vck190-revA-x-ebm-01-revA.dtb }
	      { type=raw, load=0x40000000, file=LedTest_Gpio.pdi }
	      { core=a72-0, exception_level=el-3, trustzone, file=bl31.elf }
 	      { core=a72-0, exception_level=el-2, file=u-boot.elf }
	      { core=a72-0, exception_level=el-1, trustzone,
	            load=0x60000000, startup=0x60000000, file=tee-raw.bin }
	}
}

Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>