### PR TITLE
Stricter ASN.1 certificate parsing

### DIFF
--- a/drivers/auth/mbedtls/mbedtls_crypto.c
+++ b/drivers/auth/mbedtls/mbedtls_crypto.c
@@ -115,7 +115,7 @@ static int verify_signature(void *data_ptr, unsigned int data_len,
 	end = (unsigned char *)(p + sig_len);
 	signature.tag = *p;
 	rc = mbedtls_asn1_get_bitstring_null(&p, end, &signature.len);
-	if (rc != 0) {
+	if (rc != 0 || end - p != signature.len) {
 		rc = CRYPTO_ERR_SIGNATURE;
 		goto end1;
 	}

--- a/drivers/auth/mbedtls/mbedtls_crypto.c
+++ b/drivers/auth/mbedtls/mbedtls_crypto.c
@@ -170,12 +170,15 @@ static int verify_hash(void *data_ptr, unsigned int data_len,
 	size_t len;
 	int rc;
 
-	/* Digest info should be an MBEDTLS_ASN1_SEQUENCE */
+	/*
+	 * Digest info should be an MBEDTLS_ASN1_SEQUENCE and consume all
+	 * bytes
+	 */
 	p = (unsigned char *)digest_info_ptr;
 	end = p + digest_info_len;
 	rc = mbedtls_asn1_get_tag(&p, end, &len, MBEDTLS_ASN1_CONSTRUCTED |
 				  MBEDTLS_ASN1_SEQUENCE);
-	if (rc != 0) {
+	if (rc != 0 || len != end - p) {
 		return CRYPTO_ERR_HASH;
 	}
 
@@ -195,9 +198,9 @@ static int verify_hash(void *data_ptr, unsigned int data_len,
 		return CRYPTO_ERR_HASH;
 	}
 
-	/* Hash should be octet string type */
+	/* Hash should be octet string type and consume all bytes */
 	rc = mbedtls_asn1_get_tag(&p, end, &len, MBEDTLS_ASN1_OCTET_STRING);
-	if (rc != 0) {
+	if (rc != 0 || len != end - p) {
 		return CRYPTO_ERR_HASH;
 	}
 

--- a/drivers/auth/mbedtls/mbedtls_x509_parser.c
+++ b/drivers/auth/mbedtls/mbedtls_x509_parser.c
@@ -290,24 +290,26 @@ static int cert_parse(void *img, unsigned int img_len)
 
 	/*
 	 * extensions      [3]  EXPLICIT Extensions OPTIONAL
+	 * -- must use all remaining bytes in TBSCertificate
 	 */
 	ret = mbedtls_asn1_get_tag(&p, end, &len,
 				   MBEDTLS_ASN1_CONTEXT_SPECIFIC |
 				   MBEDTLS_ASN1_CONSTRUCTED | 3);
-	if (ret != 0) {
+	if (ret != 0 || len != end - p) {
 		return IMG_PARSER_ERR_FORMAT;
 	}
 
 	/*
 	 * Extensions  ::=  SEQUENCE SIZE (1..MAX) OF Extension
+	 * -- must use all remaining bytes in TBSCertificate
 	 */
 	v3_ext.p = p;
 	ret = mbedtls_asn1_get_tag(&p, end, &len, MBEDTLS_ASN1_CONSTRUCTED |
 				   MBEDTLS_ASN1_SEQUENCE);
-	if (ret != 0) {
+	if (ret != 0 || len != end - p) {
 		return IMG_PARSER_ERR_FORMAT;
 	}
-	v3_ext.len = (p + len) - v3_ext.p;
+	v3_ext.len = end - v3_ext.p;
 
 	/*
 	 * Check extensions integrity

--- a/drivers/auth/mbedtls/mbedtls_x509_parser.c
+++ b/drivers/auth/mbedtls/mbedtls_x509_parser.c
@@ -272,7 +272,7 @@ static int cert_parse(void *img, unsigned int img_len)
 	/*
 	 * subjectPublicKey BIT STRING
 	 */
-	ret = mbedtls_asn1_get_tag(&p, end, &len, MBEDTLS_ASN1_BIT_STRING);
+	ret = mbedtls_asn1_get_bitstring_null(&p, end, &len);
 	if (ret != 0) {
 		return IMG_PARSER_ERR_FORMAT;
 	}
@@ -411,7 +411,7 @@ static int cert_parse(void *img, unsigned int img_len)
 	 * signatureValue       BIT STRING
 	 */
 	signature.p = p;
-	ret = mbedtls_asn1_get_tag(&p, end, &len, MBEDTLS_ASN1_BIT_STRING);
+	ret = mbedtls_asn1_get_bitstring_null(&p, end, &len);
 	if (ret != 0) {
 		return IMG_PARSER_ERR_FORMAT;
 	}

--- a/drivers/auth/mbedtls/mbedtls_x509_parser.c
+++ b/drivers/auth/mbedtls/mbedtls_x509_parser.c
@@ -146,6 +146,8 @@ static int cert_parse(void *img, unsigned int img_len)
 	size_t len;
 	unsigned char *p, *end, *crt_end;
 	mbedtls_asn1_buf sig_alg1, sig_alg2;
+	/* encoding of v3 */
+	char v3[5] = { 160, 3, 2, 1, 2 };
 
 	p = (unsigned char *)img;
 	len = img_len;
@@ -182,14 +184,12 @@ static int cert_parse(void *img, unsigned int img_len)
 
 	/*
 	 * Version  ::=  INTEGER  {  v1(0), v2(1), v3(2)  }
+	 * -- only v3 accepted
 	 */
-	ret = mbedtls_asn1_get_tag(&p, end, &len,
-				   MBEDTLS_ASN1_CONTEXT_SPECIFIC |
-				   MBEDTLS_ASN1_CONSTRUCTED | 0);
-	if (ret != 0) {
+	if (end - p < sizeof(v3) || 0 != memcmp(p, v3, sizeof(v3))) {
 		return IMG_PARSER_ERR_FORMAT;
 	}
-	p += len;
+	p += sizeof(v3);
 
 	/*
 	 * CertificateSerialNumber  ::=  INTEGER

--- a/drivers/auth/mbedtls/mbedtls_x509_parser.c
+++ b/drivers/auth/mbedtls/mbedtls_x509_parser.c
@@ -249,7 +249,7 @@ static int cert_parse(void *img, unsigned int img_len)
 	p += len;
 
 	/*
-	 * SubjectPublicKeyInfo
+	 * SubjectPublicKeyInfo ::= SEQUENCE {
 	 */
 	pk.p = p;
 	ret = mbedtls_asn1_get_tag(&p, end, &len, MBEDTLS_ASN1_CONSTRUCTED |
@@ -258,7 +258,35 @@ static int cert_parse(void *img, unsigned int img_len)
 		return IMG_PARSER_ERR_FORMAT;
 	}
 	pk.len = (p + len) - pk.p;
+
+	/*
+	 * algorithm AlgorithmIdentifier
+	 */
+	ret = mbedtls_asn1_get_tag(&p, end, &len, MBEDTLS_ASN1_CONSTRUCTED |
+				   MBEDTLS_ASN1_SEQUENCE);
+	if (ret != 0) {
+		return IMG_PARSER_ERR_FORMAT;
+	}
 	p += len;
+
+	/*
+	 * subjectPublicKey BIT STRING
+	 */
+	ret = mbedtls_asn1_get_tag(&p, end, &len, MBEDTLS_ASN1_BIT_STRING);
+	if (ret != 0) {
+		return IMG_PARSER_ERR_FORMAT;
+	}
+	p += len;
+
+	/*
+	 * }
+	 *
+	 * Do NOT omit this check, as other code may assume that it
+	 * has passed.
+	 */
+	if (p != (pk.p + pk.len)) {
+		return IMG_PARSER_ERR_FORMAT;
+	}
 
 	/*
 	 * issuerUniqueID  [1]  IMPLICIT UniqueIdentifier OPTIONAL,

--- a/drivers/auth/mbedtls/mbedtls_x509_parser.c
+++ b/drivers/auth/mbedtls/mbedtls_x509_parser.c
@@ -312,9 +312,11 @@ static int cert_parse(void *img, unsigned int img_len)
 	v3_ext.len = end - v3_ext.p;
 
 	/*
-	 * Check extensions integrity
+	 * Check extensions integrity.  At least one extension
+	 * is required, hence the use of a do-while loop (which
+	 * will detect emptiness on the first iteration).
 	 */
-	while (p < end) {
+	do {
 		ret = mbedtls_asn1_get_tag(&p, end, &len,
 					   MBEDTLS_ASN1_CONSTRUCTED |
 					   MBEDTLS_ASN1_SEQUENCE);
@@ -342,7 +344,7 @@ static int cert_parse(void *img, unsigned int img_len)
 			return IMG_PARSER_ERR_FORMAT;
 		}
 		p += len;
-	}
+	} while (p < end);
 
 	if (p != end) {
 		return IMG_PARSER_ERR_FORMAT;


### PR DESCRIPTION
Much of ASN.1 parsing code in ARM Trusted Firmware does not check that an ASN.1 container (such as a SEQUENCE) is the same length as the sum of the lengths of the objects contained within it.  This fixes this flaw, as well as adding several other checks:

- The version must be v3
- At least one extension must be present
- Bit strings must have no unused bits
- SubjectPublicKeyInfo values are partially validated (they must consist of a SEQUENCE followed by a BIT STRING)