### PR TITLE
Provide a mechanism to configure the initial parameters of the

### DIFF
--- a/drivers/rpi3/sdhost/rpi3_sdhost.c
+++ b/drivers/rpi3/sdhost/rpi3_sdhost.c
@@ -246,12 +246,13 @@ static void rpi3_sdhost_reset(void)
 static void rpi3_sdhost_initialize(void)
 {
 	uintptr_t reg_base = rpi3_sdhost_params.reg_base;
+	(void)reg_base;
 
 	assert((rpi3_sdhost_params.reg_base & MMC_BLOCK_MASK) == 0);
 
 	rpi3_sdhost_reset();
 
-	mmio_write_32(reg_base + HC_CLOCKDIVISOR, HC_CLOCKDIVISOR_PREFERVAL);
+	rpi3_sdhost_set_ios( rpi3_sdhost_params.clk_rate_initial, rpi3_sdhost_params.bus_width );
 	udelay(300);
 }
 

--- a/include/drivers/rpi3/sdhost/rpi3_sdhost.h
+++ b/include/drivers/rpi3/sdhost/rpi3_sdhost.h
@@ -15,6 +15,7 @@
 struct rpi3_sdhost_params {
 	uintptr_t	reg_base;
 	uint32_t	clk_rate;
+	uint32_t	clk_rate_initial;
 	uint32_t	bus_width;
 	uint32_t        flags;
 	uint32_t	current_cmd;
@@ -56,6 +57,8 @@ void rpi3_sdhost_stop(void);
 #define HC_CMD_WRITE			0x0080
 #define HC_CMD_READ			0x0040
 #define HC_CMD_COMMAND_MASK		0x003f
+
+#define RPI3_SDHOST_MAX_CLOCK		250000000	// technically, we should obtain this number from the mailbox
 
 #define HC_CLOCKDIVISOR_MAXVAL		0x07ff
 #define HC_CLOCKDIVISOR_PREFERVAL	0x027b

--- a/plat/rpi/rpi3/rpi3_bl2_setup.c
+++ b/plat/rpi/rpi3/rpi3_bl2_setup.c
@@ -35,7 +35,9 @@ static void rpi3_sdhost_setup(void)
 	params.reg_base = RPI3_SDHOST_BASE;
 	params.bus_width = MMC_BUS_WIDTH_1;
 	params.clk_rate = 50000000;
+	params.clk_rate_initial = ( RPI3_SDHOST_MAX_CLOCK / HC_CLOCKDIVISOR_MAXVAL );
 	mmc_info.mmc_dev_type = MMC_IS_SD_HC;
+	mmc_info.ocr_voltage = OCR_3_2_3_3 | OCR_3_3_3_4;
 	rpi3_sdhost_init(&params, &mmc_info);
 }
 


### PR DESCRIPTION
sdhost controller (initial clock rate, bus width), and then configure those parameters.

This change allows warm reboots of UEFI on Raspberry Pi 3B+ where existing code often fails with "unknown error".  See discussion at:

	https://github.com/pftf/RPi3/issues/24

The basic problem was that a number of SD commands are issued before sensible initialization configurations have been committed. I suspect that the primary culprit is setting the "slow card" bit, but the initial clock rate also seemed wrong, as did the missing voltage settings.