### PR TITLE
[DRAFT] fix(imx): Fix imx8mq compilation error

### DIFF
--- a/plat/imx/common/include/imx_sip_svc.h
+++ b/plat/imx/common/include/imx_sip_svc.h
@@ -7,6 +7,8 @@
 #ifndef __IMX_SIP_SVC_H__
 #define __IMX_SIP_SVC_H__
 
+#include <smccc_helpers.h>
+
 /* SMC function IDs for SiP Service queries */
 #define IMX_SIP_GPC			0xC2000000
 
@@ -88,7 +90,8 @@ int imx_src_handler(uint32_t smc_fid, u_register_t x1,
 		    u_register_t x2, u_register_t x3, void *handle);
 #endif
 
-#if defined(PLAT_imx8mm) || defined(PLAT_imx8mn) || defined(PLAT_imx8mp)
+#if defined(PLAT_imx8mm) || defined(PLAT_imx8mn) || defined(PLAT_imx8mp) || \
+	defined(PLAT_imx8mq)
 int imx_hab_handler(uint32_t smc_fid, u_register_t x1,
 		    u_register_t x2, u_register_t x3, u_register_t x4);
 #endif

--- a/plat/imx/imx8m/imx8mq/gpc.c
+++ b/plat/imx/imx8m/imx8mq/gpc.c
@@ -19,6 +19,7 @@
 #include <services/std_svc.h>
 
 #include <gpc.h>
+#include <imx_sip_svc.h>
 #include <platform_def.h>
 
 #define FSL_SIP_CONFIG_GPC_MASK		U(0x00)

--- a/plat/imx/imx8m/imx8mq/platform.mk
+++ b/plat/imx/imx8m/imx8mq/platform.mk
@@ -26,6 +26,7 @@ IMX_GIC_SOURCES		:=	${GICV3_SOURCES}			\
 				plat/imx/common/plat_imx8_gic.c
 
 BL31_SOURCES		+=	plat/imx/common/imx8_helpers.S			\
+				plat/imx/imx8m/imx_hab.c			\
 				plat/imx/imx8m/imx8mq/imx8mq_bl31_setup.c	\
 				plat/imx/imx8m/imx8mq/imx8mq_psci.c		\
 				plat/imx/imx8m/gpc_common.c			\


### PR DESCRIPTION
CROSS_COMPILE=aarch64-linux-gnu- make PLAT=imx8mq bl31 doesn't work anymore.
This fix try to solve the issue but RAM size is overloaded by 4096 Bytes.

The report only aim to trigger the discussion about how to solve this problem.