### PR TITLE
mmc: Increase number of tries for CMD13

### DIFF
--- a/drivers/mmc/mmc.c
+++ b/drivers/mmc/mmc.c
@@ -18,7 +18,7 @@
 #include <lib/utils.h>
 #include <plat/common/common_def.h>
 
-#define MMC_DEFAULT_MAX_RETRIES		5
+#define MMC_DEFAULT_MAX_RETRIES		15
 #define SEND_OP_COND_MAX_RETRIES	100
 
 #define MULT_BY_512K_SHIFT		19


### PR DESCRIPTION
On a customer hardware in ~95% seven iterations were required until the eMMC reacts as expected to CMD13. In the remaining ~5% more than that are needed. Increase the number of iterations from 5 to 15 to make the machine boot more reliably.

This should not influence the boot time in cases where the eMMC is fast enough to answer on CMD13, as we break out earlier in the loop. The slow path is only hit, when the eMMC takes more time to probe.