### PR TITLE
feat(imx93): make bl33 start configurable via PRELOADED_BL33_BASE

### DIFF
--- a/plat/imx/imx93/include/platform_def.h
+++ b/plat/imx/imx93/include/platform_def.h
@@ -36,7 +36,9 @@
 
 /* non-secure uboot base */
 /* TODO */
+#ifndef PLAT_NS_IMAGE_OFFSET
 #define PLAT_NS_IMAGE_OFFSET		U(0x80200000)
+#endif
 #define BL32_FDT_OVERLAY_ADDR           (PLAT_NS_IMAGE_OFFSET + 0x3000000)
 
 /* GICv4 base address */

--- a/plat/imx/imx93/platform.mk
+++ b/plat/imx/imx93/platform.mk
@@ -42,6 +42,10 @@ USE_COHERENT_MEM	:=	0
 PROGRAMMABLE_RESET_ADDRESS :=	1
 COLD_BOOT_SINGLE_CPU	:=	1
 
+ifneq (${PRELOADED_BL33_BASE},)
+$(eval $(call add_define_val,PLAT_NS_IMAGE_OFFSET,${PRELOADED_BL33_BASE}))
+endif
+
 BL32_BASE               ?=      0x96000000
 BL32_SIZE               ?=      0x02000000
 $(eval $(call add_define,BL32_BASE))


### PR DESCRIPTION
The TF-A does have a official PRELOADED_BL33_BASE define which is used to tell the TF-A where to jump and that no bl33 loading is requied. Use this to make the platform specific PLAT_NS_IMAGE_OFFSET configurable.

This becomes necessary if one would like to place the bl33 code to other places.