### PR TITLE
fix(rpi3_pm): fix RPi4 fails to boot secondary core at second time by PSCI

### DIFF
--- a/plat/rpi/common/rpi3_pm.c
+++ b/plat/rpi/common/rpi3_pm.c
@@ -123,15 +123,6 @@ static void rpi3_pwr_domain_off(const psci_power_state_t *target_state)
 #endif
 }
 
-void __dead2 plat_secondary_cold_boot_setup(void);
-
-static void __dead2
-rpi3_pwr_domain_pwr_down_wfi(const psci_power_state_t *target_state)
-{
-	disable_mmu_el3();
-	plat_secondary_cold_boot_setup();
-}
-
 /*******************************************************************************
  * Platform handler called when a power domain is about to be turned on. The
  * mpidr determines the CPU to be turned on.
@@ -174,6 +165,8 @@ static void rpi3_pwr_domain_on_finish(const psci_power_state_t *target_state)
 #endif
 }
 
+void __dead2 plat_secondary_cold_boot_setup(void);
+
 static void __dead2 rpi3_pwr_down_wfi(
 		const psci_power_state_t *target_state)
 {
@@ -194,10 +187,8 @@ static void __dead2 rpi3_pwr_down_wfi(
 		isb();
 	}
 
-	write_rmr_el3(RMR_EL3_RR_BIT | RMR_EL3_AA64_BIT);
-
-	while (1)
-		;
+	disable_mmu_el3();
+	plat_secondary_cold_boot_setup(); /* not return */
 }
 
 /*******************************************************************************
@@ -262,7 +253,6 @@ static void __dead2 rpi3_system_off(void)
 static const plat_psci_ops_t plat_rpi3_psci_pm_ops = {
 	.cpu_standby = rpi3_cpu_standby,
 	.pwr_domain_off = rpi3_pwr_domain_off,
-	.pwr_domain_pwr_down_wfi = rpi3_pwr_domain_pwr_down_wfi,
 	.pwr_domain_on = rpi3_pwr_domain_on,
 	.pwr_domain_on_finish = rpi3_pwr_domain_on_finish,
 	.pwr_domain_pwr_down_wfi = rpi3_pwr_down_wfi,


### PR DESCRIPTION
fix(rpi3_pm): fix RPi4 fails to boot secondary core at second time by PSCI

* the problem is that rpi3_pwr_down_wfi uses the same hook, which is not compatible with older function rpi3_pwr_domain_pwr_down_wfi.
* now we try to fix it.
* Issue: https://developer.trustedfirmware.org/T1003

Signed-off-by: luojects <luoyonglun@huawei.com>