### PR TITLE
Fixed crossplatform build for the STM32MP1 fiptool

### DIFF
--- a/tools/fiptool/plat_fiptool/st/stm32mp1/plat_def_uuid_config.c
+++ b/tools/fiptool/plat_fiptool/st/stm32mp1/plat_def_uuid_config.c
@@ -3,6 +3,7 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
+#include <stddef.h>
 
 #include <firmware_image_package.h>
 
@@ -13,6 +14,10 @@ toc_entry_t plat_def_toc_entries[] = {
 		.name = "STM32MP CONFIG CERT",
 		.uuid = UUID_STM32MP_CONFIG_CERT,
 		.cmdline_name = "stm32mp-cfg-cert"
+	},
+	{
+		.name = NULL,
+		.uuid = { {0} },
+		.cmdline_name = NULL,
 	}
 };
-


### PR DESCRIPTION
This PR fixes the issue with the missed NULL-entry in the array.
This issue was observed during the build on ARM M1 platform. After a small investigation it was possible to figure out, that this entry is used in the loops where the NULL is expected for the iteration completion. The example of the several places where this access is performed is shown below:

fiptool.c:
```c
static void fill_image_descs(void)
{
	toc_entry_t *toc_entry;

	for (toc_entry = toc_entries;
	     toc_entry->cmdline_name != NULL;
	     toc_entry++) {
		image_desc_t *desc;

		desc = new_image_desc(&toc_entry->uuid,
		    toc_entry->name,
		    toc_entry->cmdline_name);
		add_image_desc(desc);
	}
#ifdef PLAT_DEF_FIP_UUID
	for (toc_entry = plat_def_toc_entries;
	     toc_entry->cmdline_name != NULL;
	     toc_entry++) {
		image_desc_t *desc;

		desc = new_image_desc(&toc_entry->uuid,
		    toc_entry->name,
		    toc_entry->cmdline_name);
		add_image_desc(desc);
	}
#endif
}

static void unpack_usage(int exit_status)
{
	toc_entry_t *toc_entry = toc_entries;

	printf("fiptool unpack [opts] FIP_FILENAME\n");
	printf("\n");
	printf("Options:\n");
	printf("  --blob uuid=...,file=...\tUnpack an image with the given UUID to file.\n");
	printf("  --force\t\t\tIf the output file already exists, use --force to overwrite it.\n");
	printf("  --out path\t\t\tSet the output directory path.\n");
	printf("\n");
	printf("Specific images are unpacked with the following options:\n");
	for (; toc_entry->cmdline_name != NULL; toc_entry++)
		printf("  --%-16s FILENAME\t%s\n", toc_entry->cmdline_name,
		    toc_entry->name);
#ifdef PLAT_DEF_FIP_UUID
	toc_entry = plat_def_toc_entries;
	for (; toc_entry->cmdline_name != NULL; toc_entry++)
		printf("  --%-16s FILENAME\t%s\n", toc_entry->cmdline_name,
		    toc_entry->name);
#endif
	printf("\n");
	printf("If no options are provided, all images will be unpacked.\n");
	exit(exit_status);
}

static void remove_usage(int exit_status)
{
	toc_entry_t *toc_entry = toc_entries;

	printf("fiptool remove [opts] FIP_FILENAME\n");
	printf("\n");
	printf("Options:\n");
	printf("  --align <value>\tEach image is aligned to <value> (default: 1).\n");
	printf("  --blob uuid=...\tRemove an image with the given UUID.\n");
	printf("  --force\t\tIf the output FIP file already exists, use --force to overwrite it.\n");
	printf("  --out FIP_FILENAME\tSet an alternative output FIP file.\n");
	printf("\n");
	printf("Specific images are removed with the following options:\n");
	for (; toc_entry->cmdline_name != NULL; toc_entry++)
		printf("  --%-16s\t%s\n", toc_entry->cmdline_name,
		    toc_entry->name);
#ifdef PLAT_DEF_FIP_UUID
	toc_entry = plat_def_toc_entries;
	for (; toc_entry->cmdline_name != NULL; toc_entry++)
		printf("  --%-16s\t%s\n", toc_entry->cmdline_name,
		    toc_entry->name);
#endif
	exit(exit_status);
}
```

The logs from crash are attached below:
[logs_from_build.log](https://github.com/STMicroelectronics/arm-trusted-firmware/files/11436896/logs_from_build.log)

In the readable format:
```log
  CPP     fdts/stm32mp157c-dk2-mx-fw-config.dts
  CPP     /test_build/build/arm-trusted-firmware-custom/build/stm32mp1/release/fdts/stm32mp157c-dk2-mx-bl2.dts
  DTC     fdts/stm32mp157c-dk2-mx-fw-config.dts
  DTC     /test_build/build/arm-trusted-firmware-custom/build/stm32mp1/release/fdts/stm32mp157c-dk2-mx-bl2.dts
/test_build/build/arm-trusted-firmware-custom/build/stm32mp1/release/fdts/stm32mp157c-dk2-mx-bl2.pre.dts:29.3-26: Warning (interrupts_property): /soc/i2c@40013000:#interrupt-cells: size is (28), expected multiple of 12
make[2]: *** [Makefile:1412: /test_build/build/arm-trusted-firmware-custom/build/stm32mp1/release/fip.bin] Segmentation fault
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [package/pkg-generic.mk:293: /test_build/build/arm-trusted-firmware-custom/.stamp_built] Error 2
make: *** [Makefile:23: _all] Error 2
root@ac3fa7119b00:/test_build# ls
Makefile  build  host  images  target
root@ac3fa7119b00:/test_build# cd /test_build/build/arm-trusted-firmware-custom
```

This issue is also added as PR to:

https://github.com/STMicroelectronics/arm-trusted-firmware/pull/8