### PR TITLE
rockchip: rk3399: Fix documentation in how build bl31 in AARCH64

### DIFF
--- a/docs/plat/rockchip.rst
+++ b/docs/plat/rockchip.rst
@@ -35,7 +35,7 @@ these images need to get build from the TF-A repository.
 
 For AARCH64 architectures the build command looks like
 
-    make CROSS_COMPILE=aarch64-linux-gnu- PLAT=rk3399 bl32
+    make CROSS_COMPILE=aarch64-linux-gnu- PLAT=rk3399 bl31
 
 while AARCH32 needs a slightly different command
 


### PR DESCRIPTION
Rockchip SoCs expect TF-A's BL31 (AARCH64)